### PR TITLE
[Feat/53] Riot 계정 존재하는지 검증하는 API

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -19,6 +19,8 @@ jobs:
       DB_SCHEMA_NAME: ${{ secrets.DB_SCHEMA_NAME }}
       DB_USERNAME: ${{ secrets.DB_USERNAME }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      GMAIL_PWD: ${{ secrets.GMAIL_PWD }}
+      RIOT_API: ${{ secrets.RIOT_API }}
 
     steps:
       # 1. GitHub Repository 파일 불러오기

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -66,6 +66,8 @@ jobs:
             DB_SCHEMA_NAME= ${{ secrets.DB_SCHEMA_NAME }}
             DB_USERNAME= ${{ secrets.DB_USERNAME }}
             DB_PASSWORD= ${{ secrets.DB_PASSWORD }}
+            GMAIL_PWD: ${{ secrets.GMAIL_PWD }}
+            RIOT_API: ${{ secrets.RIOT_API }}
 
       ## CD (Continuous Deployment) 파트
       # 7. EC2에 SSH로 접속하여 Docker 컨테이너 실행
@@ -91,4 +93,6 @@ jobs:
             -e DB_SCHEMA_NAME=${{ secrets.DB_SCHEMA_NAME }} \
             -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
             -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+            -e GMAIL_PWD=${{ secrets.GMAIL_PWD }} \
+            -e RIOT_API=${{ secrets.RIOT_API }} \
             ${{ secrets.DOCKERHUB_USERNAME }}/gamegoov2-api:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ARG RDS_PORT
 ARG DB_SCHEMA_NAME
 ARG DB_USERNAME
 ARG DB_PASSWORD
+ARG GMAIL_PWD
+ARG RIOT_API
 
 # 라이브러리 설치에 필요한 파일만 복사
 COPY build.gradle settings.gradle ./

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-
+    implementation 'org.springframework.security:spring-security-crypto:5.8.0'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/com/gamegoo/gamegoo_v2/auth/dto/JoinRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/auth/dto/JoinRequest.java
@@ -1,0 +1,29 @@
+package com.gamegoo.gamegoo_v2.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinRequest {
+
+    @Email(message = "Email 형식이 올바르지 않습니다.")
+    @NotBlank(message = "Email은 비워둘 수 없습니다.")
+    String email;
+    @NotBlank(message = "password는 비워둘 수 없습니다.")
+    String password;
+    @NotBlank(message = "gameName 값은 비워둘 수 없습니다.")
+    String gameName;
+    @NotBlank(message = "tag 값은 비워둘 수 없습니다.")
+    String tag;
+    @NotNull(message = "isAgree 값은 비워둘 수 없습니다. true/false 둘 중 하나를 반드시 포함해야합니다.")
+    Boolean isAgree;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/auth/dto/JoinRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/auth/dto/JoinRequest.java
@@ -17,12 +17,16 @@ public class JoinRequest {
     @Email(message = "Email 형식이 올바르지 않습니다.")
     @NotBlank(message = "Email은 비워둘 수 없습니다.")
     String email;
+
     @NotBlank(message = "password는 비워둘 수 없습니다.")
     String password;
+
     @NotBlank(message = "gameName 값은 비워둘 수 없습니다.")
     String gameName;
+
     @NotBlank(message = "tag 값은 비워둘 수 없습니다.")
     String tag;
+    
     @NotNull(message = "isAgree 값은 비워둘 수 없습니다. true/false 둘 중 하나를 반드시 포함해야합니다.")
     Boolean isAgree;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/auth/service/AuthFacadeService.java
@@ -1,0 +1,39 @@
+package com.gamegoo.gamegoo_v2.auth.service;
+
+import com.gamegoo.gamegoo_v2.auth.dto.JoinRequest;
+import com.gamegoo.gamegoo_v2.member.service.MemberService;
+import com.gamegoo.gamegoo_v2.riot.service.RiotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthFacadeService {
+
+    private AuthService authService;
+    private MemberService memberService;
+    private RiotService riotService;
+
+    /**
+     * 회원가입
+     *
+     * @param request 회원가입용 정보
+     */
+    @Transactional
+    public void join(JoinRequest request) {
+        // 1. [Member] 중복확인
+        memberService.checkExistMemberByEmail(request.getEmail());
+
+        // 2. [Riot] 존재하는 소환사인지 검증 & puuid 얻기
+
+        // 3. [Riot] tier, rank, winrate 얻기
+
+        // 4. [Member] member DB에 저장
+
+        // 5. [Riot] 최근 사용한 챔피언 3개 매핑
+
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/auth/service/AuthFacadeService.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.auth.service;
 
 import com.gamegoo.gamegoo_v2.auth.dto.JoinRequest;
 import com.gamegoo.gamegoo_v2.member.service.MemberService;
-import com.gamegoo.gamegoo_v2.riot.service.RiotService;
+import com.gamegoo.gamegoo_v2.riot.service.RiotAccountService;
+import com.gamegoo.gamegoo_v2.riot.service.RiotInfoService;
+import com.gamegoo.gamegoo_v2.riot.service.RiotRecordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AuthFacadeService {
 
-    private AuthService authService;
-    private MemberService memberService;
-    private RiotService riotService;
+    private final AuthService authService;
+    private final MemberService memberService;
+    private final RiotAccountService riotAccountService;
+    private final RiotRecordService riotRecordService;
+    private final RiotInfoService riotInfoService;
 
     /**
      * 회원가입
@@ -27,6 +31,7 @@ public class AuthFacadeService {
         memberService.checkExistMemberByEmail(request.getEmail());
 
         // 2. [Riot] 존재하는 소환사인지 검증 & puuid 얻기
+        String puuid = riotAccountService.getPuuid(request.getGameName(), request.getTag());
 
         // 3. [Riot] tier, rank, winrate 얻기
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/auth/service/AuthService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/auth/service/AuthService.java
@@ -1,0 +1,14 @@
+package com.gamegoo.gamegoo_v2.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class AuthService {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/config/AppConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.gamegoo.gamegoo_v2.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/config/WebConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/config/WebConfig.java
@@ -18,7 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final AuthMemberArgumentResolver authMemberArgumentResolver;
     private final JwtInterceptor jwtInterceptor;
     private final List<String> excludeEndpoints = Arrays.asList("/api/v2/auth/token/**", "/api/v2/email/send/join",
-            "/api/v2/email/verify");
+            "/api/v2/email/verify", "/api/v2/riot/verify");
 
     // 인터셉터 설정
     @Override

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/RiotException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/RiotException.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.exception;
+
+import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.exception.common.GlobalException;
+
+public class RiotException extends GlobalException {
+
+    public RiotException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/common/ErrorCode.java
@@ -51,6 +51,20 @@ public enum ErrorCode {
     INVALID_VERIFICATION_CODE(BAD_REQUEST, "EMAIL_405", "인증 코드가 틀렸습니다"),
     EMAIL_VERIFICATION_TIME_EXCEED(BAD_REQUEST, "EMAIL_406", "인증 코드 검증 시간을 초과했습니다."),
 
+    /**
+     * Riot 관련 에러
+     */
+    RIOT_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOT404", "해당 Riot 계정이 존재하지 않습니다."),
+    RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH404",
+            "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
+    RIOT_PREFER_CHAMPION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOTCHAMPION500",
+            "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
+    CHAMPION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAMPION404", "해당 챔피언이 존재하지 않습니다."),
+    RIOT_MEMBER_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
+    RIOT_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
+    RIOT_INSUFFICIENT_MATCHES(HttpStatus.NOT_FOUND, "RIOT404",
+            "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
+    RIOT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOT500", "RIOT API 연동 중 에러가 발생했습니다."),
     /*
      * 차단 관련 에러
      */

--- a/src/main/java/com/gamegoo/gamegoo_v2/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/exception/common/ErrorCode.java
@@ -54,18 +54,19 @@ public enum ErrorCode {
     /**
      * Riot 관련 에러
      */
-    RIOT_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOT404", "해당 Riot 계정이 존재하지 않습니다."),
-    RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH404",
-            "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
-    RIOT_PREFER_CHAMPION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOTCHAMPION500",
-            "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
-    CHAMPION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAMPION404", "해당 챔피언이 존재하지 않습니다."),
-    RIOT_MEMBER_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
-    RIOT_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "RIOT409", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
+    RIOT_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOT_401", "해당 Riot 계정이 존재하지 않습니다."),
+    RIOT_MEMBER_CONFLICT(HttpStatus.CONFLICT, "RIOT_402", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
+    RIOT_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "RIOT403", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
     RIOT_INSUFFICIENT_MATCHES(HttpStatus.NOT_FOUND, "RIOT404",
             "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
-    RIOT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOT500", "RIOT API 연동 중 에러가 발생했습니다."),
-    /*
+    RIOT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOT405", "RIOT API 연동 중 에러가 발생했습니다."),
+    RIOT_MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "RIOTMATCH_401",
+            "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
+    RIOT_PREFER_CHAMPION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "RIOTCHAMPION_401",
+            "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
+    CHAMPION_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAMPION_404", "해당 챔피언이 존재하지 않습니다."),
+
+    /**
      * 차단 관련 에러
      */
     TARGET_MEMBER_NOT_FOUND(NOT_FOUND, "BLOCK_401", "차단 대상 회원을 찾을 수 없습니다."),

--- a/src/main/java/com/gamegoo/gamegoo_v2/member/controller/MemberController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/member/controller/MemberController.java
@@ -1,0 +1,5 @@
+package com.gamegoo.gamegoo_v2.member.controller;
+
+public class MemberController {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/member/service/MemberFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/member/service/MemberFacadeService.java
@@ -1,0 +1,14 @@
+package com.gamegoo.gamegoo_v2.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberFacadeService {
+
+    private final MemberService memberService;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/member/service/MemberService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/member/service/MemberService.java
@@ -15,16 +15,25 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    public void create(String email, String password, boolean isAgree) {
+
+    }
+
     /**
      * 회원 정보 조회
      *
-     * @param memberId
-     * @return
+     * @param memberId 사용자 ID
+     * @return Member
      */
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
+    /**
+     * Email 중복 확인
+     *
+     * @param email email
+     */
     public void checkExistMemberByEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new MemberException(ErrorCode.MEMBER_ALREADY_EXISTS);

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/controller/RiotController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/controller/RiotController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/riot")
-@Slf4j
 @Validated
 public class RiotController {
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/controller/RiotController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/controller/RiotController.java
@@ -1,0 +1,5 @@
+package com.gamegoo.gamegoo_v2.riot.controller;
+
+public class RiotController {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/controller/RiotController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/controller/RiotController.java
@@ -1,5 +1,35 @@
 package com.gamegoo.gamegoo_v2.riot.controller;
 
+import com.gamegoo.gamegoo_v2.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.riot.dto.RiotVerifyExistUserRequest;
+import com.gamegoo.gamegoo_v2.riot.service.RiotFacadeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Riot", description = "Riot 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/riot")
+@Slf4j
+@Validated
 public class RiotController {
+
+    private final RiotFacadeService riotFacadeService;
+
+    @PostMapping("/verify")
+    @Operation(summary = "실제 존재하는 Riot 계정인지 검증하는 API", description = "API for verifying account by riot API")
+    public ApiResponse<String> VerifyRiot(@RequestBody @Valid RiotVerifyExistUserRequest request) {
+        riotFacadeService.verifyRiotAccount(request);
+
+        return ApiResponse.ok("해당 Riot 계정은 존재합니다.");
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotAccountResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotAccountResponse.java
@@ -1,0 +1,14 @@
+package com.gamegoo.gamegoo_v2.riot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RiotAccountResponse {
+
+    String puuid;
+    String gameName;
+    String tagLine;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotSummonerResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotSummonerResponse.java
@@ -1,0 +1,17 @@
+package com.gamegoo.gamegoo_v2.riot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RiotSummonerResponse {
+
+    String id;
+    String accountId;
+    String puuid;
+    int profileIconId;
+    long revisionDate;
+    int summonerLevel;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotVerifyExistUserRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotVerifyExistUserRequest.java
@@ -1,0 +1,20 @@
+package com.gamegoo.gamegoo_v2.riot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RiotVerifyExistUserRequest {
+
+    @NotBlank(message = "gameName 값은 비워둘 수 없습니다.")
+    String gameName;
+    @NotBlank(message = "tag 값은 비워둘 수 없습니다.")
+    String tag;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotVerifyExistUserRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/dto/RiotVerifyExistUserRequest.java
@@ -14,6 +14,7 @@ public class RiotVerifyExistUserRequest {
 
     @NotBlank(message = "gameName 값은 비워둘 수 없습니다.")
     String gameName;
+    
     @NotBlank(message = "tag 값은 비워둘 수 없습니다.")
     String tag;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
@@ -34,13 +34,17 @@ public class RiotAccountService {
      */
     public String getPuuid(String gameName, String tag) {
         String url = String.format(RIOT_ACCOUNT_API_URL_TEMPLATE, gameName, tag, riotAPIKey);
-        RiotAccountResponse response = restTemplate.getForObject(url, RiotAccountResponse.class);
+        try {
+            RiotAccountResponse response = restTemplate.getForObject(url, RiotAccountResponse.class);
 
-        if (response == null) {
+            if (response == null) {
+                throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+            }
+
+            return response.getPuuid();
+        } catch (Exception e) {
             throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
         }
-
-        return response.getPuuid();
     }
 
     /**
@@ -51,12 +55,16 @@ public class RiotAccountService {
      */
     public String getSummonerId(String puuid) {
         String url = String.format(RIOT_SUMMONER_API_URL_TEMPLATE, puuid, riotAPIKey);
-        RiotSummonerResponse summonerResponse = restTemplate.getForObject(url, RiotSummonerResponse.class);
+        try {
+            RiotSummonerResponse summonerResponse = restTemplate.getForObject(url, RiotSummonerResponse.class);
 
-        if (summonerResponse == null) {
+            if (summonerResponse == null) {
+                throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+            }
+            return summonerResponse.getId();
+        } catch (Exception e) {
             throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
         }
-        return summonerResponse.getId();
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
@@ -1,0 +1,62 @@
+package com.gamegoo.gamegoo_v2.riot.service;
+
+import com.gamegoo.gamegoo_v2.exception.RiotException;
+import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.riot.dto.RiotAccountResponse;
+import com.gamegoo.gamegoo_v2.riot.dto.RiotSummonerResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RiotAccountService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${RIOT_API}")
+    private String riotAPIKey;
+
+    private static final String RIOT_ACCOUNT_API_URL_TEMPLATE = "https://asia.api.riotgames" +
+            ".com/riot/account/v1/accounts/by-riot-id/%s/%s?api_key=%s";
+    private static final String RIOT_SUMMONER_API_URL_TEMPLATE = "https://kr.api.riotgames" +
+            ".com/lol/summoner/v4/summoners/by-puuid/%s?api_key=%s";
+
+    /**
+     * puuid 얻기
+     *
+     * @param gameName 소환사명
+     * @param tag      태그
+     * @return puuid
+     */
+    public String getPuuid(String gameName, String tag) {
+        String url = String.format(RIOT_ACCOUNT_API_URL_TEMPLATE, gameName, tag, riotAPIKey);
+        RiotAccountResponse response = restTemplate.getForObject(url, RiotAccountResponse.class);
+
+        if (response == null) {
+            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+        }
+
+        return response.getPuuid();
+    }
+
+    /**
+     * 소환사아이디 얻기
+     *
+     * @param puuid puuid
+     * @return summonerId
+     */
+    public String getSummonerId(String puuid) {
+        String url = String.format(RIOT_SUMMONER_API_URL_TEMPLATE, puuid, riotAPIKey);
+        RiotSummonerResponse summonerResponse = restTemplate.getForObject(url, RiotSummonerResponse.class);
+
+        if (summonerResponse == null) {
+            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+        }
+        return summonerResponse.getId();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
@@ -17,7 +17,7 @@ public class RiotAccountService {
 
     private final RestTemplate restTemplate;
 
-    @Value("${RIOT_API}")
+    @Value("${spring.riot.api.key}")
     private String riotAPIKey;
 
     private static final String RIOT_ACCOUNT_API_URL_TEMPLATE = "https://asia.api.riotgames" +

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotAccountService.java
@@ -37,7 +37,7 @@ public class RiotAccountService {
         try {
             RiotAccountResponse response = restTemplate.getForObject(url, RiotAccountResponse.class);
 
-            if (response == null) {
+            if (response == null || response.getPuuid() == null) {
                 throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
             }
 
@@ -58,9 +58,10 @@ public class RiotAccountService {
         try {
             RiotSummonerResponse summonerResponse = restTemplate.getForObject(url, RiotSummonerResponse.class);
 
-            if (summonerResponse == null) {
+            if (summonerResponse == null || summonerResponse.getId() == null) {
                 throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
             }
+            
             return summonerResponse.getId();
         } catch (Exception e) {
             throw new RiotException(ErrorCode.RIOT_NOT_FOUND);

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotFacadeService.java
@@ -1,0 +1,34 @@
+package com.gamegoo.gamegoo_v2.riot.service;
+
+import com.gamegoo.gamegoo_v2.exception.RiotException;
+import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.riot.dto.RiotVerifyExistUserRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RiotFacadeService {
+
+    private final RiotAccountService riotAccountService;
+
+    public void verifyRiotAccount(RiotVerifyExistUserRequest request) {
+
+        // 1. puuid 발급 가능한지 검증
+        String puuid = riotAccountService.getPuuid(request.getGameName(), request.getTag());
+
+        if (puuid == null) {
+            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+        }
+
+        // 2. summonerid 발급 가능한지 검증
+        String summonerId = riotAccountService.getSummonerId(puuid);
+
+        if (summonerId == null) {
+            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotFacadeService.java
@@ -1,7 +1,5 @@
 package com.gamegoo.gamegoo_v2.riot.service;
 
-import com.gamegoo.gamegoo_v2.exception.RiotException;
-import com.gamegoo.gamegoo_v2.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.riot.dto.RiotVerifyExistUserRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,16 +17,8 @@ public class RiotFacadeService {
         // 1. puuid 발급 가능한지 검증
         String puuid = riotAccountService.getPuuid(request.getGameName(), request.getTag());
 
-        if (puuid == null) {
-            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
-        }
-
         // 2. summonerid 발급 가능한지 검증
-        String summonerId = riotAccountService.getSummonerId(puuid);
-
-        if (summonerId == null) {
-            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
-        }
+        riotAccountService.getSummonerId(puuid);
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotInfoService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotInfoService.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.riot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RiotInfoService {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotRecordService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotRecordService.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.riot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RiotRecordService {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotService.java
@@ -1,0 +1,5 @@
+package com.gamegoo.gamegoo_v2.riot.service;
+
+public class RiotService {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/riot/service/RiotService.java
@@ -1,5 +1,0 @@
-package com.gamegoo.gamegoo_v2.riot.service;
-
-public class RiotService {
-
-}

--- a/src/main/java/com/gamegoo/gamegoo_v2/utils/PasswordUtil.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/utils/PasswordUtil.java
@@ -1,0 +1,18 @@
+package com.gamegoo.gamegoo_v2.utils;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class PasswordUtil {
+
+    public static String encodePassword(String rawPassword) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        return encoder.encode(rawPassword);
+    }
+
+    public static boolean matchesPassword(String rawPassword, String encodedPassword) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        return encoder.matches(rawPassword, encodedPassword);
+    }
+
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,11 @@ spring:
           starttls:
             enable: true
 
+  # RIOT 설정
+  riot:
+    api:
+      key: ${RIOT_API}
+
 springdoc:
   swagger-ui:
     tags-sorter: alpha            # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
@@ -72,3 +77,4 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,6 +22,12 @@ spring:
           starttls:
             enable: true
 
+
+  # RIOT 설정
+  riot:
+    api:
+      key: key
+
 jwt:
   secret: "secretjwttestjwtsecretsecretjwttestjwtsecretsecretjwttestjwtsecretsecretjwttestjwtsecretsecretjwttestjwtsecret"
   access_expiration_time: 600000 # 10분 (10 * 60 * 1000 밀리초)


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> Riot 계정 존재하는지 검증하는 API

## ⏳ 작업 상세 내용

- [x] RestTemplate 사용 가능하도록 AppConfig 설정
- [x] RiotService 역할에 따라 분할
- [x] riot verify API 구현
- [x] Interceptor verify riot API jwt 검증 안하도록 설정
- [x] RiotException 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] RiotService를 각 용도에 따라 Account, Info, Record로 나눴는데 이렇게 나누는 방식이 괜찮은지 궁금합니다. Account : 계정 검증용, Record : 사용자 매칭 기록에서 가져오는 정보(최근 매칭에서 가장 많이 사용한 챔피언 3가지 들고오기), Info : 티어, 승률과 같이 소환사의 정보

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] RIOT_API 환경변수 설정
