### PR TITLE
[Feat/33] 친구 즐겨찾기 설정/해제 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/common/validator/FriendValidator.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/validator/FriendValidator.java
@@ -29,6 +29,21 @@ public class FriendValidator {
     }
 
     /**
+     * 두 회원이 서로 친구가 아니면 예외 발생
+     *
+     * @param member
+     * @param targetMember
+     */
+    public void validateIsFriend(Member member, Member targetMember) {
+        boolean exists1 = friendRepository.existsByFromMemberAndToMember(member, targetMember);
+        boolean exists2 = friendRepository.existsByFromMemberAndToMember(targetMember, member);
+
+        if (!exists1 || !exists2) {
+            throw new FriendException(ErrorCode.MEMBERS_NOT_FRIEND);
+        }
+    }
+
+    /**
      * 두 회원 사이에 PENDING 상태인 친구 요청이 존재하면 예외 발생
      *
      * @param member
@@ -49,6 +64,5 @@ public class FriendValidator {
             throw new FriendException(ErrorCode.TARGET_PENDING_FRIEND_REQUEST_EXIST);
         }
     }
-
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.friend.controller;
 import com.gamegoo.gamegoo_v2.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.friend.dto.FriendRequestResponse;
+import com.gamegoo.gamegoo_v2.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.friend.service.FriendFacadeService;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,6 +38,14 @@ public class FriendController {
     public ApiResponse<FriendRequestResponse> acceptFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
             @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.acceptFriendRequest(member, targetMemberId));
+    }
+
+    @Operation(summary = "친구 즐겨찾기 설정/해제 API", description = "대상 친구 회원을 즐겨찾기 설정/해제 하는 API 입니다.")
+    @Parameter(name = "memberId", description = "즐겨찾기 설정/해제할 친구 회원의 id 입니다.")
+    @PatchMapping("/{memberId}/star")
+    public ApiResponse<StarFriendResponse> reverseFriendLiked(@PathVariable(name = "memberId") Long friendMemberId,
+            @AuthMember Member member) {
+        return ApiResponse.ok(friendFacadeService.reverseFriendLiked(member, friendMemberId));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/domain/Friend.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/domain/Friend.java
@@ -60,4 +60,8 @@ public class Friend extends BaseDateTimeEntity {
         member.getFriendList().add(this);
     }
 
+    public void reverseLiked() {
+        this.liked = !this.liked;
+    }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/dto/StarFriendResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/dto/StarFriendResponse.java
@@ -1,0 +1,28 @@
+package com.gamegoo.gamegoo_v2.friend.dto;
+
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StarFriendResponse {
+
+    Long friendMemberId;
+    String message;
+
+    public static StarFriendResponse of(Friend friend) {
+        String message;
+        if (friend.isLiked()) {
+            message = "친구 즐겨찾기 설정 성공";
+        } else {
+            message = "친구 즐겨찾기 해제 성공";
+        }
+
+        return StarFriendResponse.builder()
+                .friendMemberId(friend.getToMember().getId())
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepository.java
@@ -8,4 +8,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
 
+    Friend findByFromMemberAndToMember(Member fromMember, Member toMember);
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
@@ -1,7 +1,9 @@
 package com.gamegoo.gamegoo_v2.friend.service;
 
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
 import com.gamegoo.gamegoo_v2.friend.domain.FriendRequest;
 import com.gamegoo.gamegoo_v2.friend.dto.FriendRequestResponse;
+import com.gamegoo.gamegoo_v2.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,21 @@ public class FriendFacadeService {
         FriendRequest friendRequest = friendService.acceptFriendRequest(member, targetMember);
 
         return FriendRequestResponse.of(friendRequest.getFromMember().getId(), "친구 요청 수락 성공");
+    }
+
+    /**
+     * 친구 즐겨찾기 설정/해제 Facade 메소드
+     *
+     * @param member
+     * @param friendMemberId
+     * @return
+     */
+    @Transactional
+    public StarFriendResponse reverseFriendLiked(Member member, Long friendMemberId) {
+        Member friendMember = memberService.findMember(friendMemberId);
+        Friend friend = friendService.reverseFriendLiked(member, friendMember);
+
+        return StarFriendResponse.of(friend);
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -86,6 +86,31 @@ public class FriendService {
         return friendRequest;
     }
 
+    /**
+     * targetMember를 즐겨찾기 설정 또는 해제 처리 메소드
+     *
+     * @param member
+     * @param targetMember
+     * @return
+     */
+    @Transactional
+    public Friend reverseFriendLiked(Member member, Member targetMember) {
+        // targetMember로 나 자신을 요청한 경우 검증
+        validateNotSelf(member, targetMember);
+
+        // targetMember의 탈퇴 여부 검증
+        memberValidator.validateTargetMemberIsNotBlind(targetMember);
+
+        // 두 회원이 친구 관계가 맞는지 검증
+        friendValidator.validateIsFriend(member, targetMember);
+
+        // liked 상태 변경
+        Friend friend = friendRepository.findByFromMemberAndToMember(member, targetMember);
+        friend.reverseLiked();
+
+        return friend;
+    }
+
     private void validateNotSelf(Member member, Member targetMember) {
         if (member.equals(targetMember)) {
             throw new FriendException(ErrorCode.FRIEND_BAD_REQUEST);

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.exception.MemberException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.friend.controller.FriendController;
 import com.gamegoo.gamegoo_v2.friend.dto.FriendRequestResponse;
+import com.gamegoo.gamegoo_v2.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.friend.service.FriendFacadeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -194,6 +195,90 @@ class FriendControllerTest extends ControllerTestSupport {
             mockMvc.perform(patch(API_URL_PREFIX + "/request/{memberId}/accept", TARGET_MEMBER_ID))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value(ErrorCode.PENDING_FRIEND_REQUEST_NOT_EXIST.getMessage()));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("친구 즐겨찾기 설정/해제")
+    class ReverseFriendLikedTest {
+
+        @DisplayName("친구 즐겨찾기 설정 성공")
+        @Test
+        void reverseFriendLikedSucceedsWhenNotLiked() throws Exception {
+            // given
+            StarFriendResponse response = StarFriendResponse.builder()
+                    .friendMemberId(TARGET_MEMBER_ID)
+                    .message("친구 즐겨찾기 설정 성공")
+                    .build();
+
+            given(friendFacadeService.reverseFriendLiked(any(), any())).willReturn(response);
+
+            // when // then
+            mockMvc.perform(patch(API_URL_PREFIX + "/{memberId}/star", TARGET_MEMBER_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.message").value("친구 즐겨찾기 설정 성공"))
+                    .andExpect(jsonPath("$.data.friendMemberId").value(TARGET_MEMBER_ID));
+        }
+
+        @DisplayName("친구 즐겨찾기 해제 성공")
+        @Test
+        void reverseFriendLikedSucceedsWhenLiked() throws Exception {
+            // given
+            StarFriendResponse response = StarFriendResponse.builder()
+                    .friendMemberId(TARGET_MEMBER_ID)
+                    .message("친구 즐겨찾기 해제 성공")
+                    .build();
+
+            given(friendFacadeService.reverseFriendLiked(any(), any())).willReturn(response);
+
+            // when // then
+            mockMvc.perform(patch(API_URL_PREFIX + "/{memberId}/star", TARGET_MEMBER_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.message").value("친구 즐겨찾기 해제 성공"))
+                    .andExpect(jsonPath("$.data.friendMemberId").value(TARGET_MEMBER_ID));
+
+        }
+
+        @DisplayName("친구 즐겨찾기 설정/해제 실패: 본인 id를 요청한 경우 에러 응답을 반환한다.")
+        @Test
+        void reverseFriendLikedFailedWhenTargetIsSelf() throws Exception {
+            // given
+            willThrow(new FriendException(ErrorCode.FRIEND_BAD_REQUEST))
+                    .given(friendFacadeService).reverseFriendLiked(any(), eq(TARGET_MEMBER_ID));
+
+            // when // then
+            mockMvc.perform(patch(API_URL_PREFIX + "/{memberId}/star", TARGET_MEMBER_ID))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(ErrorCode.FRIEND_BAD_REQUEST.getMessage()));
+        }
+
+        @DisplayName("친구 즐겨찾기 설정/해제 실패: 상대가 탈퇴한 경우 에러 응답을 반환한다.")
+        @Test
+        void reverseFriendLikedFailedWhenTargetIsBlind() throws Exception {
+            // given
+            willThrow(new MemberException(ErrorCode.TARGET_MEMBER_DEACTIVATED))
+                    .given(friendFacadeService).reverseFriendLiked(any(), eq(TARGET_MEMBER_ID));
+
+            // when // then
+            mockMvc.perform(patch(API_URL_PREFIX + "/{memberId}/star", TARGET_MEMBER_ID))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage()));
+        }
+
+        @DisplayName("친구 즐겨찾기 설정/해제 실패: 상대가 친구가 아닌 경우 예외가 발생한다.")
+        @Test
+        void reverseFriendLikedFailedWhenNotFriend() throws Exception {
+            // given
+            willThrow(new FriendException(ErrorCode.MEMBERS_NOT_FRIEND))
+                    .given(friendFacadeService).reverseFriendLiked(any(), eq(TARGET_MEMBER_ID));
+
+            // when // then
+            mockMvc.perform(patch(API_URL_PREFIX + "/{memberId}/star", TARGET_MEMBER_ID))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MEMBERS_NOT_FRIEND.getMessage()));
         }
 
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendFacadeServiceTest.java
@@ -8,6 +8,7 @@ import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.friend.domain.Friend;
 import com.gamegoo.gamegoo_v2.friend.domain.FriendRequest;
 import com.gamegoo.gamegoo_v2.friend.dto.FriendRequestResponse;
+import com.gamegoo.gamegoo_v2.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.friend.repository.FriendRepository;
 import com.gamegoo.gamegoo_v2.friend.repository.FriendRequestRepository;
 import com.gamegoo.gamegoo_v2.friend.service.FriendFacadeService;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
@@ -206,7 +208,7 @@ class FriendFacadeServiceTest {
 
     @DisplayName("친구 요청 수락 실패: PENDING 상태인 친구 요청이 없는 경우 예외가 발생한다")
     @Test
-    void accpetFriendRequest_shouldThrowWhenNoPendingRequest() {
+    void acceptFriendRequest_shouldThrowWhenNoPendingRequest() {
         // given
         Member member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
         Member targetMember = createMember("target@naver.com", "target");
@@ -215,6 +217,90 @@ class FriendFacadeServiceTest {
         assertThatThrownBy(() -> friendFacadeService.acceptFriendRequest(member, targetMember.getId()))
                 .isInstanceOf(FriendException.class)
                 .hasMessage(ErrorCode.PENDING_FRIEND_REQUEST_NOT_EXIST.getMessage());
+    }
+
+    @DisplayName("친구 즐겨찾기 설정 성공: 즐겨찾기 되지 않은 친구를 요청한 경우 즐겨찾기가 설정된다.")
+    @Test
+    void reverseFriendLikedSucceedsWhenNotLiked() {
+        // given
+        Member member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+        Member targetMember = createMember("target@naver.com", "target");
+
+        // 두 회원 간 친구 관계 생성
+        friendRepository.save(Friend.create(member, targetMember));
+        friendRepository.save(Friend.create(targetMember, member));
+
+        // when
+        StarFriendResponse response = friendFacadeService.reverseFriendLiked(member, targetMember.getId());
+
+        // then
+        Friend friend = friendRepository.findByFromMemberAndToMember(member, targetMember);
+        assertTrue(friend.isLiked());
+        assertThat(response.getMessage()).isEqualTo("친구 즐겨찾기 설정 성공");
+    }
+
+    @DisplayName("친구 즐겨찾기 해제 성공: 즐겨찾기 된 친구를 요청한 경우 즐겨찾기가 해제된다.")
+    @Test
+    void reverseFriendLikedSucceedsWhenLiked() {
+        // given
+        Member member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+        Member targetMember = createMember("target@naver.com", "target");
+
+        // 두 회원 간 친구 관계 생성
+        Friend savedFriend = friendRepository.save(Friend.create(member, targetMember));
+        friendRepository.save(Friend.create(targetMember, member));
+
+        // member -> targetMember 즐겨찾기 설정
+        savedFriend.reverseLiked();
+
+        // when
+        StarFriendResponse response = friendFacadeService.reverseFriendLiked(member, targetMember.getId());
+
+        // then
+        Friend friend = friendRepository.findByFromMemberAndToMember(member, targetMember);
+        assertFalse(friend.isLiked());
+        assertThat(response.getMessage()).isEqualTo("친구 즐겨찾기 해제 성공");
+    }
+
+    @DisplayName("친구 즐겨찾기 설정/해제 실패: 본인 id를 요청한 경우 예외가 발생한다.")
+    @Test
+    void reverseFriendLiked_shouldThrownWhenTargetIsSelf() {
+        // given
+        Member member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+
+        // when // then
+        assertThatThrownBy(() -> friendFacadeService.reverseFriendLiked(member, member.getId()))
+                .isInstanceOf(FriendException.class)
+                .hasMessage(ErrorCode.FRIEND_BAD_REQUEST.getMessage());
+    }
+
+    @DisplayName("친구 즐겨찾기 설정/해제 실패: 상대가 탈퇴한 회원인 경우 예외가 발생한다.")
+    @Test
+    void reverseFriendLiked_shouldThrownWhenTargetIsBlind() {
+        // given
+        Member member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+        Member targetMember = createMember("target@naver.com", "target");
+
+        // 대상 회원을 탈퇴 처리
+        targetMember.updateBlind(true);
+
+        // when // then
+        assertThatThrownBy(() -> friendFacadeService.reverseFriendLiked(member, targetMember.getId()))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage());
+    }
+
+    @DisplayName("친구 즐겨찾기 설정/해제 실패: 상대가 친구가 아닌 경우 예외가 발생한다.")
+    @Test
+    void reverseFriendLiked_shouldThrownWhenTargetIsNotFriend() {
+        // given
+        Member member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+        Member targetMember = createMember("target@naver.com", "target");
+
+        // when // then
+        assertThatThrownBy(() -> friendFacadeService.reverseFriendLiked(member, targetMember.getId()))
+                .isInstanceOf(FriendException.class)
+                .hasMessage(ErrorCode.MEMBERS_NOT_FRIEND.getMessage());
     }
 
     private Member createMember(String email, String gameName) {


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 친구 즐겨찾기 설정/해제 API 구현 및 테스트

## ⏳ 작업 상세 내용

<!--  -->

- [x] 친구 즐겨찾기 설정/해제 API 구현
- [x] 친구 즐겨찾기 설정/해제 API 서비스 테스트
- [x] 친구 즐겨찾기 설정/해제 API 컨트롤러 테스트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 기존에는 친구 즐겨찾기 설정 API, 즐겨찾기 해제 API 가 별도로 있었는데 이걸 하나의 api로 통합했습니다. api 요청을 했을 때 member -> targetMember로 즐겨찾기가 되어있는 상태였으면 즐겨찾기 해제 처리, 즐겨찾기가 안되어있는 상태였으면 즐겨찾기 설정 처리하도록 변경했습니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크 
