### PR TITLE
[Feat/39] 친구 목록 조회 API 구현 및 테스트

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,0 +1,25 @@
+name: PR Test
+
+on:
+  pull_request:
+    branches: [ develop ] # develop branch에 PR을 보낼 때 실행
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Gradle wrapper 파일 실행 권한주기
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Gradle test를 실행
+      - name: Test with Gradle
+        run: ./gradlew --info test

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-/src/main/generated
+/src/main/generated/**
 
 
 # General

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+/src/main/generated
+
+
 # General
 .DS_Store
 .AppleDouble

--- a/build.gradle
+++ b/build.gradle
@@ -51,13 +51,32 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // security
-    // implementation 'org.springframework.boot:spring-boot-starter-security'
-    // testImplementation 'org.springframework.security:spring-security-test'
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-//    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
@@ -63,6 +63,7 @@ public class BlockFacadeService {
      * @param member
      * @param targetMemberId
      */
+    @Transactional
     public void deleteBlock(Member member, Long targetMemberId) {
         Member targetMember = memberService.findMember(targetMemberId);
         blockService.deleteBlock(member, targetMember);

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockService.java
@@ -66,6 +66,7 @@ public class BlockService {
      * @param member
      * @param targetMember
      */
+    @Transactional
     public void unBlockMember(Member member, Member targetMember) {
         // 대상 회원의 탈퇴 여부 검증
         memberValidator.validateTargetMemberIsNotBlind(targetMember);
@@ -85,6 +86,7 @@ public class BlockService {
      * @param member
      * @param targetMember
      */
+    @Transactional
     public void deleteBlock(Member member, Member targetMember) {
         // targetMember가 차단 목록에 존재하는지 검증 및 block 엔티티 조회
         Block block = blockRepository.findByBlockerMemberAndBlockedMember(member, targetMember)

--- a/src/main/java/com/gamegoo/gamegoo_v2/common/annotation/ValidCursor.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/annotation/ValidCursor.java
@@ -1,0 +1,23 @@
+package com.gamegoo.gamegoo_v2.common.annotation;
+
+import com.gamegoo.gamegoo_v2.common.annotationValidator.ValidCursorAnnotationValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ValidCursorAnnotationValidator.class)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCursor {
+
+    String message() default "커서는 1 이상의 값이어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/common/annotationValidator/ValidCursorAnnotationValidator.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/annotationValidator/ValidCursorAnnotationValidator.java
@@ -1,0 +1,23 @@
+package com.gamegoo.gamegoo_v2.common.annotationValidator;
+
+import com.gamegoo.gamegoo_v2.common.annotation.ValidPage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidCursorAnnotationValidator implements ConstraintValidator<ValidPage, Integer> {
+
+    @Override
+    public void initialize(ValidPage constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        if (value != null && value < 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/common/annotationValidator/ValidCursorAnnotationValidator.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/common/annotationValidator/ValidCursorAnnotationValidator.java
@@ -1,18 +1,18 @@
 package com.gamegoo.gamegoo_v2.common.annotationValidator;
 
-import com.gamegoo.gamegoo_v2.common.annotation.ValidPage;
+import com.gamegoo.gamegoo_v2.common.annotation.ValidCursor;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class ValidCursorAnnotationValidator implements ConstraintValidator<ValidPage, Integer> {
+public class ValidCursorAnnotationValidator implements ConstraintValidator<ValidCursor, Long> {
 
     @Override
-    public void initialize(ValidPage constraintAnnotation) {
+    public void initialize(ValidCursor constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
     }
 
     @Override
-    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
         if (value != null && value < 1) {
             return false;
         }

--- a/src/main/java/com/gamegoo/gamegoo_v2/config/QuerydslConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.gamegoo.gamegoo_v2.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    
+    @Autowired
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.friend.controller;
 
 import com.gamegoo.gamegoo_v2.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.friend.dto.DeleteFriendResponse;
+import com.gamegoo.gamegoo_v2.friend.dto.FriendListResponse;
 import com.gamegoo.gamegoo_v2.friend.dto.FriendRequestResponse;
 import com.gamegoo.gamegoo_v2.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.friend.service.FriendFacadeService;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -82,6 +85,15 @@ public class FriendController {
     @GetMapping("/ids")
     public ApiResponse<List<Long>> getFriendIds(@AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.getFriendIdList(member));
+    }
+
+    @Operation(summary = "친구 목록 조회 API", description = "해당 회원의 친구 목록을 조회하는 API 입니다. 이름 오름차순(한글-영문-숫자 순)으로 정렬해 제공합니다."
+            + "cursor를 보내지 않으면 상위 10개 친구 목록을 조회합니다.")
+    @Parameter(name = "cursor", description = "페이징을 위한 커서, 이전 친구 목록 조회에서 응답받은 next_cursor를 보내주세요.")
+    @GetMapping
+    public ApiResponse<FriendListResponse> getFriendList(
+            @ValidCursor @RequestParam(name = "cursor", required = false) Long cursor, @AuthMember Member member) {
+        return ApiResponse.ok(friendFacadeService.getFriends(member, cursor));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,6 +29,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/friends")
+@Validated
 public class FriendController {
 
     private final FriendFacadeService friendFacadeService;

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/controller/FriendController.java
@@ -12,11 +12,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Friend", description = "친구 관련 API")
 @RestController
@@ -49,7 +52,7 @@ public class FriendController {
             @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.rejectFriendRequest(member, targetMemberId));
     }
-  
+
     @Operation(summary = "친구 요청 취소 API", description = "대상 회원에게 보낸 친구 요청을 취소하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 취소할 대상 회원의 id 입니다.")
     @DeleteMapping("/request/{memberId}")
@@ -72,6 +75,13 @@ public class FriendController {
     public ApiResponse<DeleteFriendResponse> deleteFriend(@PathVariable(name = "memberId") Long targetMemberId,
             @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.deleteFriend(member, targetMemberId));
+    }
+
+    @Operation(summary = "모든 친구 id 조회 API", description = "해당 회원의 모든 친구 id 목록을 조회하는 API 입니다. " +
+            "정렬 기능 없음, socket서버용 API입니다.")
+    @GetMapping("/ids")
+    public ApiResponse<List<Long>> getFriendIds(@AuthMember Member member) {
+        return ApiResponse.ok(friendFacadeService.getFriendIdList(member));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/dto/FriendListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/dto/FriendListResponse.java
@@ -12,9 +12,9 @@ import java.util.List;
 public class FriendListResponse {
 
     List<FriendInfoResponse> friendInfoDTOList;
-    int list_size;
-    boolean has_next;
-    Long next_cursor;
+    int listSize;
+    boolean hasNext;
+    Long nextCursor;
 
     @Getter
     @Builder
@@ -50,9 +50,9 @@ public class FriendListResponse {
 
         return FriendListResponse.builder()
                 .friendInfoDTOList(friendInfoResponseList)
-                .list_size(friendInfoResponseList.size())
-                .has_next(friends.hasNext())
-                .next_cursor(nextCursor)
+                .listSize(friendInfoResponseList.size())
+                .hasNext(friends.hasNext())
+                .nextCursor(nextCursor)
                 .build();
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/dto/FriendListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/dto/FriendListResponse.java
@@ -1,0 +1,59 @@
+package com.gamegoo.gamegoo_v2.friend.dto;
+
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FriendListResponse {
+
+    List<FriendInfoResponse> friendInfoDTOList;
+    int list_size;
+    boolean has_next;
+    Long next_cursor;
+
+    @Getter
+    @Builder
+    public static class FriendInfoResponse {
+
+        Long memberId;
+        String name;
+        int profileImg;
+        boolean isLiked;
+        boolean isBlind;
+
+        public static FriendInfoResponse of(Friend friend) {
+            String name = friend.getToMember().isBlind() ? "(탈퇴한 사용자)" : friend.getToMember().getGameName();
+            return FriendInfoResponse.builder()
+                    .memberId(friend.getToMember().getId())
+                    .profileImg(friend.getToMember().getProfileImage())
+                    .name(name)
+                    .isLiked(friend.isLiked())
+                    .isBlind(friend.getToMember().isBlind())
+                    .build();
+        }
+
+    }
+
+    public static FriendListResponse of(Slice<Friend> friends) {
+        List<FriendInfoResponse> friendInfoResponseList = friends.stream()
+                .map(FriendInfoResponse::of)
+                .toList();
+
+        Long nextCursor = friends.hasNext()
+                ? friends.getContent().get(friendInfoResponseList.size() - 1).getToMember().getId()
+                : null;
+
+        return FriendListResponse.builder()
+                .friendInfoDTOList(friendInfoResponseList)
+                .list_size(friendInfoResponseList.size())
+                .has_next(friends.hasNext())
+                .next_cursor(nextCursor)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepository.java
@@ -4,7 +4,7 @@ import com.gamegoo.gamegoo_v2.friend.domain.Friend;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FriendRepository extends JpaRepository<Friend, Long> {
+public interface FriendRepository extends JpaRepository<Friend, Long>, FriendRepositoryCustom {
 
     boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.gamegoo.gamegoo_v2.friend.repository;
+
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import org.springframework.data.domain.Slice;
+
+public interface FriendRepositoryCustom {
+
+    Slice<Friend> findFriendsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepositoryCustomImpl.java
@@ -1,17 +1,17 @@
 package com.gamegoo.gamegoo_v2.friend.repository;
 
 import com.gamegoo.gamegoo_v2.friend.domain.Friend;
-import com.gamegoo.gamegoo_v2.friend.domain.QFriend;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
+import static com.gamegoo.gamegoo_v2.friend.domain.QFriend.friend;
 
 @RequiredArgsConstructor
 public class FriendRepositoryCustomImpl implements FriendRepositoryCustom {
@@ -19,40 +19,110 @@ public class FriendRepositoryCustomImpl implements FriendRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Friend> findFriendsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize) {
-        QFriend friend = QFriend.friend;
-
-        List<Friend> friends = queryFactory.selectFrom(friend)
-                .where(
-                        friend.toMember.id.eq(memberId),
-                        cursor != null ? friend.id.gt(cursor) : null // 커서 조건: cursor 이후의 데이터
-                )
-                .orderBy(
-                        // 한글 → 영문자 → 숫자 → 그 외 순으로 정렬
-                        new CaseBuilder()
-                                .when(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
-                                        .between("가", "힣")).then(1)
-                                .when(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
-                                        .between("A", "Z")
-                                        .or(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
-                                                .between("a", "z"))).then(2)
-                                .when(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
-                                        .between("0", "9")).then(3)
-                                .otherwise(4)
-                                .asc(),
-                        friend.toMember.gameName.asc(),   // 같은 그룹 내에서는 이름으로 정렬
-                        friend.id.asc()      // 중복을 피하기 위해 ID로 정렬
-                )
-                .limit(pageSize + 1)     // 다음 페이지 여부를 확인하기 위해 pageSize보다 1개 더 가져옴
+    public Slice<Friend> findFriendsByCursorAndOrdered(Long memberId, Long cursorId, Integer pageSize) {
+        // 전체 친구 목록 조회
+        List<Friend> allFriends = queryFactory.selectFrom(friend)
+                .where(friend.fromMember.id.eq(memberId))
                 .fetch();
 
-        boolean hasNext = friends.size() > pageSize;
+        // 친구 목록 전체 정렬
+        allFriends.sort(
+                (f1, f2) -> memberNameComparator.compare(f1.getToMember().getGameName(),
+                        f2.getToMember().getGameName()));
 
+        // 정렬된 데이터에서 페이징 적용
+        // cursorId에 해당하는 요소의 인덱스 찾기
+        int startIndex = findCursorIndex(allFriends, cursorId);
+
+        List<Friend> pagedFriends = allFriends.stream()
+                .skip(startIndex)
+                .limit(pageSize + 1) // 다음 페이지가 있는지 확인하기 위해 +1
+                .collect(Collectors.toList());
+
+        boolean hasNext = pagedFriends.size() > pageSize;
         if (hasNext) {
-            friends.remove(friends.size() - 1); // 다음 페이지가 있으면 마지막 요소를 제거
+            pagedFriends.remove(pagedFriends.size() - 1); // 다음 페이지가 있으면 마지막 요소를 제거
         }
 
-        return new SliceImpl<>(friends, Pageable.unpaged(), hasNext);
+        return new SliceImpl<>(pagedFriends, Pageable.unpaged(), hasNext);
     }
+
+
+    /**
+     * cursorId에 해당하는 Friend 객체의 다음 인덱스 찾기
+     *
+     * @param allFriends
+     * @param cursorId
+     * @return
+     */
+    private static int findCursorIndex(List<Friend> allFriends, Long cursorId) {
+        if (cursorId == null) {
+            return 0;
+        }
+
+        for (int i = 0; i < allFriends.size(); i++) {
+            if (allFriends.get(i).getToMember().getId().equals(cursorId)) {
+                return i + 1;
+            }
+        }
+        return 0; // cursorId에 해당하는 객체를 찾지 못하면 0을 리턴
+    }
+
+    private static final Comparator<String> memberNameComparator = (s1, s2) -> {
+        int length1 = s1.length();
+        int length2 = s2.length();
+        int minLength = Math.min(length1, length2);
+
+        // 각 문자 비교
+        for (int i = 0; i < minLength; i++) {
+            int result = compareChars(s1.charAt(i), s2.charAt(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        // 앞부분이 동일하면, 길이가 짧은 것이 앞으로 오도록 정렬
+        return Integer.compare(length1, length2);
+    };
+
+    /**
+     * 문자 비교 메서드: 한글 -> 영문자 -> 숫자 순으로 우선순위 지정
+     *
+     * @param c1
+     * @param c2
+     * @return
+     */
+    private static int compareChars(char c1, char c2) {
+        boolean isC1Korean = isKorean(c1);
+        boolean isC2Korean = isKorean(c2);
+
+        // 한글과 영문자/숫자를 구분하여 우선순위 설정
+        if (isC1Korean && !isC2Korean) {
+            return -1; // 한글은 영문자/숫자보다 먼저
+        } else if (!isC1Korean && isC2Korean) {
+            return 1; // 영문자/숫자는 한글보다 뒤
+        } else if (Character.isDigit(c1) && Character.isDigit(c2)) {
+            return Character.compare(c1, c2); // 둘 다 숫자인 경우 숫자 비교
+        } else if (Character.isDigit(c1)) {
+            return 1; // 숫자는 항상 뒤로
+        } else if (Character.isDigit(c2)) {
+            return -1; // 숫자는 항상 뒤로
+        } else {
+            return Character.compare(c1, c2); // 기본적으로 문자 비교 (영문자끼리 등)
+        }
+    }
+
+    /**
+     * 한글 여부를 판별
+     *
+     * @param c
+     * @return
+     */
+    private static boolean isKorean(char c) {
+        return (c >= 0x1100 && c <= 0x11FF) || // 한글 자모
+                (c >= 0xAC00 && c <= 0xD7AF) || // 한글 음절
+                (c >= 0x3130 && c <= 0x318F);   // 한글 호환 자모
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/repository/FriendRepositoryCustomImpl.java
@@ -1,0 +1,58 @@
+package com.gamegoo.gamegoo_v2.friend.repository;
+
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import com.gamegoo.gamegoo_v2.friend.domain.QFriend;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
+
+@RequiredArgsConstructor
+public class FriendRepositoryCustomImpl implements FriendRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Friend> findFriendsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize) {
+        QFriend friend = QFriend.friend;
+
+        List<Friend> friends = queryFactory.selectFrom(friend)
+                .where(
+                        friend.toMember.id.eq(memberId),
+                        cursor != null ? friend.id.gt(cursor) : null // 커서 조건: cursor 이후의 데이터
+                )
+                .orderBy(
+                        // 한글 → 영문자 → 숫자 → 그 외 순으로 정렬
+                        new CaseBuilder()
+                                .when(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
+                                        .between("가", "힣")).then(1)
+                                .when(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
+                                        .between("A", "Z")
+                                        .or(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
+                                                .between("a", "z"))).then(2)
+                                .when(stringTemplate("SUBSTRING({0}, 1, 1)", friend.toMember.gameName)
+                                        .between("0", "9")).then(3)
+                                .otherwise(4)
+                                .asc(),
+                        friend.toMember.gameName.asc(),   // 같은 그룹 내에서는 이름으로 정렬
+                        friend.id.asc()      // 중복을 피하기 위해 ID로 정렬
+                )
+                .limit(pageSize + 1)     // 다음 페이지 여부를 확인하기 위해 pageSize보다 1개 더 가져옴
+                .fetch();
+
+        boolean hasNext = friends.size() > pageSize;
+
+        if (hasNext) {
+            friends.remove(friends.size() - 1); // 다음 페이지가 있으면 마지막 요소를 제거
+        }
+
+        return new SliceImpl<>(friends, Pageable.unpaged(), hasNext);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -63,8 +65,8 @@ public class FriendFacadeService {
 
         return FriendRequestResponse.of(friendRequest.getFromMember().getId(), "친구 요청 거절 성공");
     }
- 
-      /**
+
+    /**
      * 친구 요청 취소 Facade 메소드
      *
      * @param member
@@ -107,6 +109,16 @@ public class FriendFacadeService {
         friendService.deleteFriend(member, targetMember);
 
         return DeleteFriendResponse.of(targetMemberId);
+    }
+
+    /**
+     * 모든 친구 목록 조회 Facade 메소드
+     *
+     * @param member
+     * @return
+     */
+    public List<Long> getFriendIdList(Member member) {
+        return member.getFriendList().stream().map(friend -> friend.getToMember().getId()).toList();
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.friend.service;
 import com.gamegoo.gamegoo_v2.friend.domain.Friend;
 import com.gamegoo.gamegoo_v2.friend.domain.FriendRequest;
 import com.gamegoo.gamegoo_v2.friend.dto.DeleteFriendResponse;
+import com.gamegoo.gamegoo_v2.friend.dto.FriendListResponse;
 import com.gamegoo.gamegoo_v2.friend.dto.FriendRequestResponse;
 import com.gamegoo.gamegoo_v2.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
@@ -112,13 +113,24 @@ public class FriendFacadeService {
     }
 
     /**
-     * 모든 친구 목록 조회 Facade 메소드
+     * 모든 친구 id 목록 조회 Facade 메소드
      *
      * @param member
      * @return
      */
     public List<Long> getFriendIdList(Member member) {
         return member.getFriendList().stream().map(friend -> friend.getToMember().getId()).toList();
+    }
+
+    /**
+     * 친구 목록 조회 Facade 메소드
+     *
+     * @param member
+     * @param cursor
+     * @return
+     */
+    public FriendListResponse getFriends(Member member, Long cursor) {
+        return FriendListResponse.of(friendService.getFriends(member, cursor));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -12,6 +12,7 @@ import com.gamegoo.gamegoo_v2.friend.repository.FriendRepository;
 import com.gamegoo.gamegoo_v2.friend.repository.FriendRequestRepository;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,8 @@ public class FriendService {
     private final BlockValidator blockValidator;
     private final MemberValidator memberValidator;
     private final FriendValidator friendValidator;
+
+    private final static int PAGE_SIZE = 10;
 
     /**
      * 친구 요청 생성 메소드
@@ -186,6 +189,16 @@ public class FriendService {
         if (friend2 != null) {
             friendRepository.delete(friend2);
         }
+    }
+
+    /**
+     * 해당 회원의 친구 목록 Slice 객체 반환하는 메소드
+     *
+     * @param member
+     * @return
+     */
+    public Slice<Friend> getFriends(Member member, Long cursor) {
+        return friendRepository.findFriendsByCursorAndOrdered(member.getId(), cursor, PAGE_SIZE);
     }
 
     private void validateNotSelf(Member member, Member targetMember) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
@@ -15,11 +15,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -300,6 +304,7 @@ class FriendControllerTest extends ControllerTestSupport {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value(ErrorCode.PENDING_FRIEND_REQUEST_NOT_EXIST.getMessage()));
         }
+
     }
 
     @Nested
@@ -433,6 +438,27 @@ class FriendControllerTest extends ControllerTestSupport {
             mockMvc.perform(delete(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message").value(ErrorCode.MEMBERS_NOT_FRIEND.getMessage()));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("모든 친구 id 조회")
+    class GetFriendIdListTest {
+
+        @DisplayName("모든 친구 id 조회 성공")
+        @Test
+        void getFriendIdListSucceeds() throws Exception {
+            // given
+            List<Long> response = new ArrayList<>();
+
+            given(friendFacadeService.getFriendIdList(any())).willReturn(response);
+
+            // when // then
+            mockMvc.perform(get(API_URL_PREFIX + "/ids"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data").isArray());
         }
 
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -229,7 +228,6 @@ class BlockServiceTest {
 
         @DisplayName("차단 목록에서 삭제 성공")
         @Test
-        @Transactional
         void deleteBlockSucceeds() {
             // given
             Member targetMember = createMember(TARGET_EMAIL, TARGET_GAMENAME);

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendQueryServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendQueryServiceTest.java
@@ -1,0 +1,110 @@
+package com.gamegoo.gamegoo_v2.integration.friend;
+
+import com.gamegoo.gamegoo_v2.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import com.gamegoo.gamegoo_v2.friend.repository.FriendRepository;
+import com.gamegoo.gamegoo_v2.friend.service.FriendFacadeService;
+import com.gamegoo.gamegoo_v2.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class FriendQueryServiceTest {
+
+    @Autowired
+    FriendFacadeService friendFacadeService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    BlockRepository blockRepository;
+
+    @Autowired
+    FriendRepository friendRepository;
+
+    private static final String MEMBER_EMAIL = "test@gmail.com";
+    private static final String MEMBER_GAMENAME = "member";
+    private static final String TARGET_EMAIL = "target@naver.com";
+    private static final String TARGET_GAMENAME = "target";
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+    }
+
+    @AfterEach
+    void tearDown() {
+        friendRepository.deleteAllInBatch();
+        blockRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("모든 친구 id 조회")
+    class GetFriendIdList {
+
+        @DisplayName("모든 친구 id 조회 성공: 친구가 있는 경우")
+        @Test
+        void getFriendIdListSucceeds() {
+            // given
+            for (int i = 1; i <= 5; i++) {
+                Member targetMember = createMember("member" + i + "@gmail.com", "member" + i);
+
+                // 친구 관계 생성
+                friendRepository.save(Friend.create(member, targetMember));
+                friendRepository.save(Friend.create(targetMember, member));
+            }
+
+            // when
+            List<Long> friendIdList = friendFacadeService.getFriendIdList(member);
+
+            // then
+            assertThat(friendIdList).hasSize(5);
+        }
+
+        @DisplayName("모든 친구 id 조회 성공: 친구가 없는 경우")
+        @Test
+        void getFriendIdListSucceedsWhenNoFriend() {
+            // when
+            List<Long> friendIdList = friendFacadeService.getFriendIdList(member);
+
+            // then
+            assertThat(friendIdList).hasSize(0);
+        }
+
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.repository.block;
 
 import com.gamegoo.gamegoo_v2.block.domain.Block;
 import com.gamegoo.gamegoo_v2.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.config.QuerydslConfig;
 import com.gamegoo.gamegoo_v2.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.domain.Tier;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -20,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 class BlockRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/friend/FriendRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/friend/FriendRepositoryTest.java
@@ -1,0 +1,193 @@
+package com.gamegoo.gamegoo_v2.repository.friend;
+
+import com.gamegoo.gamegoo_v2.config.QuerydslConfig;
+import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import com.gamegoo.gamegoo_v2.friend.repository.FriendRepository;
+import com.gamegoo.gamegoo_v2.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.member.domain.Tier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslConfig.class)
+class FriendRepositoryTest {
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private static final int PAGE_SIZE = 10;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember("test@gmail.com", "member");
+    }
+
+    @Nested
+    @DisplayName("친구 목록 조회")
+    class findFriendsByCursorAndOrderedTest {
+
+        @DisplayName("친구 목록 조회: 친구가 0명인 경우")
+        @Test
+        void findFriendsByCursorAndOrderedWhenNoFriend() {
+            // when
+            Slice<Friend> friendSlice = friendRepository.findFriendsByCursorAndOrdered(member.getId(), null,
+                    PAGE_SIZE);
+
+            // then
+            assertThat(friendSlice).isEmpty();
+            assertFalse(friendSlice.hasNext());
+        }
+
+        @DisplayName("친구 목록 조회: 친구가 page size 이하이고 cursor로 null을 입력한 경우")
+        @Test
+        void findFriendsByCursorAndOrderedOnePage() {
+            // given
+            for (int i = 1; i <= 10; i++) {
+                Member toMember = createMember("member" + i + "@gmail.com", "member" + i);
+                createFriend(member, toMember);
+            }
+
+            // when
+            Slice<Friend> friendSlice = friendRepository.findFriendsByCursorAndOrdered(member.getId(), null,
+                    PAGE_SIZE);
+
+            // then
+            assertThat(friendSlice).hasSize(10);
+            assertThat(friendSlice.hasNext()).isEqualTo(false);
+            assertThat(friendSlice.getContent().get(0).getToMember().getGameName()).isEqualTo("member1");
+            assertThat(friendSlice.getContent().get(9).getToMember().getGameName()).isEqualTo("member9");
+        }
+
+        @DisplayName("친구 목록 조회: 친구가 page size 이상이고 cursor로 null을 입력한 경우 첫 페이지를 조회해야 한다.")
+        @Test
+        void findFriendsByCursorAndOrderedFirstPage() {
+            // given
+            for (int i = 1; i <= 20; i++) {
+                Member toMember = createMember("member" + i + "@gmail.com", "member" + i);
+                createFriend(member, toMember);
+            }
+
+            // when
+            Slice<Friend> friendSlice = friendRepository.findFriendsByCursorAndOrdered(member.getId(), null,
+                    PAGE_SIZE);
+
+            // then
+            assertThat(friendSlice).hasSize(10);
+            assertThat(friendSlice.hasNext()).isEqualTo(true);
+            assertThat(friendSlice.getContent().get(0).getToMember().getGameName()).isEqualTo("member1");
+            assertThat(friendSlice.getContent().get(9).getToMember().getGameName()).isEqualTo("member18");
+        }
+
+        @DisplayName("친구 목록 조회: 친구가 page size 이상이고 cursor를 정상 입력한 경우 다음 페이지를 조회해야 한다.")
+        @Test
+        void findFriendsByCursorAndOrderedNextPage() {
+            Long cursorId = 0L;
+            // given
+            for (int i = 1; i <= 20; i++) {
+                Member toMember = createMember("member" + i + "@gmail.com", "member" + i);
+                createFriend(member, toMember);
+                if (i == 18) {
+                    cursorId = toMember.getId();
+                }
+            }
+
+            // when
+            Slice<Friend> friendSlice = friendRepository.findFriendsByCursorAndOrdered(member.getId(), cursorId,
+                    PAGE_SIZE);
+
+            // then
+            assertThat(friendSlice).hasSize(10);
+            assertThat(friendSlice.hasNext()).isEqualTo(false);
+            assertThat(friendSlice.getContent().get(0).getToMember().getGameName()).isEqualTo("member19");
+            assertThat(friendSlice.getContent().get(9).getToMember().getGameName()).isEqualTo("member9");
+        }
+
+        @DisplayName("친구 목록 조회: 친구가 page size 이상이고 cursor에 해당하는 회원이 없는 경우 첫 페이지를 조회해야 한다.")
+        @Test
+        void findFriendsByCursorAndOrderedFirstPageWhenNoCursorMember() {
+            // given
+            for (int i = 1; i <= 20; i++) {
+                Member toMember = createMember("member" + i + "@gmail.com", "member" + i);
+                createFriend(member, toMember);
+            }
+            Long cursorId = 100L;
+
+            // when
+            Slice<Friend> friendSlice = friendRepository.findFriendsByCursorAndOrdered(member.getId(), cursorId,
+                    PAGE_SIZE);
+
+            // then
+            assertThat(friendSlice).hasSize(10);
+            assertThat(friendSlice.hasNext()).isEqualTo(true);
+            assertThat(friendSlice.getContent().get(0).getToMember().getGameName()).isEqualTo("member1");
+            assertThat(friendSlice.getContent().get(9).getToMember().getGameName()).isEqualTo("member18");
+        }
+
+        @DisplayName("친구 목록 조회: 조회 결과는 친구 회원의 소환사명에 대해 한>영>숫자 순으로 정렬되어야 한다.")
+        @Test
+        void findFriendsByCursorAndOrderedByGameName() {
+            // given
+            List<String> gameNameList = Arrays.asList("가", "가1", "가2", "가10", "가a", "가가", "a", "가a1", "가aa", "123");
+            for (int i = 0; i < gameNameList.size(); i++) {
+                Member toMember = createMember("member" + (i + 1) + "@gmail.com", gameNameList.get(i));
+                createFriend(member, toMember);
+            }
+
+            // when
+            Slice<Friend> friendSlice = friendRepository.findFriendsByCursorAndOrdered(member.getId(), null,
+                    PAGE_SIZE);
+
+            // then
+            assertThat(friendSlice).hasSize(10);
+            assertThat(friendSlice.hasNext()).isEqualTo(false);
+            List<String> orderedGameName = Arrays.asList("가", "가가", "가a", "가aa", "가a1", "가1", "가10", "가2", "a", "123");
+            for (int i = 0; i < orderedGameName.size(); i++) {
+                assertThat(friendSlice.getContent().get(i).getToMember().getGameName()).isEqualTo(orderedGameName.get(i));
+            }
+        }
+
+    }
+
+    private Member createMember(String email, String gameName) {
+        return em.persist(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private Friend createFriend(Member fromMember, Member toMember) {
+        friendRepository.save(Friend.create(toMember, fromMember));
+        return friendRepository.save(Friend.create(fromMember, toMember));
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 친구 목록 조회 API 구현 및 테스트

## ⏳ 작업 상세 내용

<!--  -->

- [x] 모든 친구 id 조회 API 구현
- [x] 모든 친구 id 조회 API 서비스 테스트
- [x] 모든 친구 id 조회 API 컨트롤러 테스트
- [x] 모든 친구 목록 조회 API 구현
- [x] 모든 친구 목록 조회 API 서비스 테스트
- [x] 모든 친구 목록 조회 API 컨트롤러 테스트
- [x] 모든 친구 목록 조회 API repository 테스트
- [x] querydsl 관련 설정 추가
- [x] pr 등록 시 테스트 자동 실행되도록 action 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 쿼리 파라미터로 cursor 값을 받을 때 이 cursor가 음수가 아님을 검증하는 용도의 어노테이션 @ValidCursor 구현했습니다.
- [ ] pr 등록 시 전체 테스트가 실행되도록 action 추가했습니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크 
