### PR TITLE
[Feat/57] 알림 전체/팝업 목록 조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/block/dto/BlockListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/dto/BlockListResponse.java
@@ -26,7 +26,7 @@ public class BlockListResponse {
         int profileImg;
         String email;
         String name;
-        Boolean isBlind;
+        boolean isBlind;
 
         public static BlockedMemberResponse of(Member member) {
             String name = member.isBlind() ? "(탈퇴한 사용자)" : member.getGameName();

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockFacadeService.java
@@ -5,7 +5,6 @@ import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,8 +15,6 @@ public class BlockFacadeService {
 
     private final MemberService memberService;
     private final BlockService blockService;
-
-    private final static int PAGE_SIZE = 10;
 
     /**
      * 회원 차단 Facade 메소드
@@ -39,8 +36,7 @@ public class BlockFacadeService {
      * @return
      */
     public BlockListResponse getBlockList(Member member, Integer pageIdx) {
-        PageRequest pageRequest = PageRequest.of(pageIdx - 1, PAGE_SIZE);
-        Page<Member> members = blockService.findBlockedMembersByBlockerId(member.getId(), pageRequest);
+        Page<Member> members = blockService.getBlockedMemberPage(member.getId(), pageIdx);
 
         return BlockListResponse.of(members);
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/block/service/BlockService.java
@@ -8,7 +8,8 @@ import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,8 @@ public class BlockService {
 
     private final BlockRepository blockRepository;
     private final MemberValidator memberValidator;
+
+    private final static int PAGE_SIZE = 10;
 
     /**
      * member가 targetMember를 차단 처리하는 메소드
@@ -53,11 +56,13 @@ public class BlockService {
      * 해당 회원이 차단한 회원의 목록 Page 객체 반환하는 메소드
      *
      * @param blockerId
-     * @param pageable
+     * @param pageIdx
      * @return
      */
-    public Page<Member> findBlockedMembersByBlockerId(Long blockerId, Pageable pageable) {
-        return blockRepository.findBlockedMembersByBlockerIdAndNotDeleted(blockerId, pageable);
+    public Page<Member> getBlockedMemberPage(Long blockerId, Integer pageIdx) {
+        PageRequest pageRequest = PageRequest.of(pageIdx - 1, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return blockRepository.findBlockedMembersByBlockerIdAndNotDeleted(blockerId, pageRequest);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendFacadeService.java
@@ -131,7 +131,7 @@ public class FriendFacadeService {
      * @return
      */
     public FriendListResponse getFriends(Member member, Long cursor) {
-        return FriendListResponse.of(friendService.getFriends(member, cursor));
+        return FriendListResponse.of(friendService.getFriendSlice(member, cursor));
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/friend/service/FriendService.java
@@ -207,7 +207,7 @@ public class FriendService {
      * @param member
      * @return
      */
-    public Slice<Friend> getFriends(Member member, Long cursor) {
+    public Slice<Friend> getFriendSlice(Member member, Long cursor) {
         return friendRepository.findFriendsByCursorAndOrdered(member.getId(), cursor, PAGE_SIZE);
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
@@ -2,23 +2,28 @@ package com.gamegoo.gamegoo_v2.notification.controller;
 
 import com.gamegoo.gamegoo_v2.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Notification", description = "Notification 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/notification")
+@Validated
 public class NotificationController {
 
     private final NotificationFacadeService notificationFacadeService;
@@ -35,6 +40,14 @@ public class NotificationController {
     @GetMapping("/unread/count")
     public ApiResponse<Integer> getUnreadNotificationCount(@AuthMember Member member) {
         return ApiResponse.ok(notificationFacadeService.countUnreadNotification(member));
+    }
+
+    @Operation(summary = "알림 전체 목록 조회 API", description = "알림 전체보기 화면에서 알림 목록을 조회하는 API 입니다.")
+    @Parameter(name = "page", description = "페이지 번호, 1 이상의 숫자를 입력해 주세요.")
+    @GetMapping("/total")
+    public ApiResponse<NotificationPageListResponse> getTotalNotificationList(
+            @ValidPage @RequestParam(name = "page") Integer page, @AuthMember Member member) {
+        return ApiResponse.ok(notificationFacadeService.getNotificationPageList(member, page));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
@@ -2,8 +2,10 @@ package com.gamegoo.gamegoo_v2.notification.controller;
 
 import com.gamegoo.gamegoo_v2.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.notification.dto.NotificationCursorListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationFacadeService;
@@ -45,9 +47,19 @@ public class NotificationController {
     @Operation(summary = "알림 전체 목록 조회 API", description = "알림 전체보기 화면에서 알림 목록을 조회하는 API 입니다.")
     @Parameter(name = "page", description = "페이지 번호, 1 이상의 숫자를 입력해 주세요.")
     @GetMapping("/total")
-    public ApiResponse<NotificationPageListResponse> getTotalNotificationList(
+    public ApiResponse<NotificationPageListResponse> getNotificationListByPage(
             @ValidPage @RequestParam(name = "page") Integer page, @AuthMember Member member) {
         return ApiResponse.ok(notificationFacadeService.getNotificationPageList(member, page));
+    }
+
+    @Operation(summary = "알림 팝업 목록 조회 API", description = "알림 팝업 화면에서 알림 목록을 조회하는 API 입니다.")
+    @Parameter(name = "cursor", description = "페이징을 위한 커서, Long 타입 notificationId를 보내주세요. " +
+            "보내지 않으면 가장 최근 알림 10개를 조회합니다.")
+    @GetMapping
+    public ApiResponse<NotificationCursorListResponse> getNotificationListByCursor(
+            @ValidCursor @RequestParam(name = "cursor", required = false) Long cursor,
+            @AuthMember Member member) {
+        return ApiResponse.ok(notificationFacadeService.getNotificationCursorList(member, cursor));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationType.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationType.java
@@ -32,19 +32,24 @@ public class NotificationType extends BaseDateTimeEntity {
 
     private String sourceUrl;
 
+    @Column(nullable = false)
+    private int imgType;
+
     public static NotificationType create(NotificationTypeTitle title) {
         return NotificationType.builder()
                 .title(title)
                 .content(title.getMessage())
                 .sourceUrl(title.getSourceUrl())
+                .imgType(title.getImgType())
                 .build();
     }
 
     @Builder
-    private NotificationType(NotificationTypeTitle title, String content, String sourceUrl) {
+    private NotificationType(NotificationTypeTitle title, String content, String sourceUrl, int imgType) {
         this.title = title;
         this.content = content;
         this.sourceUrl = sourceUrl;
+        this.imgType = imgType;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationTypeTitle.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/domain/NotificationTypeTitle.java
@@ -1,30 +1,27 @@
 package com.gamegoo.gamegoo_v2.notification.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum NotificationTypeTitle {
 
-    FRIEND_REQUEST_SEND("님에게 친구 요청을 보냈어요.", null),
-    FRIEND_REQUEST_RECEIVED("님에게 친구 요청이 왔어요.", "/member/profile/"),
-    FRIEND_REQUEST_ACCEPTED("님이 친구를 수락했어요.", null),
-    FRIEND_REQUEST_REJECTED("님이 친구를 거절했어요.", null),
-    MANNER_LEVEL_UP("매너레벨이 n단계로 올라갔어요!", "/member/manner"),
-    MANNER_LEVEL_DOWN("매너레벨이 n단계로 떨어졌어요.", "/member/manner"),
-    MANNER_KEYWORD_RATED("지난 매칭에서 n 키워드를 받았어요. 자세한 내용은 내 평가에서 확인하세요!", "/member/manner"),
-    TEST_ALARM("TEST PUSH. NUMBER: ", null),
+    FRIEND_REQUEST_SEND(1, "님에게 친구 요청을 보냈어요.", null),
+    FRIEND_REQUEST_RECEIVED(1, "님에게 친구 요청이 왔어요.", "/member/profile/"),
+    FRIEND_REQUEST_ACCEPTED(1, "님이 친구를 수락했어요.", null),
+    FRIEND_REQUEST_REJECTED(1, "님이 친구를 거절했어요.", null),
+    MANNER_LEVEL_UP(2, "매너레벨이 n단계로 올라갔어요!", "/member/manner"),
+    MANNER_LEVEL_DOWN(2, "매너레벨이 n단계로 떨어졌어요.", "/member/manner"),
+    MANNER_KEYWORD_RATED(3, "지난 매칭에서 n 키워드를 받았어요. 자세한 내용은 내 평가에서 확인하세요!", "/member/manner"),
+    TEST_ALARM(0, "TEST PUSH. NUMBER: ", null),
     ;
 
-    private final String content;
+    private final int imgType;
+    private final String message;
     private final String sourceUrl;
 
-    NotificationTypeTitle(String content, String sourceUrl) {
-        this.content = content;
+    NotificationTypeTitle(int imgType, String message, String sourceUrl) {
+        this.imgType = imgType;
+        this.message = message;
         this.sourceUrl = sourceUrl;
-    }
-
-    public String getMessage() {
-        return content;
-    }
-
-    public String getSourceUrl() {
-        return sourceUrl;
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/dto/NotificationCursorListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/dto/NotificationCursorListResponse.java
@@ -1,0 +1,36 @@
+package com.gamegoo.gamegoo_v2.notification.dto;
+
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationCursorListResponse {
+
+    List<NotificationResponse> notificationList;
+    int listSize;
+    boolean hasNext;
+    Long nextCursor;
+
+    public static NotificationCursorListResponse of(Slice<Notification> notificationSlice) {
+        List<NotificationResponse> notificationResponseList = notificationSlice.stream()
+                .map(NotificationResponse::of)
+                .toList();
+
+        Long nextCursor = notificationSlice.hasNext()
+                ? notificationSlice.getContent().get(notificationResponseList.size() - 1).getId()
+                : null;
+
+        return NotificationCursorListResponse.builder()
+                .notificationList(notificationResponseList)
+                .listSize(notificationResponseList.size())
+                .hasNext(notificationSlice.hasNext())
+                .nextCursor(nextCursor)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/dto/NotificationPageListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/dto/NotificationPageListResponse.java
@@ -1,0 +1,37 @@
+package com.gamegoo.gamegoo_v2.notification.dto;
+
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class NotificationPageListResponse {
+
+    List<NotificationResponse> notificationList;
+    int listSize;
+    int totalPage;
+    long totalElements;
+    Boolean isFirst;
+    Boolean isLast;
+
+    public static NotificationPageListResponse of(Page<Notification> notificationPage) {
+        List<NotificationResponse> notificationList = notificationPage.stream()
+                .map(NotificationResponse::of)
+                .toList();
+
+        return NotificationPageListResponse.builder()
+                .notificationList(notificationList)
+                .listSize(notificationList.size())
+                .totalPage(notificationPage.getTotalPages())
+                .totalElements(notificationPage.getTotalElements())
+                .isFirst(notificationPage.isFirst())
+                .isLast(notificationPage.isLast())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/dto/NotificationResponse.java
@@ -1,0 +1,74 @@
+package com.gamegoo.gamegoo_v2.notification.dto;
+
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NotificationResponse {
+
+    Long notificationId;
+    int notificationType;
+    String content;
+    String pageUrl;
+    boolean read;
+    LocalDateTime createdAt;
+
+    public static NotificationResponse of(Notification notification) {
+        String pageUrl = createPageUrl(notification);
+        String content = createContent(notification);
+
+        return NotificationResponse.builder()
+                .notificationId(notification.getId())
+                .notificationType(notification.getNotificationType().getImgType())
+                .content(content)
+                .pageUrl(pageUrl)
+                .read(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+
+    private static String createPageUrl(Notification notification) {
+        String sourceUrl = notification.getNotificationType().getSourceUrl();
+
+        if (sourceUrl == null) {
+            return null;
+        }
+
+        // sourceUrl을 기반으로 URL 생성
+        StringBuilder urlBuilder = new StringBuilder(sourceUrl);
+
+        // sourceMember가 없는 경우
+        if (notification.getSourceMember() == null) {
+            return urlBuilder.toString();
+        }
+
+        // sourceMember가 탈퇴한 회원인 경우 URL 생성하지 않음
+        if (notification.getSourceMember().isBlind()) {
+            return null;
+        }
+
+        // 탈퇴하지 않은 sourceMember의 id 추가
+        return urlBuilder.append(notification.getSourceMember().getId()).toString();
+    }
+
+    private static String createContent(Notification notification) {
+        String content = notification.getContent();
+
+        // sourceMember가 없는 경우 content를 그대로 리턴
+        if (notification.getSourceMember() == null) {
+            return content;
+        }
+
+        // sourceMember 닉네임 표시
+        if (notification.getSourceMember().isBlind()) { // sourceMember가 탈퇴한 회원인 경우
+            return "(탈퇴한 사용자)" + content;
+        } else {
+            return notification.getSourceMember().getGameName() + content;
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
     boolean existsByMemberAndId(Member member, Long id);
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepository.java
@@ -2,10 +2,14 @@ package com.gamegoo.gamegoo_v2.notification.repository;
 
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     boolean existsByMemberAndId(Member member, Long id);
+
+    Page<Notification> findNotificationsByMember(Member member, Pageable pageable);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustom.java
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Slice;
 
 public interface NotificationRepositoryCustom {
 
-    Slice<Notification> findNotificationsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize);
+    Slice<Notification> findNotificationsByCursor(Long memberId, Long cursor, int pageSize);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.gamegoo.gamegoo_v2.notification.repository;
+
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import org.springframework.data.domain.Slice;
+
+public interface NotificationRepositoryCustom {
+
+    Slice<Notification> findNotificationsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,46 @@
+package com.gamegoo.gamegoo_v2.notification.repository;
+
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static com.gamegoo.gamegoo_v2.notification.domain.QNotification.notification;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Notification> findNotificationsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize) {
+
+        List<Notification> result = queryFactory.selectFrom(notification)
+                .where(
+                        notification.member.id.eq(memberId),
+                        idBefore(cursor)
+                )
+                .orderBy(notification.createdAt.desc())
+                .limit(pageSize + 1) // 다음 페이지가 있는지 확인하기 위해 +1
+                .fetch();
+
+        boolean hasNext = result.size() > pageSize;
+        if (hasNext) {
+            result.remove(result.size() - 1); // 다음 페이지가 있으면 마지막 요소를 제거
+        }
+
+        return new SliceImpl<>(result, Pageable.unpaged(), hasNext);
+    }
+
+    //--- BooleanExpression ---//
+
+    private BooleanExpression idBefore(Long cursor) {
+        return cursor != null ? notification.id.lt(cursor) : null;
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/repository/NotificationRepositoryCustomImpl.java
@@ -18,8 +18,7 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Notification> findNotificationsByCursorAndOrdered(Long memberId, Long cursor, Integer pageSize) {
-
+    public Slice<Notification> findNotificationsByCursor(Long memberId, Long cursor, int pageSize) {
         List<Notification> result = queryFactory.selectFrom(notification)
                 .where(
                         notification.member.id.eq(memberId),

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationFacadeService.java
@@ -2,10 +2,12 @@ package com.gamegoo.gamegoo_v2.notification.service;
 
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.dto.NotificationCursorListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,4 +54,18 @@ public class NotificationFacadeService {
 
         return NotificationPageListResponse.of(notificationPage);
     }
+
+    /**
+     * 알림 팝업 목록 조회 Facade 메소드
+     *
+     * @param member
+     * @param cursorId
+     * @return
+     */
+    public NotificationCursorListResponse getNotificationCursorList(Member member, Long cursorId) {
+        Slice<Notification> notificationSlice = notificationService.getNotificationSlice(member, cursorId);
+
+        return NotificationCursorListResponse.of(notificationSlice);
+    }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationFacadeService.java
@@ -2,8 +2,10 @@ package com.gamegoo.gamegoo_v2.notification.service;
 
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,4 +40,16 @@ public class NotificationFacadeService {
         return notificationService.countUnreadNotification(member);
     }
 
+    /**
+     * 알림 전체 목록 조회 Facade 메소드
+     *
+     * @param member
+     * @param pageIdx
+     * @return
+     */
+    public NotificationPageListResponse getNotificationPageList(Member member, Integer pageIdx) {
+        Page<Notification> notificationPage = notificationService.getNotificationPage(member, pageIdx);
+
+        return NotificationPageListResponse.of(notificationPage);
+    }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -10,6 +10,9 @@ import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +27,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     private static final String PLACEHOLDER = "n";
+    private final static int PAGE_SIZE = 10;
 
     /**
      * 친구 요청 전송됨 알림 생성 메소드
@@ -132,6 +136,20 @@ public class NotificationService {
     }
 
     /**
+     * 테스트 알림 생성 메소드
+     *
+     * @param member
+     * @return
+     */
+    @Transactional
+    public Notification createTestNotification(Member member) {
+        validateMember(member);
+
+        NotificationType notificationType = findNotificationType(NotificationTypeTitle.TEST_ALARM);
+        return saveNotification(notificationType, notificationType.getContent(), member, null);
+    }
+
+    /**
      * 알림 생성 및 저장 메소드
      *
      * @param type
@@ -174,6 +192,19 @@ public class NotificationService {
                 .count();
 
         return Long.valueOf(count).intValue();
+    }
+
+    /**
+     * 해당 회원의 알림 목록 Page 객체 반환하는 메소드
+     *
+     * @param member
+     * @param pageIdx
+     * @return
+     */
+    public Page<Notification> getNotificationPage(Member member, Integer pageIdx) {
+        PageRequest pageRequest = PageRequest.of(pageIdx - 1, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return notificationRepository.findNotificationsByMember(member, pageRequest);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -216,7 +216,7 @@ public class NotificationService {
      * @return
      */
     public Slice<Notification> getNotificationSlice(Member member, Long cursor) {
-        return notificationRepository.findNotificationsByCursorAndOrdered(member.getId(), cursor, PAGE_SIZE);
+        return notificationRepository.findNotificationsByCursor(member.getId(), cursor, PAGE_SIZE);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -12,6 +12,7 @@ import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -208,6 +209,17 @@ public class NotificationService {
     }
 
     /**
+     * 해당 회원의 알림 목록 Slice 객체 반환하는 메소드
+     *
+     * @param member
+     * @param cursor
+     * @return
+     */
+    public Slice<Notification> getNotificationSlice(Member member, Long cursor) {
+        return notificationRepository.findNotificationsByCursorAndOrdered(member.getId(), cursor, PAGE_SIZE);
+    }
+
+    /**
      * title로 NotificationType을 찾는 메소드
      *
      * @param title
@@ -235,7 +247,7 @@ public class NotificationService {
      * @param mannerKeywordList
      */
     private void validateMannerKeywordList(List<MannerKeyword> mannerKeywordList) {
-        if (mannerKeywordList.size() == 0) {
+        if (mannerKeywordList.isEmpty()) {
             throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);
         }
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/notification/NotificationControllerTest.java
@@ -5,6 +5,7 @@ import com.gamegoo.gamegoo_v2.exception.NotificationException;
 import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.controller.NotificationController;
+import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationFacadeService;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.ArrayList;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -81,6 +84,65 @@ public class NotificationControllerTest extends ControllerTestSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value("OK"))
                     .andExpect(jsonPath("$.data").value(5));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("알림 전체 목록 조회")
+    class GetNotificationPageListTest {
+
+        @DisplayName("알림 전체 목록 조회 성공")
+        @Test
+        void getNotificationPageListSucceeds() throws Exception {
+            // given
+            NotificationPageListResponse response = NotificationPageListResponse.builder()
+                    .notificationList(new ArrayList<>())
+                    .listSize(0)
+                    .totalPage(0)
+                    .totalElements(0)
+                    .isFirst(true)
+                    .isLast(true)
+                    .build();
+
+            given(notificationFacadeService.getNotificationPageList(any(Member.class), any(Integer.class))).willReturn(response);
+
+            // when // then
+            int pageIdx = 1;
+            mockMvc.perform(get(API_URL_PREFIX + "/total")
+                            .param("page", String.valueOf(pageIdx)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.notificationList").isEmpty())
+                    .andExpect(jsonPath("$.data.listSize").value(0))
+                    .andExpect(jsonPath("$.data.totalPage").value(0))
+                    .andExpect(jsonPath("$.data.totalElements").value(0))
+                    .andExpect(jsonPath("$.data.isFirst").value(true))
+                    .andExpect(jsonPath("$.data.isLast").value(true));
+        }
+
+        @DisplayName("알림 전체 목록 조회 실패: 페이지 번호가 1 미만인 경우 에러 응답을 반환한다")
+        @Test
+        void getNotificationPageListFailedWhenPageIsNotValid() throws Exception {
+            // given
+            NotificationPageListResponse response = NotificationPageListResponse.builder()
+                    .notificationList(new ArrayList<>())
+                    .listSize(0)
+                    .totalPage(0)
+                    .totalElements(0)
+                    .isFirst(true)
+                    .isLast(true)
+                    .build();
+
+            given(notificationFacadeService.getNotificationPageList(any(Member.class), any(Integer.class))).willReturn(response);
+
+
+            // when // then
+            int pageIdx = 0;
+            mockMvc.perform(get(API_URL_PREFIX + "/total")
+                            .param("page", String.valueOf(pageIdx)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("페이지 번호는 1 이상의 값이어야 합니다."));
         }
 
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/notification/NotificationFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/notification/NotificationFacadeServiceTest.java
@@ -9,6 +9,7 @@ import com.gamegoo.gamegoo_v2.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
 import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
 import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.dto.NotificationCursorListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
@@ -22,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -164,6 +168,65 @@ class NotificationFacadeServiceTest {
             assertThat(response.getTotalElements()).isEqualTo(0);
             assertThat(response.getIsFirst()).isTrue();
             assertThat(response.getIsLast()).isTrue();
+        }
+
+    }
+
+    @Nested
+    @DisplayName("알림 팝업 목록 조회")
+    class GetNotificationCursorListTest {
+
+        @DisplayName("알림 팝업 목록 조회 성공: 알림이 존재하지 않는 경우")
+        @Test
+        void getNotificationCursorListSucceedsWhenNotificationNotExists() {
+            // when
+            NotificationCursorListResponse response = notificationFacadeService.getNotificationCursorList(member, 1L);
+
+            // then
+            assertThat(response.getNotificationList()).isEmpty();
+            assertThat(response.getListSize()).isEqualTo(0);
+            assertThat(response.getNextCursor()).isNull();
+            assertThat(response.isHasNext()).isFalse();
+        }
+
+        @DisplayName("알림 팝업 목록 조회 성공: cursor를 입력하지 않은 경우")
+        @Test
+        void getNotificationCursorListSucceedsFirstPage() {
+            // given
+            for (int i = 1; i <= 5; i++) {
+                createTestNotification(member);
+            }
+
+            // when
+            NotificationCursorListResponse response = notificationFacadeService.getNotificationCursorList(member, null);
+
+            // then
+            assertThat(response.getNotificationList()).hasSize(5);
+            assertThat(response.getListSize()).isEqualTo(5);
+            assertThat(response.getNextCursor()).isNull();
+            assertThat(response.isHasNext()).isFalse();
+        }
+
+        @DisplayName("알림 팝업 목록 조회 성공: 알림 개수가 page size 이상이고 cursor를 입력한 경우")
+        @Test
+        void getNotificationCursorListSucceedsNextPage() {
+            // given
+            List<Notification> notifications = new ArrayList<>();
+            for (int i = 1; i <= 15; i++) {
+                notifications.add(createTestNotification(member));
+            }
+
+            Long cursor = notifications.get(5).getId();
+
+            // when
+            NotificationCursorListResponse response = notificationFacadeService.getNotificationCursorList(member,
+                    cursor);
+
+            // then
+            assertThat(response.getNotificationList()).hasSize(5);
+            assertThat(response.getListSize()).isEqualTo(5);
+            assertThat(response.getNextCursor()).isNull();
+            assertThat(response.isHasNext()).isFalse();
         }
 
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/notification/NotificationRepositoryTest.java
@@ -1,0 +1,142 @@
+package com.gamegoo.gamegoo_v2.repository.notification;
+
+import com.gamegoo.gamegoo_v2.config.JpaAuditingConfig;
+import com.gamegoo.gamegoo_v2.config.QuerydslConfig;
+import com.gamegoo.gamegoo_v2.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.member.domain.Member;
+import com.gamegoo.gamegoo_v2.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, JpaAuditingConfig.class})
+public class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private static final int PAGE_SIZE = 10;
+
+    private NotificationType testNotificationType;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember("test@gmail.com", "member");
+        testNotificationType = em.persist(NotificationType.create(NotificationTypeTitle.TEST_ALARM));
+    }
+
+    @Nested
+    @DisplayName("알림 전체 목록 조회")
+    class findNotificationsByMemberTest {
+
+        @DisplayName("알림이 없는 경우")
+        @Test
+        void findNotificationsByMemberWhenNoResult() {
+            // given
+            PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+            // when
+            Page<Notification> notificationPage =
+                    notificationRepository.findNotificationsByMember(member, pageRequest);
+
+            // then
+            assertThat(notificationPage).isEmpty();
+            assertThat(notificationPage.getTotalElements()).isEqualTo(0);
+            assertThat(notificationPage.getTotalPages()).isEqualTo(0);
+            assertTrue(notificationPage.isFirst());
+            assertTrue(notificationPage.isLast());
+        }
+
+        @DisplayName("알림이 10개 이하일 때 첫번째 페이지 요청")
+        @Test
+        void findNotificationByMemberFirstPage() {
+            // given
+            Notification testNotification1 = createTestNotification(member);
+            createTestNotification(member);
+            createTestNotification(member);
+            createTestNotification(member);
+            Notification testNotification5 = createTestNotification(member);
+
+            PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+            // when
+            Page<Notification> notificationPage = notificationRepository.findNotificationsByMember(member, pageRequest);
+
+            // then
+            assertThat(notificationPage).isNotEmpty();
+            assertThat(notificationPage.getContent()).hasSize(5);
+            assertThat(notificationPage.getTotalElements()).isEqualTo(5);
+            assertThat(notificationPage.getTotalPages()).isEqualTo(1);
+            assertThat(notificationPage.isFirst()).isTrue();
+            assertThat(notificationPage.isLast()).isTrue();
+
+            // 목록 정렬 검증
+            assertThat(notificationPage.getContent().get(0).getId()).isEqualTo(testNotification5.getId());
+            assertThat(notificationPage.getContent().get(4).getId()).isEqualTo(testNotification1.getId());
+        }
+
+        @DisplayName("알림이 10개 초과일 때 두번째 페이지 요청")
+        @Test
+        void findNotificationByMemberSecondPage() {
+            // given
+            for (int i = 1; i <= 15; i++) {
+                createTestNotification(member);
+            }
+
+            PageRequest pageRequest = PageRequest.of(1, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+            // when
+            Page<Notification> notificationPage = notificationRepository.findNotificationsByMember(member, pageRequest);
+
+            // then
+            assertThat(notificationPage).isNotEmpty();
+            assertThat(notificationPage.getContent()).hasSize(5);
+            assertThat(notificationPage.getTotalElements()).isEqualTo(15);
+            assertThat(notificationPage.getTotalPages()).isEqualTo(2);
+            assertThat(notificationPage.isFirst()).isFalse();
+            assertThat(notificationPage.isLast()).isTrue();
+        }
+
+    }
+
+    private Member createMember(String email, String gameName) {
+        return em.persist(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private Notification createTestNotification(Member member) {
+        return em.persist(Notification.create(member, null, testNotificationType, testNotificationType.getContent()));
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 알림 전체/팝업 목록 조회 API 구현 및 테스트

## ⏳ 작업 상세 내용
- [x] 알림 전체 목록 조회 API 구현
- [x] 알림 전체 목록 조회 API repository 테스트
- [x] 알림 전체 목록 조회 API 통합 테스트
- [x] 알림 전체 목록 조회 API 컨트롤러 테스트
- [x] 알림 팝업 목록 조회 API 구현
- [x] 알림 팝업 목록 조회 API repository 테스트
- [x] 알림 팝업 목록 조회 API 통합 테스트
- [x] 알림 팝업 목록 조회 API 컨트롤러 테스트
- [x] PageRequest를 facadeService에서 생성 -> service에서 생성하도록 변경
- [x] NotificationType 도메인에 imgType 필드 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크 
