### PR TITLE
[Feat/84] 특정 채팅방의 메시지 내역 조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/domain/Chat.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/domain/Chat.java
@@ -1,8 +1,8 @@
 package com.gamegoo.gamegoo_v2.chat.domain;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.core.common.BaseDateTimeEntity;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.utils.TimestampUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,7 +54,7 @@ public class Chat extends BaseDateTimeEntity {
     private Board sourceBoard;
 
     public static Chat create(String contents, Integer systemType, Chatroom chatroom, Member fromMember,
-            Member toMember, Board sourceBoard) {
+                              Member toMember, Board sourceBoard) {
         return Chat.builder()
                 .contents(contents)
                 .systemType(systemType)
@@ -63,12 +62,13 @@ public class Chat extends BaseDateTimeEntity {
                 .fromMember(fromMember)
                 .toMember(toMember)
                 .sourceBoard(sourceBoard)
+                .timestamp(TimestampUtil.getNowUtcTimeStamp())
                 .build();
     }
 
     @Builder
     private Chat(String contents, long timestamp, Integer systemType, Chatroom chatroom, Member fromMember,
-            Member toMember, Board sourceBoard) {
+                 Member toMember, Board sourceBoard) {
         this.contents = contents;
         this.timestamp = timestamp;
         this.systemType = systemType;
@@ -76,12 +76,6 @@ public class Chat extends BaseDateTimeEntity {
         this.fromMember = fromMember;
         this.toMember = toMember;
         this.sourceBoard = sourceBoard;
-    }
-
-    // repository에 저장되기 전에 해당 timestamp를 자동으로 설정
-    @PrePersist
-    public void prePersist() {
-        this.timestamp = TimestampUtil.getNowUtcTimeStamp();
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustom.java
@@ -7,4 +7,6 @@ public interface ChatRepositoryCustom {
 
     Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId, Long memberId, int pageSize);
 
+    Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Long memberChatroomId, Long memberId, int pageSize);
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatFacadeService.java
@@ -88,7 +88,7 @@ public class ChatFacadeService {
         MemberChatroom memberChatroom = chatCommandService.enterExistingChatroom(member, targetMember, chatroom);
 
         // 최근 메시지 내역 조회
-        Slice<Chat> chatSlice = chatQueryService.getRecentChatSlice(member, chatroom, memberChatroom);
+        Slice<Chat> chatSlice = chatQueryService.getRecentChatSlice(member, chatroom);
 
         // 응답 dto 생성
         ChatMessageListResponse chatMessageListResponse = chatResponseFactory.toChatMessageListResponse(chatSlice);
@@ -130,7 +130,7 @@ public class ChatFacadeService {
         MemberChatroom memberChatroom = chatCommandService.enterExistingChatroom(member, targetMember, chatroom);
 
         // 최근 메시지 내역 조회
-        Slice<Chat> chatSlice = chatQueryService.getRecentChatSlice(member, chatroom, memberChatroom);
+        Slice<Chat> chatSlice = chatQueryService.getRecentChatSlice(member, chatroom);
 
         // 응답 dto 생성
         ChatMessageListResponse chatMessageListResponse = chatResponseFactory.toChatMessageListResponse(chatSlice);
@@ -162,7 +162,7 @@ public class ChatFacadeService {
         MemberChatroom memberChatroom = chatCommandService.enterExistingChatroom(member, targetMember, chatroom);
 
         // 최근 메시지 내역 조회
-        Slice<Chat> chatSlice = chatQueryService.getRecentChatSlice(member, chatroom, memberChatroom);
+        Slice<Chat> chatSlice = chatQueryService.getRecentChatSlice(member, chatroom);
 
         // 응답 dto 생성
         ChatMessageListResponse chatMessageListResponse = chatResponseFactory.toChatMessageListResponse(chatSlice);
@@ -222,6 +222,33 @@ public class ChatFacadeService {
         }
 
         return ChatCreateResponse.of(chat);
+    }
+
+    /**
+     * 해당 채팅방의 대화 내역을 cursor 기반 페이징 조회
+     *
+     * @param member
+     * @param chatroomUuid
+     * @param cursor
+     * @return
+     */
+    public ChatMessageListResponse getChatMessagesByCursor(Member member, String chatroomUuid, Long cursor) {
+        // chatroom 엔티티 조회
+        Chatroom chatroom = chatQueryService.getChatroomByUuid(chatroomUuid);
+
+        // 해당 채팅방이 회원의 것이 맞는지 검증
+        chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
+
+        Slice<Chat> chatSlice;
+        if (cursor == null) { // cursor가 null인 경우
+            // 최근 대화 내역 조회
+            chatSlice = chatQueryService.getRecentChatSlice(member, chatroom);
+        } else {
+            // 커서 기반 대화 내역 조회
+            chatSlice = chatQueryService.getChatSliceByCursor(member, chatroom, cursor);
+        }
+
+        return chatResponseFactory.toChatMessageListResponse(chatSlice);
     }
 
     private int getSystemFlag(MemberChatroom memberChatroom) {


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 여기에 작성해주세요.

## ⏳ 작업 상세 내용
- [x] 특정 채팅방의 메시지 내역 조회 API 구현
- [x] 특정 채팅방의 메시지 내역 조회 repository 테스트
- [x] 특정 채팅방의 메시지 내역 조회 API 통합 테스트
- [x] 특정 채팅방의 메시지 내역 조회 API 컨트롤러 테스트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ x] 없을 경우 체크
