### PR TITLE
[Feat/18] 회원 차단 목록 조회 API 구현 및 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,9 @@ dependencies {
     implementation 'com.github.mwiede:jsch:0.2.16'
 
     // JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/gamegoo/gamegoo_v2/auth/controller/AuthController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ public class AuthController {
     private final JwtProvider jwtProvider;
 
     @GetMapping("/token/{memberId}")
-    @Operation(summary = "jwt 토큰 재발급 API", description = "access token, refresh token을 재발급 받는 API 입니다.")
+    @Operation(summary = "임시 access token 발급 API", description = "테스트용으로 access token을 발급받을 수 있는 API 입니다.")
     public ApiResponse<String> getTestAccessToken(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(jwtProvider.createAccessToken(memberId));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/controller/BlockController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/controller/BlockController.java
@@ -1,20 +1,28 @@
 package com.gamegoo.gamegoo_v2.block.controller;
 
 import com.gamegoo.gamegoo_v2.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.block.service.BlockFacadeService;
 import com.gamegoo.gamegoo_v2.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Block", description = "회원 차단 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/block")
+@Validated
 public class BlockController {
 
     private final BlockFacadeService blockFacadeService;
@@ -26,6 +34,14 @@ public class BlockController {
             @AuthMember Member member) {
         blockFacadeService.blockMember(member, targetMemberId);
         return ApiResponse.ok("회원 차단 성공");
+    }
+
+    @Operation(summary = "차단 목록 조회 API", description = "내가 차단한 회원의 목록을 조회하는 API 입니다.")
+    @Parameter(name = "page", description = "페이지 번호, 1 이상의 숫자를 입력해 주세요.")
+    @GetMapping
+    public ApiResponse<BlockListResponse> getBlockList(@ValidPage @RequestParam(name = "page") Integer page,
+            @AuthMember Member member) {
+        return ApiResponse.ok(blockFacadeService.getBlockList(member, page));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/dto/BlockListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/dto/BlockListResponse.java
@@ -15,8 +15,8 @@ public class BlockListResponse {
     int listSize;
     int totalPage;
     long totalElements;
-    boolean isFirst;
-    boolean isLast;
+    Boolean isFirst;
+    Boolean isLast;
 
     @Getter
     @Builder
@@ -26,7 +26,7 @@ public class BlockListResponse {
         int profileImg;
         String email;
         String name;
-        boolean isBlind;
+        Boolean isBlind;
 
         public static BlockedMemberResponse of(Member member) {
             String name = member.isBlind() ? "(탈퇴한 사용자)" : member.getGameName();

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/dto/BlockListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/dto/BlockListResponse.java
@@ -1,0 +1,59 @@
+package com.gamegoo.gamegoo_v2.block.dto;
+
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BlockListResponse {
+
+    List<BlockedMemberResponse> blockedMemberList;
+    int listSize;
+    int totalPage;
+    long totalElements;
+    boolean isFirst;
+    boolean isLast;
+
+    @Getter
+    @Builder
+    public static class BlockedMemberResponse {
+
+        Long memberId;
+        int profileImg;
+        String email;
+        String name;
+        boolean isBlind;
+
+        public static BlockedMemberResponse of(Member member) {
+            String name = member.isBlind() ? "(탈퇴한 사용자)" : member.getGameName();
+            return BlockedMemberResponse.builder()
+                    .memberId(member.getId())
+                    .profileImg(member.getProfileImage())
+                    .email(member.getEmail())
+                    .name(name)
+                    .isBlind(member.isBlind())
+                    .build();
+        }
+
+    }
+
+    public static BlockListResponse of(Page<Member> memberPage) {
+        List<BlockedMemberResponse> blockMemberList = memberPage.stream()
+                .map(BlockedMemberResponse::of)
+                .toList();
+
+        return BlockListResponse.builder()
+                .blockedMemberList(blockMemberList)
+                .listSize(blockMemberList.size())
+                .totalPage(memberPage.getTotalPages())
+                .totalElements(memberPage.getTotalElements())
+                .isFirst(memberPage.isFirst())
+                .isLast(memberPage.isLast())
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/repository/BlockRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/repository/BlockRepository.java
@@ -2,10 +2,18 @@ package com.gamegoo.gamegoo_v2.block.repository;
 
 import com.gamegoo.gamegoo_v2.block.domain.Block;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
 
     boolean existsByBlockerMemberAndBlockedMember(Member blockerMember, Member blockedMember);
+
+    @Query("SELECT m FROM Member m INNER JOIN Block b ON m.id = b.blockedMember.id WHERE b.blockerMember.id = " +
+            ":blockerId AND b.deleted = false ORDER BY b.createdAt DESC")
+    Page<Member> findBlockedMembersByBlockerIdAndNotDeleted(@Param("blockerId") Long blockerId, Pageable pageable);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
@@ -39,7 +39,7 @@ public class BlockFacadeService {
      * @return
      */
     public BlockListResponse getBlockList(Member member, Integer pageIdx) {
-        PageRequest pageRequest = PageRequest.of(pageIdx, PAGE_SIZE);
+        PageRequest pageRequest = PageRequest.of(pageIdx - 1, PAGE_SIZE);
         Page<Member> members = blockService.findBlockedMembersByBlockerId(member.getId(), pageRequest);
 
         return BlockListResponse.of(members);

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
@@ -1,8 +1,11 @@
 package com.gamegoo.gamegoo_v2.block.service;
 
+import com.gamegoo.gamegoo_v2.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +17,8 @@ public class BlockFacadeService {
     private final MemberService memberService;
     private final BlockService blockService;
 
+    private final static int PAGE_SIZE = 10;
+
     /**
      * 회원 차단 Facade 메소드
      *
@@ -24,6 +29,20 @@ public class BlockFacadeService {
     public void blockMember(Member member, Long targetMemberId) {
         Member targetMember = memberService.findMember(targetMemberId);
         blockService.blockMember(member, targetMember);
+    }
+
+    /**
+     * 차단한 회원 목록 조회 메소드
+     *
+     * @param member
+     * @param pageIdx
+     * @return
+     */
+    public BlockListResponse getBlockList(Member member, Integer pageIdx) {
+        PageRequest pageRequest = PageRequest.of(pageIdx, PAGE_SIZE);
+        Page<Member> members = blockService.findBlockedMembersByBlockerId(member.getId(), pageRequest);
+
+        return BlockListResponse.of(members);
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockService.java
@@ -7,6 +7,8 @@ import com.gamegoo.gamegoo_v2.exception.BlockException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +47,17 @@ public class BlockService {
 
         // 차단 대상 회원에게 보냈던 친구 요청이 있는 경우, 해당 요청 취소 처리
 
+    }
+
+    /**
+     * 해당 회원이 차단한 회원의 목록 Page 객체 반환하는 메소드
+     *
+     * @param blockerId
+     * @param pageable
+     * @return
+     */
+    public Page<Member> findBlockedMembersByBlockerId(Long blockerId, Pageable pageable) {
+        return blockRepository.findBlockedMembersByBlockerIdAndNotDeleted(blockerId, pageable);
     }
 
     private void validateNotSelfBlock(Member member, Member targetMember) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/common/annotation/ValidPage.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/annotation/ValidPage.java
@@ -1,0 +1,23 @@
+package com.gamegoo.gamegoo_v2.common.annotation;
+
+import com.gamegoo.gamegoo_v2.common.annotationValidator.ValidPageAnnotationValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ValidPageAnnotationValidator.class)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPage {
+
+    String message() default "페이지 번호는 1 이상의 값이어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/common/annotationValidator/ValidPageAnnotationValidator.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/annotationValidator/ValidPageAnnotationValidator.java
@@ -1,0 +1,23 @@
+package com.gamegoo.gamegoo_v2.common.annotationValidator;
+
+import com.gamegoo.gamegoo_v2.common.annotation.ValidPage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidPageAnnotationValidator implements ConstraintValidator<ValidPage, Integer> {
+
+    @Override
+    public void initialize(ValidPage constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        if (value < 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/common/validator/MemberValidator.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/validator/MemberValidator.java
@@ -1,7 +1,7 @@
 package com.gamegoo.gamegoo_v2.common.validator;
 
+import com.gamegoo.gamegoo_v2.exception.MemberException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.exception.common.MemberException;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/gamegoo/gamegoo_v2/config/SwaggerConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/config/SwaggerConfig.java
@@ -29,7 +29,7 @@ public class SwaggerConfig {
                         new SecurityScheme()
                                 .name(jwtSchemeName)
                                 .type(SecurityScheme.Type.HTTP) // HTTP 방식
-                                .scheme("bearer")
+                                .scheme("Bearer")
                                 .bearerFormat("JWT"));
 
         return new OpenAPI()

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/MemberException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/MemberException.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.exception;
+
+import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.exception.common.GlobalException;
+
+public class MemberException extends GlobalException {
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/common/MemberException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/common/MemberException.java
@@ -1,9 +1,0 @@
-package com.gamegoo.gamegoo_v2.exception.common;
-
-public class MemberException extends GlobalException {
-
-    public MemberException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-
-}

--- a/src/main/java/com/gamegoo/gamegoo_v2/member/service/MemberService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.gamegoo.gamegoo_v2.member.service;
 
+import com.gamegoo.gamegoo_v2.exception.MemberException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.exception.common.MemberException;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/block/BlockControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/block/BlockControllerTest.java
@@ -5,40 +5,24 @@ import com.gamegoo.gamegoo_v2.block.service.BlockFacadeService;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
 import com.gamegoo.gamegoo_v2.exception.BlockException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.exception.common.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BlockController.class)
-@Import(BlockControllerTest.TestConfig.class)
 class BlockControllerTest extends ControllerTestSupport {
 
-    @TestConfiguration
-    static class TestConfig {
-
-        @Bean
-        public BlockFacadeService blockFacadeService() {
-            return Mockito.mock(BlockFacadeService.class);
-        }
-
-    }
-
-    @Autowired
+    @MockitoBean
     private BlockFacadeService blockFacadeService;
 
     private static final String API_URL_PREFIX = "/api/v2/block";
@@ -53,7 +37,7 @@ class BlockControllerTest extends ControllerTestSupport {
         @Test
         void blockMemberSucceeds() throws Exception {
             // given
-            doNothing().when(blockFacadeService).blockMember(any(), eq(TARGET_MEMBER_ID));
+            willDoNothing().given(blockFacadeService).blockMember(any(), eq(TARGET_MEMBER_ID));
 
             // when // then
             mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))
@@ -66,8 +50,8 @@ class BlockControllerTest extends ControllerTestSupport {
         @Test
         void blockMemberFailedWhenAlreadyBlocked() throws Exception {
             // given
-            doThrow(new BlockException(ErrorCode.ALREADY_BLOCKED))
-                    .when(blockFacadeService).blockMember(any(), eq(TARGET_MEMBER_ID));
+            willThrow(new BlockException(ErrorCode.ALREADY_BLOCKED))
+                    .given(blockFacadeService).blockMember(any(), eq(TARGET_MEMBER_ID));
 
             // when // then
             mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))
@@ -80,8 +64,8 @@ class BlockControllerTest extends ControllerTestSupport {
         @Test
         void blockMemberFailedWhenTargetIsBlind() throws Exception {
             // given
-            doThrow(new MemberException(ErrorCode.TARGET_MEMBER_DEACTIVATED))
-                    .when(blockFacadeService).blockMember(any(), eq(TARGET_MEMBER_ID));
+            willThrow(new BlockException(ErrorCode.TARGET_MEMBER_DEACTIVATED))
+                    .given(blockFacadeService).blockMember(any(), eq(TARGET_MEMBER_ID));
 
             // when // then
             mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/block/BlockControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/block/BlockControllerTest.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.controller.block;
 
 import com.gamegoo.gamegoo_v2.block.controller.BlockController;
+import com.gamegoo.gamegoo_v2.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.block.service.BlockFacadeService;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
 import com.gamegoo.gamegoo_v2.exception.BlockException;
@@ -11,10 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.ArrayList;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -71,6 +76,64 @@ class BlockControllerTest extends ControllerTestSupport {
             mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message").value("대상 회원이 탈퇴했습니다."));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("차단한 회원 목록 조회")
+    class GetBlockListTest {
+
+        @DisplayName("차단한 회원 목록 조회 성공: 조회 결과가 반환된다.")
+        @Test
+        void getBlockListSucceeds() throws Exception {
+            // given
+            BlockListResponse blockListResponse = BlockListResponse.builder()
+                    .blockedMemberList(new ArrayList<>())
+                    .listSize(0)
+                    .totalPage(0)
+                    .totalElements(0)
+                    .isFirst(true)
+                    .isLast(true)
+                    .build();
+
+            given(blockFacadeService.getBlockList(any(), any())).willReturn(blockListResponse);
+
+            // when // then
+            int pageIdx = 1;
+            mockMvc.perform(get(API_URL_PREFIX)
+                            .param("page", String.valueOf(pageIdx)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.blockedMemberList").isEmpty())
+                    .andExpect(jsonPath("$.data.listSize").value(0))
+                    .andExpect(jsonPath("$.data.totalPage").value(0))
+                    .andExpect(jsonPath("$.data.totalElements").value(0))
+                    .andExpect(jsonPath("$.data.isFirst").value(true))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @DisplayName("차단한 회원 목록 조회 실패: 페이지 번호가 1 미만인 경우 에러 응답을 반환한다")
+        @Test
+        void getBlockListFailedWhenPageIsNotValid() throws Exception {
+            // given
+            BlockListResponse blockListResponse = BlockListResponse.builder()
+                    .blockedMemberList(new ArrayList<>())
+                    .listSize(0)
+                    .totalPage(0)
+                    .totalElements(0)
+                    .isFirst(true)
+                    .isLast(true)
+                    .build();
+
+            given(blockFacadeService.getBlockList(any(), any())).willReturn(blockListResponse);
+
+            // when // then
+            int pageIdx = 0;
+            mockMvc.perform(get(API_URL_PREFIX)
+                            .param("page", String.valueOf(pageIdx)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("페이지 번호는 1 이상의 값이어야 합니다."));
         }
 
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
@@ -1,0 +1,118 @@
+package com.gamegoo.gamegoo_v2.repository.block;
+
+import com.gamegoo.gamegoo_v2.block.domain.Block;
+import com.gamegoo.gamegoo_v2.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.member.domain.Tier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+class BlockRepositoryTest {
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private static final int PAGE_SIZE = 10;
+
+    private Member blocker;
+
+    @BeforeEach
+    void setUp() {
+        blocker = createMember("test@gmail.com", "member");
+    }
+
+    @DisplayName("차단한 회원 목록 조회: 차단한 회원이 없는 경우")
+    @Test
+    void findBlockedMembersByBlockerIdAndNotDeleted() {
+        // when
+        Page<Member> blockedMembers = blockRepository.findBlockedMembersByBlockerIdAndNotDeleted(blocker.getId(),
+                PageRequest.of(0, PAGE_SIZE));
+
+        // then
+        assertThat(blockedMembers).isEmpty();
+        assertThat(blockedMembers.getTotalElements()).isEqualTo(0);
+        assertThat(blockedMembers.getTotalPages()).isEqualTo(0);
+        assertTrue(blockedMembers.isFirst());
+        assertTrue(blockedMembers.isLast());
+    }
+
+    @DisplayName("차단한 회원 목록 조회: 차단한 회원이 10명 이하일 때 첫번째 페이지 요청")
+    @Test
+    void findBlockedMembersByBlockerIdAndNotDeletedOnePage() {
+        // given
+        for (int i = 1; i <= 10; i++) {
+            Member blocked = createMember("member" + i + "@gmail.com", "member" + i);
+            blockMember(blocker, blocked);
+        }
+
+        // when
+        Page<Member> blockedMembers = blockRepository.findBlockedMembersByBlockerIdAndNotDeleted(blocker.getId(),
+                PageRequest.of(0, PAGE_SIZE));
+
+        // then
+        assertThat(blockedMembers).isNotEmpty();
+        assertThat(blockedMembers.getTotalElements()).isEqualTo(10);
+        assertThat(blockedMembers.getTotalPages()).isEqualTo(1);
+        assertTrue(blockedMembers.isFirst());
+        assertTrue(blockedMembers.isLast());
+    }
+
+    @DisplayName("차단한 회원 목록 조회: 차단한 회원이 10명 초과일 때 두번째 페이지 요청")
+    @Test
+    void findBlockedMembersByBlockerIdAndNotDeletedSecondPage() {
+        // given
+        for (int i = 1; i <= 15; i++) {
+            Member blocked = createMember("member" + i + "@gmail.com", "member" + i);
+            blockMember(blocker, blocked);
+        }
+
+        // when
+        Page<Member> blockedMembers = blockRepository.findBlockedMembersByBlockerIdAndNotDeleted(blocker.getId(),
+                PageRequest.of(1, PAGE_SIZE));
+
+        // then
+
+        assertThat(blockedMembers).isNotEmpty();
+        assertThat(blockedMembers.getTotalElements()).isEqualTo(15);
+        assertThat(blockedMembers.getTotalPages()).isEqualTo(2);
+        assertFalse(blockedMembers.isFirst());
+        assertTrue(blockedMembers.isLast());
+    }
+
+    private Member createMember(String email, String gameName) {
+        return em.persist(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private void blockMember(Member blocker, Member blocked) {
+        Block block = Block.create(blocker, blocked);
+        em.persist(block);
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 회원 차단 목록 조회 API 구현 및 테스트

## ⏳ 작업 상세 내용

<!--  -->

- [x] 회원 차단 목록 조회 API 구현
- [x] 회원 차단 목록 조회 API 서비스 테스트
- [x] 회원 차단 목록 조회 API 컨트롤러 테스트
- [x] 회원 차단 목록 조회 repository 테스트
- [x] @ValidPage 어노테이션 및 검증 로직 구현
- [x] ExceptionAdvice 에러 핸들링 추가
- [x] jjwt 버전 업그레이드로 인한 JwtProvider 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] @ValidPage 커스텀 어노테이션 추가했습니다. 페이징이 필요한 목록 조회 API에서 이렇게 사용 가능합니다! 
```
public ApiResponse<BlockListResponse> getBlockList(@ValidPage @RequestParam(name = "page") Integer page,
            @AuthMember Member member)
```
이 어노테이션을 붙이면 파라미터로 받은 page의 값이 1보다 작은 경우 에러를 발생시킵니다

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크 
