### PR TITLE
[Feat/41] 알림 생성 이벤트 및 리스너 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 
     // security
     // implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/gamegoo/gamegoo_v2/config/AsyncConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.gamegoo.gamegoo_v2.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/AcceptFriendRequestEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/AcceptFriendRequestEvent.java
@@ -1,0 +1,13 @@
+package com.gamegoo.gamegoo_v2.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AcceptFriendRequestEvent {
+
+    private final Long memberId;
+    private final Long targetMemberId;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/FriendRequestEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/FriendRequestEvent.java
@@ -1,0 +1,14 @@
+package com.gamegoo.gamegoo_v2.event;
+
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FriendRequestEvent {
+
+    private final Member member;
+    private final Member sourceMember;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/RejectFriendRequestEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/RejectFriendRequestEvent.java
@@ -1,0 +1,13 @@
+package com.gamegoo.gamegoo_v2.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RejectFriendRequestEvent {
+
+    private final Long memberId;
+    private final Long targetMemberId;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/SendFriendRequestEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/SendFriendRequestEvent.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class FriendRequestEvent {
+public class SendFriendRequestEvent {
 
     private final Member member;
     private final Member sourceMember;

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/SendFriendRequestEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/SendFriendRequestEvent.java
@@ -1,6 +1,5 @@
 package com.gamegoo.gamegoo_v2.event;
 
-import com.gamegoo.gamegoo_v2.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SendFriendRequestEvent {
 
-    private final Member member;
-    private final Member sourceMember;
+    private final Long memberId;
+    private final Long sourceMemberId;
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.event.listener;
 
 import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.member.service.MemberService;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FriendRequestEventListener {
 
     private final NotificationService notificationService;
+    private final MemberService memberService;
 
     /**
      * 친구 요청 전송 event listener
@@ -27,8 +29,8 @@ public class FriendRequestEventListener {
     @EventListener
     public void handleSendFriendRequestEvent(SendFriendRequestEvent event) {
         try {
-            Member member = event.getMember();
-            Member sourceMember = event.getSourceMember();
+            Member member = memberService.findMember(event.getMemberId());
+            Member sourceMember = memberService.findMember(event.getSourceMemberId());
 
             // member가 sourceMember에게 친구 요청 전송했음 알림 생성
             notificationService.createSendFriendRequestNotification(member, sourceMember);

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -44,6 +44,11 @@ public class FriendRequestEventListener {
         }
     }
 
+    /**
+     * 친구 요청 수락 event listener
+     *
+     * @param event
+     */
     @Async
     @Transactional
     @EventListener
@@ -59,6 +64,11 @@ public class FriendRequestEventListener {
         }
     }
 
+    /**
+     * 친구 요청 거절 event listener
+     *
+     * @param event
+     */
     @Async
     @Transactional
     @EventListener

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -1,0 +1,39 @@
+package com.gamegoo.gamegoo_v2.event.listener;
+
+import com.gamegoo.gamegoo_v2.event.FriendRequestEvent;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FriendRequestEventListener {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @Transactional
+    @EventListener
+    public void handleFriendRequestEvent(FriendRequestEvent event) {
+        try {
+            Member member = event.getMember();
+            Member sourceMember = event.getSourceMember();
+
+            // member가 sourceMember에게 친구 요청 전송했음 알림 생성
+            notificationService.createSendFriendRequestNotification(member, sourceMember);
+
+            // sourceMeber가 member로부터 친구 요청 받았음 알림 생성
+            notificationService.createReceivedFriendRequestNotification(sourceMember, member);
+        } catch (Exception e) {
+            log.error("Failed to create friend request notifications", e);
+        }
+
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -37,7 +37,7 @@ public class FriendRequestEventListener {
             // member가 sourceMember에게 친구 요청 전송했음 알림 생성
             notificationService.createSendFriendRequestNotification(member, sourceMember);
 
-            // sourceMeber가 member로부터 친구 요청 받았음 알림 생성
+            // sourceMember가 member로부터 친구 요청 받았음 알림 생성
             notificationService.createReceivedFriendRequestNotification(sourceMember, member);
         } catch (Exception e) {
             log.error("Failed to create friend request notifications", e);

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -1,5 +1,6 @@
 package com.gamegoo.gamegoo_v2.event.listener;
 
+import com.gamegoo.gamegoo_v2.event.AcceptFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.service.MemberService;
@@ -39,6 +40,21 @@ public class FriendRequestEventListener {
             notificationService.createReceivedFriendRequestNotification(sourceMember, member);
         } catch (Exception e) {
             log.error("Failed to create friend request notifications", e);
+        }
+    }
+
+    @Async
+    @Transactional
+    @EventListener
+    public void handleAcceptFriendRequestEvent(AcceptFriendRequestEvent event) {
+        try {
+            Member member = memberService.findMember(event.getMemberId());
+            Member targetMember = memberService.findMember(event.getTargetMemberId());
+
+            // targetMember에게 member가 친구 요청 수락했음 알림 생성
+            notificationService.createAcceptFriendRequestNotification(targetMember, member);
+        } catch (Exception e) {
+            log.error("Failed to create accept friend request notifications", e);
         }
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.event.listener;
 
 import com.gamegoo.gamegoo_v2.event.AcceptFriendRequestEvent;
+import com.gamegoo.gamegoo_v2.event.RejectFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.service.MemberService;
@@ -55,6 +56,21 @@ public class FriendRequestEventListener {
             notificationService.createAcceptFriendRequestNotification(targetMember, member);
         } catch (Exception e) {
             log.error("Failed to create accept friend request notifications", e);
+        }
+    }
+
+    @Async
+    @Transactional
+    @EventListener
+    public void handleRejectFriendRequestEvent(RejectFriendRequestEvent event) {
+        try {
+            Member member = memberService.findMember(event.getMemberId());
+            Member targetMember = memberService.findMember(event.getTargetMemberId());
+
+            // targetMember에게 member가 친구 요청 거절했음 알림 생성
+            notificationService.createRejectFriendRequestNotification(targetMember, member);
+        } catch (Exception e) {
+            log.error("Failed to create reject friend request notifications", e);
         }
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/event/listener/FriendRequestEventListener.java
@@ -1,6 +1,6 @@
 package com.gamegoo.gamegoo_v2.event.listener;
 
-import com.gamegoo.gamegoo_v2.event.FriendRequestEvent;
+import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +17,15 @@ public class FriendRequestEventListener {
 
     private final NotificationService notificationService;
 
+    /**
+     * 친구 요청 전송 event listener
+     *
+     * @param event
+     */
     @Async
     @Transactional
     @EventListener
-    public void handleFriendRequestEvent(FriendRequestEvent event) {
+    public void handleSendFriendRequestEvent(SendFriendRequestEvent event) {
         try {
             Member member = event.getMember();
             Member sourceMember = event.getSourceMember();
@@ -33,7 +38,6 @@ public class FriendRequestEventListener {
         } catch (Exception e) {
             log.error("Failed to create friend request notifications", e);
         }
-
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/NotificationException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/NotificationException.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.exception;
+
+import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.exception.common.GlobalException;
+
+public class NotificationException extends GlobalException {
+
+    public NotificationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/common/ErrorCode.java
@@ -64,7 +64,17 @@ public enum ErrorCode {
     MEMBERS_NOT_FRIEND(BAD_REQUEST, "FRIEND408", "두 회원은 친구 관계가 아닙니다."),
     ALREADY_STAR_FRIEND(BAD_REQUEST, "FRIEND409", "이미 즐겨찾기 되어 있는 친구입니다."),
     NOT_STAR_FRIEND(BAD_REQUEST, "FRIEND410", "즐겨찾기 되어 있는 친구가 아닙니다."),
-    FRIEND_SEARCH_QUERY_BAD_REQUEST(BAD_REQUEST, "FRIEND411", "친구 검색 쿼리는 100자 이하여야 합니다.");
+    FRIEND_SEARCH_QUERY_BAD_REQUEST(BAD_REQUEST, "FRIEND411", "친구 검색 쿼리는 100자 이하여야 합니다."),
+
+
+    /**
+     * 알림 관련 에러
+     */
+    NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI_401", "해당 알림 타입 데이터를 찾을 수 없습니다."),
+    NOTIFICATION_METHOD_BAD_REQUEST(HttpStatus.BAD_REQUEST, "NOTI_402", "알림 생성 메소드 호출이 잘못되었습니다."),
+    INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "NOTI_403",
+            "잘못된 알림 조회 타입입니다. general과 friend 중 하나를 입력하세요."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI_404", "해당 알림 내역을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -4,6 +4,7 @@ import com.gamegoo.gamegoo_v2.common.validator.BlockValidator;
 import com.gamegoo.gamegoo_v2.common.validator.FriendValidator;
 import com.gamegoo.gamegoo_v2.common.validator.MemberValidator;
 import com.gamegoo.gamegoo_v2.event.AcceptFriendRequestEvent;
+import com.gamegoo.gamegoo_v2.event.RejectFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.exception.FriendException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
@@ -114,6 +115,7 @@ public class FriendService {
         friendRequest.updateStatus(FriendRequestStatus.REJECTED);
 
         // targetMember에게 친구 요청 거절 알림 생성
+        eventPublisher.publishEvent(new RejectFriendRequestEvent(member.getId(), targetMember.getId()));
 
         return friendRequest;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.friend.service;
 import com.gamegoo.gamegoo_v2.common.validator.BlockValidator;
 import com.gamegoo.gamegoo_v2.common.validator.FriendValidator;
 import com.gamegoo.gamegoo_v2.common.validator.MemberValidator;
+import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.exception.FriendException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.friend.domain.Friend;
@@ -12,6 +13,7 @@ import com.gamegoo.gamegoo_v2.friend.repository.FriendRepository;
 import com.gamegoo.gamegoo_v2.friend.repository.FriendRequestRepository;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,8 @@ public class FriendService {
     private final BlockValidator blockValidator;
     private final MemberValidator memberValidator;
     private final FriendValidator friendValidator;
+    private final ApplicationEventPublisher eventPublisher;
+
 
     /**
      * 친구 요청 생성 메소드
@@ -53,6 +57,7 @@ public class FriendService {
         FriendRequest friendRequest = friendRequestRepository.save(FriendRequest.create(member, targetMember));
 
         // 친구 요청 알림 생성
+        eventPublisher.publishEvent(new SendFriendRequestEvent(member, targetMember));
 
         return friendRequest;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.friend.service;
 import com.gamegoo.gamegoo_v2.common.validator.BlockValidator;
 import com.gamegoo.gamegoo_v2.common.validator.FriendValidator;
 import com.gamegoo.gamegoo_v2.common.validator.MemberValidator;
+import com.gamegoo.gamegoo_v2.event.AcceptFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.event.SendFriendRequestEvent;
 import com.gamegoo.gamegoo_v2.exception.FriendException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
@@ -87,6 +88,7 @@ public class FriendService {
         friendRepository.save(Friend.create(targetMember, member));
 
         // targetMember에게 친구 요청 수락 알림 생성
+        eventPublisher.publishEvent(new AcceptFriendRequestEvent(member.getId(), targetMember.getId()));
 
         return friendRequest;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -57,7 +57,7 @@ public class FriendService {
         FriendRequest friendRequest = friendRequestRepository.save(FriendRequest.create(member, targetMember));
 
         // 친구 요청 알림 생성
-        eventPublisher.publishEvent(new SendFriendRequestEvent(member, targetMember));
+        eventPublisher.publishEvent(new SendFriendRequestEvent(member.getId(), targetMember.getId()));
 
         return friendRequest;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/manner/domain/MannerKeyword.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/manner/domain/MannerKeyword.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,5 +26,18 @@ public class MannerKeyword extends BaseDateTimeEntity {
 
     @Column(nullable = false)
     private boolean positive;
+
+    public static MannerKeyword create(String contents, boolean positive) {
+        return MannerKeyword.builder()
+                .contents(contents)
+                .positive(positive)
+                .build();
+    }
+
+    @Builder
+    private MannerKeyword(String contents, boolean positive) {
+        this.contents = contents;
+        this.positive = positive;
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/manner/repository/MannerKeywordRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/manner/repository/MannerKeywordRepository.java
@@ -1,0 +1,8 @@
+package com.gamegoo.gamegoo_v2.manner.repository;
+
+import com.gamegoo.gamegoo_v2.manner.domain.MannerKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MannerKeywordRepository extends JpaRepository<MannerKeyword, Long> {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.member.domain;
 import com.gamegoo.gamegoo_v2.block.domain.Block;
 import com.gamegoo.gamegoo_v2.common.BaseDateTimeEntity;
 import com.gamegoo.gamegoo_v2.friend.domain.Friend;
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -91,6 +92,9 @@ public class Member extends BaseDateTimeEntity {
 
     @OneToMany(mappedBy = "fromMember", cascade = CascadeType.ALL)
     private List<Friend> friendList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Notification> notificationList = new ArrayList<>();
 
     public static Member create(String email, String password, LoginType loginType, String gameName, String tag,
             Tier tier, int gameRank, double winRate, int gameCount, boolean isAgree) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/Notification.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/Notification.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,5 +42,34 @@ public class Notification extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notification_type_id", nullable = false)
     private NotificationType notificationType;
+
+    public static Notification create(Member member, Member sourceMember, NotificationType notificationType,
+            String content) {
+        Notification notification = Notification.builder()
+                .sourceMember(sourceMember)
+                .notificationType(notificationType)
+                .content(content)
+                .build();
+        notification.setMember(member); // 양방향 연관관계 설정
+        return notification;
+    }
+
+    @Builder
+    private Notification(String content, boolean isRead, Member sourceMember, Member member,
+            NotificationType notificationType) {
+        this.content = content;
+        this.isRead = isRead;
+        this.sourceMember = sourceMember;
+        this.member = member;
+        this.notificationType = notificationType;
+    }
+
+    private void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getNotificationList().remove(this);
+        }
+        this.member = member;
+        member.getNotificationList().add(this);
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationType.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationType.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,5 +31,20 @@ public class NotificationType extends BaseDateTimeEntity {
     private String content;
 
     private String sourceUrl;
+
+    public static NotificationType create(NotificationTypeTitle title) {
+        return NotificationType.builder()
+                .title(title)
+                .content(title.getMessage())
+                .sourceUrl(title.getSourceUrl())
+                .build();
+    }
+
+    @Builder
+    private NotificationType(NotificationTypeTitle title, String content, String sourceUrl) {
+        this.title = title;
+        this.content = content;
+        this.sourceUrl = sourceUrl;
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationTypeTitle.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationTypeTitle.java
@@ -8,7 +8,7 @@ public enum NotificationTypeTitle {
     FRIEND_REQUEST_REJECTED("님이 친구를 거절했어요.", null),
     MANNER_LEVEL_UP("매너레벨이 n단계로 올라갔어요!", "/member/manner"),
     MANNER_LEVEL_DOWN("매너레벨이 n단계로 떨어졌어요.", "/member/manner"),
-    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요. 자세한 내용은 내정보에서 확인하세요!", "/member/manner"),
+    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요. 자세한 내용은 내 평가에서 확인하세요!", "/member/manner"),
     TEST_ALARM("TEST PUSH. NUMBER: ", null),
     ;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.gamegoo.gamegoo_v2.notification.repository;
+
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationTypeRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationTypeRepository.java
@@ -1,0 +1,13 @@
+package com.gamegoo.gamegoo_v2.notification.repository;
+
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationTypeRepository extends JpaRepository<NotificationType, Long> {
+
+    Optional<NotificationType> findNotificationTypeByTitle(NotificationTypeTitle title);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -1,0 +1,157 @@
+package com.gamegoo.gamegoo_v2.notification.service;
+
+import com.gamegoo.gamegoo_v2.exception.NotificationException;
+import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private final NotificationTypeRepository notificationTypeRepository;
+    private final NotificationRepository notificationRepository;
+
+    private static final String PLACEHOLDER = "n";
+
+
+    /**
+     * 친구 요청 전송됨 알림 생성 메소드
+     *
+     * @param member
+     * @param sourceMember
+     * @return
+     */
+    public Notification createSendFriendRequestNotification(Member member, Member sourceMember) {
+        validateMember(member);
+        validateMember(sourceMember);
+        NotificationType notificationType = findNotificationType(NotificationTypeTitle.FRIEND_REQUEST_SEND);
+        return saveNotification(notificationType, notificationType.getContent(), member, sourceMember);
+    }
+
+    /**
+     * 친구 요청 받음 알림 생성 메소드
+     *
+     * @param member
+     * @param sourceMember
+     * @return
+     */
+    public Notification createReceivedFriendRequestNotification(Member member, Member sourceMember) {
+        validateMember(member);
+        validateMember(sourceMember);
+
+        NotificationType notificationType = findNotificationType(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED);
+        return saveNotification(notificationType, notificationType.getContent(), member, sourceMember);
+    }
+
+    /**
+     * 친구 요청 수락됨 알림 생성 메소드
+     *
+     * @param member
+     * @param sourceMember
+     * @return
+     */
+    public Notification createAcceptFriendRequestNotification(Member member, Member sourceMember) {
+        validateMember(member);
+        validateMember(sourceMember);
+
+        NotificationType notificationType = findNotificationType(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED);
+        return saveNotification(notificationType, notificationType.getContent(), member, sourceMember);
+    }
+
+    /**
+     * 친구 요청 거절됨 알림 생성 메소드
+     *
+     * @param member
+     * @param sourceMember
+     * @return
+     */
+    public Notification createRejectFriendRequestNotification(Member member, Member sourceMember) {
+        validateMember(member);
+        validateMember(sourceMember);
+
+        NotificationType notificationType = findNotificationType(NotificationTypeTitle.FRIEND_REQUEST_REJECTED);
+        return saveNotification(notificationType, notificationType.getContent(), member, sourceMember);
+    }
+
+    /**
+     * 매너레벨 상승/하락 알림 생성 메소드
+     *
+     * @param notificationTypeTitle
+     * @param member
+     * @param mannerLevel
+     * @return
+     */
+    public Notification createMannerLevelNotification(NotificationTypeTitle notificationTypeTitle, Member member,
+            int mannerLevel) {
+        validateMember(member);
+
+        NotificationType notificationType = findNotificationType(notificationTypeTitle);
+        String notificationContent = notificationType.getContent().replace(PLACEHOLDER, Integer.toString(mannerLevel));
+        return saveNotification(notificationType, notificationContent, member, null);
+    }
+
+    /**
+     * 매너 평가 등록됨 알림 생성 메소드
+     *
+     * @param mannerKeywordList
+     * @param member
+     * @return
+     */
+    public Notification createMannerRatingNotification(List<MannerKeyword> mannerKeywordList, Member member) {
+        validateMember(member);
+
+        NotificationType notificationType = findNotificationType(NotificationTypeTitle.MANNER_KEYWORD_RATED);
+
+        String mannerKeywordString = mannerKeywordList.get(0).getContents();
+        if (mannerKeywordList.size() > 1) {
+            mannerKeywordString += " 외 " + (mannerKeywordList.size() - 1) + "개의";
+        }
+
+        String notificationContent = notificationType.getContent().replace(PLACEHOLDER, mannerKeywordString);
+
+        return saveNotification(notificationType, notificationContent, member, null);
+    }
+
+    /**
+     * 알림 생성 및 저장 메소드
+     *
+     * @param type
+     * @param content
+     * @param member
+     * @param sourceMember
+     * @return
+     */
+    private Notification saveNotification(NotificationType type, String content, Member member, Member sourceMember) {
+        return notificationRepository.save(Notification.create(member, sourceMember, type, content));
+    }
+
+    /**
+     * title로 NotificationType을 찾는 메소드
+     *
+     * @param title
+     * @return
+     */
+    private NotificationType findNotificationType(NotificationTypeTitle title) {
+        return notificationTypeRepository.findNotificationTypeByTitle(title)
+                .orElseThrow(() -> new NotificationException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
+    }
+
+    private void validateMember(Member member) {
+        if (member == null) {
+            throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -25,7 +25,6 @@ public class NotificationService {
 
     private static final String PLACEHOLDER = "n";
 
-
     /**
      * 친구 요청 전송됨 알림 생성 메소드
      *
@@ -111,6 +110,7 @@ public class NotificationService {
      */
     public Notification createMannerRatingNotification(List<MannerKeyword> mannerKeywordList, Member member) {
         validateMember(member);
+        validateMannerKeywordList(mannerKeywordList);
 
         NotificationType notificationType = findNotificationType(NotificationTypeTitle.MANNER_KEYWORD_RATED);
 
@@ -150,6 +150,12 @@ public class NotificationService {
 
     private void validateMember(Member member) {
         if (member == null) {
+            throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);
+        }
+    }
+
+    private void validateMannerKeywordList(List<MannerKeyword> mannerKeywordList) {
+        if (mannerKeywordList.size() == 0) {
             throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);
         }
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -35,6 +35,7 @@ public class NotificationService {
     public Notification createSendFriendRequestNotification(Member member, Member sourceMember) {
         validateMember(member);
         validateMember(sourceMember);
+
         NotificationType notificationType = findNotificationType(NotificationTypeTitle.FRIEND_REQUEST_SEND);
         return saveNotification(notificationType, notificationType.getContent(), member, sourceMember);
     }
@@ -148,12 +149,22 @@ public class NotificationService {
                 .orElseThrow(() -> new NotificationException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
     }
 
+    /**
+     * member가 null이 아닌지 검증하는 메소드
+     *
+     * @param member
+     */
     private void validateMember(Member member) {
         if (member == null) {
             throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);
         }
     }
 
+    /**
+     * mannerKeywordList에 키워드가 1개 이상 있는지 검증하는 메소드
+     *
+     * @param mannerKeywordList
+     */
     private void validateMannerKeywordList(List<MannerKeyword> mannerKeywordList) {
         if (mannerKeywordList.size() == 0) {
             throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockFacadeServiceTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
 @SpringBootTest
-class BlockServiceTest {
+class BlockFacadeServiceTest {
 
     @Autowired
     private BlockFacadeService blockFacadeService;

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockQueryFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockQueryFacadeServiceTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @SpringBootTest
-class BlockQueryServiceTest {
+class BlockQueryFacadeServiceTest {
 
     @Autowired
     private BlockFacadeService blockFacadeService;

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendFacadeServiceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
 @SpringBootTest
-class FriendServiceTest {
+class FriendFacadeServiceTest {
 
     @Autowired
     FriendFacadeService friendFacadeService;

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestFacadeServiceTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.verify;
 @ActiveProfiles("test")
 @SpringBootTest
 @Import(AsyncConfig.class)
-class FriendRequestServiceTest {
+class FriendRequestFacadeServiceTest {
 
     @Autowired
     FriendFacadeService friendFacadeService;

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestServiceTest.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.integration.friend;
 
 import com.gamegoo.gamegoo_v2.block.domain.Block;
 import com.gamegoo.gamegoo_v2.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.config.AsyncConfig;
 import com.gamegoo.gamegoo_v2.exception.FriendException;
 import com.gamegoo.gamegoo_v2.exception.MemberException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
@@ -16,6 +17,11 @@ import com.gamegoo.gamegoo_v2.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,15 +29,24 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Import(AsyncConfig.class)
 class FriendRequestServiceTest {
 
     @Autowired
@@ -48,6 +63,12 @@ class FriendRequestServiceTest {
 
     @Autowired
     FriendRequestRepository friendRequestRepository;
+
+    @MockitoSpyBean
+    NotificationRepository notificationRepository;
+
+    @Autowired
+    NotificationTypeRepository notificationTypeRepository;
 
     private static final String MEMBER_EMAIL = "test@gmail.com";
     private static final String MEMBER_GAMENAME = "member";
@@ -66,12 +87,19 @@ class FriendRequestServiceTest {
         friendRepository.deleteAllInBatch();
         friendRequestRepository.deleteAllInBatch();
         blockRepository.deleteAllInBatch();
+        notificationRepository.deleteAllInBatch();
+        notificationTypeRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
 
     @Nested
     @DisplayName("친구 요청 전송")
     class SendFriendRequestTest {
+
+        @BeforeEach
+        void setUp() {
+            initNotificationType();
+        }
 
         @DisplayName("친구 요청 전송 성공")
         @Test
@@ -85,6 +113,11 @@ class FriendRequestServiceTest {
             // then
             assertThat(response.getTargetMemberId()).isEqualTo(targetMember.getId());
             assertThat(response.getMessage()).isEqualTo("친구 요청 전송 성공");
+
+            // event로 인해 알림 2개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationRepository, times(2)).save(any(Notification.class));
+            });
         }
 
         @DisplayName("친구 요청 전송 실패: 본인 id를 요청한 경우 예외가 발생한다.")
@@ -337,6 +370,16 @@ class FriendRequestServiceTest {
                 .gameCount(0)
                 .isAgree(true)
                 .build());
+    }
+
+    private void initNotificationType() {
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_SEND));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_REJECTED));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_UP));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_DOWN));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_KEYWORD_RATED));
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestServiceTest.java
@@ -227,6 +227,11 @@ class FriendRequestServiceTest {
     @DisplayName("친구 요청 수락")
     class AcceptFriendRequestTest {
 
+        @BeforeEach
+        void setUp() {
+            initNotificationType();
+        }
+
         @DisplayName("친구 요청 수락 성공")
         @Test
         void acceptFriendRequestSucceeds() {
@@ -242,6 +247,11 @@ class FriendRequestServiceTest {
             // then
             assertThat(response.getTargetMemberId()).isEqualTo(targetMember.getId());
             assertTrue(friendRepository.existsByFromMemberAndToMember(member, targetMember));
+
+            // event로 인해 알림 1개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationRepository, times(1)).save(any(Notification.class));
+            });
         }
 
         @DisplayName("친구 요청 수락 실패: 본인 id를 요청한 경우 예외가 발생한다.")
@@ -271,6 +281,11 @@ class FriendRequestServiceTest {
     @DisplayName("친구 요청 거절")
     class RejectFriendRequestTest {
 
+        @BeforeEach
+        void setUp() {
+            initNotificationType();
+        }
+
         @DisplayName("친구 요청 거절 성공")
         @Test
         void rejectFriendRequestSucceeds() {
@@ -286,6 +301,11 @@ class FriendRequestServiceTest {
             // then
             assertThat(response.getTargetMemberId()).isEqualTo(targetMember.getId());
             assertFalse(friendRepository.existsByFromMemberAndToMember(member, targetMember));
+
+            // event로 인해 알림 1개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationRepository, times(1)).save(any(Notification.class));
+            });
         }
 
         @DisplayName("친구 요청 거절 실패: 본인 id를 요청한 경우 예외가 발생한다.")

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/notification/NotificationServiceTest.java
@@ -1,0 +1,248 @@
+package com.gamegoo.gamegoo_v2.service.notification;
+
+import com.gamegoo.gamegoo_v2.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.manner.repository.MannerKeywordRepository;
+import com.gamegoo.gamegoo_v2.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
+import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class NotificationServiceTest {
+
+    @Autowired
+    NotificationService notificationService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    NotificationTypeRepository notificationTypeRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Autowired
+    MannerKeywordRepository mannerKeywordRepository;
+
+    private static final String MEMBER_EMAIL = "test@gmail.com";
+    private static final String MEMBER_GAMENAME = "member";
+    private static final String TARGET_EMAIL = "target@naver.com";
+    private static final String TARGET_GAMENAME = "target";
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember(MEMBER_EMAIL, MEMBER_GAMENAME);
+        initNotificationType();
+    }
+
+    @AfterEach
+    void tearDown() {
+        notificationRepository.deleteAllInBatch();
+        notificationTypeRepository.deleteAllInBatch();
+        mannerKeywordRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("친구 요청 전송됨 알림 생성 성공")
+    @Test
+    void createSendFriendRequestNotificationSucceeds() {
+        // given
+        Member sourceMember = createMember(TARGET_EMAIL, TARGET_GAMENAME);
+
+        // when
+        Notification notification = notificationService.createSendFriendRequestNotification(member, sourceMember);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_SEND);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(member.getId());
+        assertThat(notification.getSourceMember().getId()).isEqualTo(sourceMember.getId());
+
+        assertThat(member.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("친구 요청 받음 알림 생성 성공")
+    @Test
+    void createReceivedFriendRequestNotificationSucceeds() {
+        // given
+        Member sourceMember = createMember(TARGET_EMAIL, TARGET_GAMENAME);
+
+        // when
+        Notification notification = notificationService.createReceivedFriendRequestNotification(sourceMember, member);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(sourceMember.getId());
+        assertThat(notification.getSourceMember().getId()).isEqualTo(member.getId());
+
+        assertThat(sourceMember.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("친구 요청 수락 알림 생성 성공")
+    @Test
+    void createAcceptFriendRequestNotificationSucceeds() {
+        // given
+        Member targetMember = createMember(TARGET_EMAIL, TARGET_GAMENAME);
+
+        // when
+        Notification notification = notificationService.createAcceptFriendRequestNotification(targetMember, member);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(targetMember.getId());
+        assertThat(notification.getSourceMember().getId()).isEqualTo(member.getId());
+
+        assertThat(targetMember.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("친구 요청 거절 알림 생성 성공")
+    @Test
+    void createRejectFriendRequestNotificationSucceeds() {
+        // given
+        Member targetMember = createMember(TARGET_EMAIL, TARGET_GAMENAME);
+
+        // when
+        Notification notification = notificationService.createRejectFriendRequestNotification(targetMember, member);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_REJECTED);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(targetMember.getId());
+        assertThat(notification.getSourceMember().getId()).isEqualTo(member.getId());
+
+        assertThat(targetMember.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("매너 레벨 상승 알림 생성 성공")
+    @Test
+    void createMannerLevelUpNotificationSucceeds() {
+        // given
+        int mannerLevel = 2;
+
+        // when
+        Notification notification = notificationService.createMannerLevelNotification(
+                NotificationTypeTitle.MANNER_LEVEL_UP, member, mannerLevel);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.MANNER_LEVEL_UP);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(member.getId());
+        assertThat(notification.getSourceMember()).isNull();
+        assertThat(notification.getContent()).isEqualTo("매너레벨이 2단계로 올라갔어요!");
+
+        assertThat(member.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("매너 레벨 하락 알림 생성 성공")
+    @Test
+    void createMannerLevelDownNotificationSucceeds() {
+        // given
+        int mannerLevel = 1;
+
+        // when
+        Notification notification = notificationService.createMannerLevelNotification(
+                NotificationTypeTitle.MANNER_LEVEL_DOWN, member, mannerLevel);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.MANNER_LEVEL_DOWN);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(member.getId());
+        assertThat(notification.getSourceMember()).isNull();
+        assertThat(notification.getContent()).isEqualTo("매너레벨이 1단계로 떨어졌어요.");
+
+        assertThat(member.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("매너 평가 등록 알림 생성 성공: 키워드가 여러개인 경우")
+    @Test
+    void createMannerRatingNotificationSucceedsWithManyKeywords() {
+        // given
+        List<MannerKeyword> mannerKeywordList = new ArrayList<>();
+        mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("캐리했어요", true)));
+        mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("1인분 이상은 해요", true)));
+        mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("욕 안해요", true)));
+
+        // when
+        Notification notification = notificationService.createMannerRatingNotification(mannerKeywordList, member);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.MANNER_KEYWORD_RATED);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(member.getId());
+        assertThat(notification.getSourceMember()).isNull();
+        assertThat(notification.getContent()).isEqualTo("지난 매칭에서 캐리했어요 외 2개의 키워드를 받았어요. 자세한 내용은 내 평가에서 확인하세요!");
+
+        assertThat(member.getNotificationList()).hasSize(1);
+    }
+
+    @DisplayName("매너 평가 등록 알림 생성 성공: 키워드가 1개인 경우")
+    @Test
+    void createMannerRatingNotificationSucceedsWithSingleKeyword() {
+        // given
+        List<MannerKeyword> mannerKeywordList = new ArrayList<>();
+        mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("캐리했어요", true)));
+
+        // when
+        Notification notification = notificationService.createMannerRatingNotification(mannerKeywordList, member);
+
+        // then
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.MANNER_KEYWORD_RATED);
+        assertThat(notification.isRead()).isEqualTo(false);
+        assertThat(notification.getMember().getId()).isEqualTo(member.getId());
+        assertThat(notification.getSourceMember()).isNull();
+        assertThat(notification.getContent()).isEqualTo("지난 매칭에서 캐리했어요 키워드를 받았어요. 자세한 내용은 내 평가에서 확인하세요!");
+
+        assertThat(member.getNotificationList()).hasSize(1);
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private void initNotificationType() {
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_SEND));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_REJECTED));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_UP));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_DOWN));
+        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_KEYWORD_RATED));
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 알림 생성 이벤트 및 리스너 구현

## ⏳ 작업 상세 내용
- [x] 알림 생성 이벤트 구현
- [x] 알림 생성 이벤트 리스너 구현
- [x] 알림 생성 메소드 구현
- [x] 알림 생성 메소드 테스트
- [x] 친구 관련 서비스 코드에 알림 로직 추가
- [x] 친구 관련 테스트 코드에 알림 검증 추가
- [x] 스프링 이벤트 관련 설정 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 친구 요청 등록/수락/거절 및 매너평가 등록/수정 시에 알림 전송하는 로직을 스프링 이벤트로 분리해서 별도 트랜잭션으로 실행하도록 변경했습니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크 
