### PR TITLE
[Feat/104] 채팅방 목록 조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/controller/ChatController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.chat.dto.request.ChatCreateRequest;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatCreateResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageListResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomListResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.service.ChatFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
@@ -109,6 +110,12 @@ public class ChatController {
     public ApiResponse<Object> exitChatroom(@PathVariable(name = "chatroomUuid") String chatroomUuid,
                                             @AuthMember Member member) {
         return ApiResponse.ok(chatFacadeService.exitChatroom(member, chatroomUuid));
+    }
+
+    @Operation(summary = "채팅방 목록 조회 API", description = "회원이 속한 채팅방 목록을 조회하는 API 입니다.")
+    @GetMapping("/chatroom")
+    public ApiResponse<ChatroomListResponse> getChatroom(@AuthMember Member member) {
+        return ApiResponse.ok(chatFacadeService.getChatrooms(member));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/domain/Chatroom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/domain/Chatroom.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +26,10 @@ public class Chatroom extends BaseDateTimeEntity {
     @Column(nullable = false)
     private String uuid;
 
+    private Long lastChatId;
+
+    private LocalDateTime lastChatAt;
+
     public static Chatroom create(String uuid) {
         return Chatroom.builder()
                 .uuid(uuid)
@@ -33,6 +39,14 @@ public class Chatroom extends BaseDateTimeEntity {
     @Builder
     private Chatroom(String uuid) {
         this.uuid = uuid;
+    }
+
+    public void updateLastChatAt(LocalDateTime lastChatAt) {
+        this.lastChatAt = lastChatAt;
+    }
+
+    public void updateLastChatId(Long lastChatId) {
+        this.lastChatId = lastChatId;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/ChatResponseFactory.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/ChatResponseFactory.java
@@ -1,13 +1,17 @@
 package com.gamegoo.gamegoo_v2.chat.dto;
 
-import com.gamegoo.gamegoo_v2.social.block.service.BlockService;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.chat.domain.Chat;
+import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageListResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomListResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.SystemMessageResponse;
+import com.gamegoo.gamegoo_v2.social.block.service.BlockService;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendService;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.utils.DateTimeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -94,6 +98,54 @@ public class ChatResponseFactory {
                 .friendRequestMemberId(friendService.getFriendRequestMemberId(member, targetMember))
                 .system(null)
                 .chatMessageListResponse(chatMessageListResponse)
+                .build();
+    }
+
+    public ChatroomListResponse toChatroomListResponse() {
+        return ChatroomListResponse.builder()
+                .chatroomResponseList(new ArrayList<>())
+                .listSize(0)
+                .build();
+    }
+
+    public ChatroomListResponse toChatroomListResponse(List<ChatroomResponse> chatroomResponseList) {
+        return ChatroomListResponse.builder()
+                .chatroomResponseList(chatroomResponseList)
+                .listSize(chatroomResponseList.size())
+                .build();
+    }
+
+    public ChatroomResponse toChatroomResponse(Chatroom chatroom, Member targetMember, boolean isFriend,
+                                               boolean isBlocked, Long friendRequestMemberId, Chat lastChat,
+                                               int unreadCnt) {
+        String gameName = targetMember.isBlind()
+                ? "(탈퇴한 사용자)"
+                : targetMember.getGameName();
+
+        String lastMsg = null;
+        String lastMsgAt = null;
+        Long lastMsgTimestamp = null;
+        
+        if (lastChat != null) {
+            lastMsg = lastChat.getContents();
+            lastMsgAt = DateTimeUtil.toKSTString(lastChat.getCreatedAt());
+            lastMsgTimestamp = lastChat.getTimestamp();
+        }
+
+        return ChatroomResponse.builder()
+                .chatroomId(chatroom.getId())
+                .uuid(chatroom.getUuid())
+                .targetMemberId(targetMember.getId())
+                .targetMemberImg(targetMember.getProfileImage())
+                .targetMemberName(gameName)
+                .friend(isFriend)
+                .blocked(isBlocked)
+                .blind(targetMember.isBlind())
+                .friendRequestMemberId(friendRequestMemberId)
+                .lastMsg(lastMsg)
+                .lastMsgAt(lastMsgAt)
+                .notReadMsgCnt(unreadCnt)
+                .lastMsgTimestamp(lastMsgTimestamp)
                 .build();
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/ChatResponseFactory.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/ChatResponseFactory.java
@@ -30,9 +30,9 @@ public class ChatResponseFactory {
         List<ChatMessageResponse> chatMessageResponseList = chatSlice.stream()
                 .map(chat -> {
                     if (chat.getSystemType() == null) {
-                        return SystemMessageResponse.of(chat);
+                        return ChatMessageResponse.of(chat);
                     }
-                    return ChatMessageResponse.of(chat);
+                    return SystemMessageResponse.of(chat);
                 })
                 .toList();
 
@@ -125,7 +125,7 @@ public class ChatResponseFactory {
         String lastMsg = null;
         String lastMsgAt = null;
         Long lastMsgTimestamp = null;
-        
+
         if (lastChat != null) {
             lastMsg = lastChat.getContents();
             lastMsgAt = DateTimeUtil.toKSTString(lastChat.getCreatedAt());

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/response/ChatroomListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/response/ChatroomListResponse.java
@@ -1,0 +1,15 @@
+package com.gamegoo.gamegoo_v2.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatroomListResponse {
+
+    List<ChatroomResponse> chatroomResponseList;
+    int listSize;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/response/ChatroomResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/response/ChatroomResponse.java
@@ -1,0 +1,24 @@
+package com.gamegoo.gamegoo_v2.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatroomResponse {
+
+    Long chatroomId;
+    String uuid;
+    Long targetMemberId;
+    int targetMemberImg;
+    String targetMemberName;
+    boolean friend;
+    boolean blocked;
+    boolean blind;
+    Long friendRequestMemberId;
+    String lastMsg;
+    String lastMsgAt;
+    int notReadMsgCnt;
+    Long lastMsgTimestamp;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustom.java
@@ -5,10 +5,10 @@ import org.springframework.data.domain.Slice;
 
 public interface ChatRepositoryCustom {
 
-    Slice<Chat> findRecentChats(Long chatroomId, Long memberChatroomId, Long memberId, int pageSize);
+    Slice<Chat> findRecentChats(Long chatroomId, Long memberId, int pageSize);
 
-    Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Long memberChatroomId, Long memberId, int pageSize);
+    Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Long memberId, int pageSize);
 
-    int countUnreadChats(Long chatroomId, Long memberChatroomId, Long memberId);
+    int countUnreadChats(Long chatroomId, Long memberId);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustom.java
@@ -3,6 +3,9 @@ package com.gamegoo.gamegoo_v2.chat.repository;
 import com.gamegoo.gamegoo_v2.chat.domain.Chat;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+import java.util.Map;
+
 public interface ChatRepositoryCustom {
 
     Slice<Chat> findRecentChats(Long chatroomId, Long memberId, int pageSize);
@@ -10,5 +13,7 @@ public interface ChatRepositoryCustom {
     Slice<Chat> findChatsByCursor(Long cursor, Long chatroomId, Long memberId, int pageSize);
 
     int countUnreadChats(Long chatroomId, Long memberId);
+
+    Map<Long, Integer> countUnreadChatsBatch(List<Long> chatroomIds, Long memberId);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatRepositoryCustomImpl.java
@@ -115,7 +115,7 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
     @Override
     public Map<Long, Integer> countUnreadChatsBatch(List<Long> chatroomIds, Long memberId) {
         List<Tuple> results = queryFactory
-                .select(chat.chatroom.id, chat.count())
+                .select(chat.chatroom.id, chat.countDistinct())
                 .from(chat)
                 .join(memberChatroom).on(
                         memberChatroom.chatroom.id.in(chatroomIds),
@@ -134,7 +134,7 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom {
         Map<Long, Integer> unreadMap = new HashMap<>();
         for (Tuple tuple : results) {
             Long roomId = tuple.get(chat.chatroom.id);
-            Long countVal = tuple.get(chat.count());
+            Long countVal = tuple.get(chat.countDistinct());
 
             unreadMap.put(roomId, countVal != null ? countVal.intValue() : 0);
         }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/MemberChatroomRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/MemberChatroomRepository.java
@@ -1,19 +1,35 @@
 package com.gamegoo.gamegoo_v2.chat.repository;
 
-import com.gamegoo.gamegoo_v2.chat.domain.MemberChatroom;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.chat.domain.MemberChatroom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface MemberChatroomRepository extends JpaRepository<MemberChatroom, Long> {
+public interface MemberChatroomRepository extends JpaRepository<MemberChatroom, Long>, MemberChatroomRepositoryCustom {
 
     Optional<MemberChatroom> findByMemberIdAndChatroomId(Long memberId, Long chatroomId);
 
-    @Query("SELECT mc.member FROM MemberChatroom mc WHERE mc.chatroom.id = :chatroomId AND mc.member.id != :memberId")
+    @Query("""
+            SELECT mc.member
+            FROM MemberChatroom mc
+            WHERE mc.chatroom.id = :chatroomId
+            AND mc.member.id != :memberId
+            """)
     Optional<Member> findTargetMemberByChatroomIdAndMemberId(@Param("chatroomId") Long chatroomId,
                                                              @Param("memberId") Long memberId);
+
+    @Query("""
+            SELECT mc
+            FROM MemberChatroom mc
+            JOIN FETCH mc.chatroom c
+            WHERE mc.member.id = :memberId
+            AND mc.lastJoinDate is not null
+            ORDER BY COALESCE(c.lastChatAt, mc.lastJoinDate) DESC
+            """)
+    List<MemberChatroom> findAllActiveMemberChatroomByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/MemberChatroomRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/MemberChatroomRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.chat.repository;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MemberChatroomRepositoryCustom {
+
+    Map<Long, Member> findTargetMembersBatch(List<Long> chatroomIds, Long memberId);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/MemberChatroomRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/MemberChatroomRepositoryCustomImpl.java
@@ -1,0 +1,40 @@
+package com.gamegoo.gamegoo_v2.chat.repository;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.gamegoo.gamegoo_v2.chat.domain.QMemberChatroom.memberChatroom;
+
+@RequiredArgsConstructor
+public class MemberChatroomRepositoryCustomImpl implements MemberChatroomRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, Member> findTargetMembersBatch(List<Long> chatroomIds, Long memberId) {
+        List<Tuple> results = queryFactory
+                .select(memberChatroom.chatroom.id, memberChatroom.member)
+                .from(memberChatroom)
+                .where(
+                        memberChatroom.chatroom.id.in(chatroomIds),
+                        memberChatroom.member.id.ne(memberId)
+                )
+                .fetch();
+
+        Map<Long, Member> resultMap = new HashMap<>();
+        for (Tuple elem : results) {
+            Long chatroomId = elem.get(memberChatroom.chatroom.id);
+            Member targetMember = elem.get(memberChatroom.member);
+            resultMap.put(chatroomId, targetMember);
+        }
+
+        return resultMap;
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatCommandService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatCommandService.java
@@ -243,4 +243,15 @@ public class ChatCommandService {
         }
     }
 
+    /**
+     * chatroom 엔티티의 lastChatId와 lastChatAt 업데이트 메소드
+     *
+     * @param chat
+     * @param chatroom
+     */
+    public void updateLastChat(Chat chat, Chatroom chatroom) {
+        chatroom.updateLastChatId(chat.getId());
+        chatroom.updateLastChatAt(chat.getCreatedAt());
+    }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatFacadeService.java
@@ -380,7 +380,7 @@ public class ChatFacadeService {
 
         // 상대 회원과 친구 여부, 차단 여부, 친구 요청 배치 조회
         Map<Long, Boolean> isFriendMap = friendService.isFriendBatch(member, targetMemberIds);
-        Map<Long, Boolean> isBlockedMap = blockService.isBlockedBatch(member, targetMemberIds);
+        Map<Long, Boolean> isBlockedMap = blockService.isBlockedByTargetMembersBatch(member, targetMemberIds);
         Map<Long, Long> friendRequestMap = friendService.getFriendRequestMemberIdBatch(member, targetMemberIds);
 
         // dto 생성

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatFacadeService.java
@@ -224,6 +224,8 @@ public class ChatFacadeService {
             chatCommandService.updateMemberChatroomDatesByAddChat(member, targetMember, chat);
         }
 
+        chatCommandService.updateLastChat(chat, chatroom);
+
         return ChatCreateResponse.of(chat);
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatQueryService.java
@@ -50,8 +50,8 @@ public class ChatQueryService {
      * @return
      */
     public Slice<Chat> getRecentChatSlice(Member member, Chatroom chatroom) {
-        MemberChatroom memberChatroom = chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
-        return chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(), member.getId(), PAGE_SIZE);
+        chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
+        return chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
     }
 
     /**
@@ -85,9 +85,8 @@ public class ChatQueryService {
      * @return
      */
     public Slice<Chat> getChatSliceByCursor(Member member, Chatroom chatroom, Long cursor) {
-        MemberChatroom memberChatroom = chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
-        return chatRepository.findChatsByCursor(cursor, chatroom.getId(), memberChatroom.getId(), member.getId(),
-                PAGE_SIZE);
+        chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
+        return chatRepository.findChatsByCursor(cursor, chatroom.getId(), member.getId(), PAGE_SIZE);
     }
 
     /**
@@ -108,8 +107,8 @@ public class ChatQueryService {
      * @return
      */
     public int countUnreadChats(Member member, Chatroom chatroom) {
-        MemberChatroom memberChatroom = chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
-        return chatRepository.countUnreadChats(member.getId(), memberChatroom.getId(), chatroom.getId());
+        chatValidator.validateMemberChatroom(member.getId(), chatroom.getId());
+        return chatRepository.countUnreadChats(member.getId(), chatroom.getId());
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatQueryService.java
@@ -15,7 +15,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -77,6 +79,17 @@ public class ChatQueryService {
     }
 
     /**
+     * 모든 chatroom의 상대 회원을 반환하는 메소드
+     *
+     * @param member
+     * @param chatroomIds
+     * @return
+     */
+    public Map<Long, Member> getChatroomTargetMembersBatch(Member member, List<Long> chatroomIds) {
+        return memberChatroomRepository.findTargetMembersBatch(chatroomIds, member.getId());
+    }
+
+    /**
      * 해당 chatroom의 메시지 내역 slice 객체를 반환하는 메소드
      *
      * @param member
@@ -100,6 +113,16 @@ public class ChatQueryService {
     }
 
     /**
+     * 회원이 입장한 상태인 모든 memberChatroom list 반환하는 메소드
+     *
+     * @param member
+     * @return
+     */
+    public List<MemberChatroom> getActiveMemberChatrooms(Member member) {
+        return memberChatroomRepository.findAllActiveMemberChatroomByMemberId(member.getId());
+    }
+
+    /**
      * 해당 채팅방의 안읽은 메시지 개수를 반환하는 메소드
      *
      * @param member
@@ -112,6 +135,17 @@ public class ChatQueryService {
     }
 
     /**
+     * 모든 채팅방의 안읽은 메시지 개수를 반환하는 메소드
+     *
+     * @param member
+     * @param chatroomIds
+     * @return
+     */
+    public Map<Long, Integer> countUnreadChatsBatch(Member member, List<Long> chatroomIds) {
+        return chatRepository.countUnreadChatsBatch(chatroomIds, member.getId());
+    }
+
+    /**
      * 해당 채팅방에 해당 timestamp를 갖는 chat 엔티티 조회 메소드
      *
      * @param chatroom
@@ -121,6 +155,23 @@ public class ChatQueryService {
     public Chat getChatByChatroomAndTimestamp(Chatroom chatroom, Long timestamp) {
         return chatRepository.findByChatroomAndTimestamp(chatroom, timestamp).orElseThrow(
                 () -> new ChatException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
+    }
+
+    /**
+     * id로 chat 엔티티 배치 조회 메소드
+     *
+     * @param chatIds
+     * @return
+     */
+    public Map<Long, Chat> findAllChatsBatch(List<Long> chatIds) {
+        List<Chat> chats = chatRepository.findAllById(chatIds);
+
+        Map<Long, Chat> chatMap = new HashMap<>();
+        for (Chat chat : chats) {
+            chatMap.put(chat.getChatroom().getId(), chat);
+        }
+
+        return chatMap;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepository.java
@@ -1,7 +1,7 @@
 package com.gamegoo.gamegoo_v2.social.block.repository;
 
-import com.gamegoo.gamegoo_v2.social.block.domain.Block;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.social.block.domain.Block;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,13 +10,20 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface BlockRepository extends JpaRepository<Block, Long> {
+public interface BlockRepository extends JpaRepository<Block, Long>, BlockRepositoryCustom {
 
     boolean existsByBlockerMemberAndBlockedMemberAndDeleted(Member blockerMember, Member blockedMember,
-            Boolean deleted);
+                                                            Boolean deleted);
 
-    @Query("SELECT m FROM Member m INNER JOIN Block b ON m.id = b.blockedMember.id WHERE b.blockerMember.id = " +
-            ":blockerId AND b.deleted = false ORDER BY b.createdAt DESC")
+    @Query("""
+            SELECT m
+            FROM Member m
+            INNER JOIN Block b
+            ON m.id = b.blockedMember.id
+            WHERE b.blockerMember.id = :blockerId
+            AND b.deleted = false
+            ORDER BY b.createdAt DESC
+            """)
     Page<Member> findBlockedMembersByBlockerMember(@Param("blockerId") Long blockerId, Pageable pageable);
 
     Optional<Block> findByBlockerMemberAndBlockedMember(Member blockerMember, Member blockedMember);

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.gamegoo.gamegoo_v2.social.block.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BlockRepositoryCustom {
+
+    Map<Long, Boolean> isBlockedBatch(List<Long> targetMemberIds, Long memberId);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustom.java
@@ -5,6 +5,6 @@ import java.util.Map;
 
 public interface BlockRepositoryCustom {
 
-    Map<Long, Boolean> isBlockedBatch(List<Long> targetMemberIds, Long memberId);
+    Map<Long, Boolean> isBlockedByTargetMembersBatch(List<Long> targetMemberIds, Long memberId);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustomImpl.java
@@ -17,14 +17,14 @@ public class BlockRepositoryCustomImpl implements BlockRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Map<Long, Boolean> isBlockedBatch(List<Long> targetMemberIds, Long memberId) {
+    public Map<Long, Boolean> isBlockedByTargetMembersBatch(List<Long> targetMemberIds, Long memberId) {
         Set<Long> blockedSet = new HashSet<>(
                 queryFactory
                         .select(block.blockedMember.id)
                         .from(block)
                         .where(
-                                block.blockerMember.id.eq(memberId),
-                                block.blockedMember.id.in(targetMemberIds),
+                                block.blockerMember.id.in(targetMemberIds),
+                                block.blockedMember.id.eq(memberId),
                                 block.deleted.eq(false)
                         )
                         .fetch()

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustomImpl.java
@@ -20,7 +20,7 @@ public class BlockRepositoryCustomImpl implements BlockRepositoryCustom {
     public Map<Long, Boolean> isBlockedByTargetMembersBatch(List<Long> targetMemberIds, Long memberId) {
         Set<Long> blockedSet = new HashSet<>(
                 queryFactory
-                        .select(block.blockedMember.id)
+                        .select(block.blockerMember.id)
                         .from(block)
                         .where(
                                 block.blockerMember.id.in(targetMemberIds),

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/repository/BlockRepositoryCustomImpl.java
@@ -1,0 +1,40 @@
+package com.gamegoo.gamegoo_v2.social.block.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.gamegoo.gamegoo_v2.social.block.domain.QBlock.block;
+
+@RequiredArgsConstructor
+public class BlockRepositoryCustomImpl implements BlockRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, Boolean> isBlockedBatch(List<Long> targetMemberIds, Long memberId) {
+        Set<Long> blockedSet = new HashSet<>(
+                queryFactory
+                        .select(block.blockedMember.id)
+                        .from(block)
+                        .where(
+                                block.blockerMember.id.eq(memberId),
+                                block.blockedMember.id.in(targetMemberIds),
+                                block.deleted.eq(false)
+                        )
+                        .fetch()
+        );
+
+        return targetMemberIds.stream()
+                .collect(Collectors.toMap(
+                        targetId -> targetId,
+                        blockedSet::contains
+                ));
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/service/BlockService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/service/BlockService.java
@@ -125,8 +125,8 @@ public class BlockService {
      * @param targetMemberIds
      * @return
      */
-    public Map<Long, Boolean> isBlockedBatch(Member member, List<Long> targetMemberIds) {
-        return blockRepository.isBlockedBatch(targetMemberIds, member.getId());
+    public Map<Long, Boolean> isBlockedByTargetMembersBatch(Member member, List<Long> targetMemberIds) {
+        return blockRepository.isBlockedByTargetMembersBatch(targetMemberIds, member.getId());
     }
 
     private void validateNotSelfBlock(Member member, Member targetMember) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/service/BlockService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/service/BlockService.java
@@ -1,17 +1,20 @@
 package com.gamegoo.gamegoo_v2.social.block.service;
 
-import com.gamegoo.gamegoo_v2.social.block.domain.Block;
-import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.validator.MemberValidator;
 import com.gamegoo.gamegoo_v2.core.exception.BlockException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.social.block.domain.Block;
+import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -113,6 +116,17 @@ public class BlockService {
      */
     public boolean isBlocked(Member member, Member targetMember) {
         return blockRepository.existsByBlockerMemberAndBlockedMemberAndDeleted(member, targetMember, false);
+    }
+
+    /**
+     * 모든 targetMember에 대한 차단 여부 반환하는 메소드
+     *
+     * @param member
+     * @param targetMemberIds
+     * @return
+     */
+    public Map<Long, Boolean> isBlockedBatch(Member member, List<Long> targetMemberIds) {
+        return blockRepository.isBlockedBatch(targetMemberIds, member.getId());
     }
 
     private void validateNotSelfBlock(Member member, Member targetMember) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/controller/FriendController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.social.friend.controller;
 
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.social.friend.dto.DeleteFriendResponse;
@@ -9,7 +10,6 @@ import com.gamegoo.gamegoo_v2.social.friend.dto.FriendListResponse;
 import com.gamegoo.gamegoo_v2.social.friend.dto.FriendRequestResponse;
 import com.gamegoo.gamegoo_v2.social.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendFacadeService;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,7 +29,7 @@ import java.util.List;
 @Tag(name = "Friend", description = "친구 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v2/friends")
+@RequestMapping("/api/v2/friend")
 @Validated
 public class FriendController {
 
@@ -47,7 +47,7 @@ public class FriendController {
     @Parameter(name = "memberId", description = "친구 요청을 수락할 대상 회원의 id 입니다.")
     @PatchMapping("/request/{memberId}/accept")
     public ApiResponse<FriendRequestResponse> acceptFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                                  @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.acceptFriendRequest(member, targetMemberId));
     }
 
@@ -55,7 +55,7 @@ public class FriendController {
     @Parameter(name = "memberId", description = "친구 요청을 거절할 대상 회원의 id 입니다.")
     @PatchMapping("/request/{memberId}/reject")
     public ApiResponse<FriendRequestResponse> rejectFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                                  @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.rejectFriendRequest(member, targetMemberId));
     }
 
@@ -63,7 +63,7 @@ public class FriendController {
     @Parameter(name = "memberId", description = "친구 요청을 취소할 대상 회원의 id 입니다.")
     @DeleteMapping("/request/{memberId}")
     public ApiResponse<FriendRequestResponse> cancelFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                                  @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.cancelFriendRequest(member, targetMemberId));
     }
 
@@ -71,7 +71,7 @@ public class FriendController {
     @Parameter(name = "memberId", description = "즐겨찾기 설정/해제할 친구 회원의 id 입니다.")
     @PatchMapping("/{memberId}/star")
     public ApiResponse<StarFriendResponse> reverseFriendLiked(@PathVariable(name = "memberId") Long friendMemberId,
-            @AuthMember Member member) {
+                                                              @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.reverseFriendLiked(member, friendMemberId));
     }
 
@@ -79,7 +79,7 @@ public class FriendController {
     @Parameter(name = "memberId", description = "삭제 처리할 친구 회원의 id 입니다.")
     @DeleteMapping("/{memberId}")
     public ApiResponse<DeleteFriendResponse> deleteFriend(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                          @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.deleteFriend(member, targetMemberId));
     }
 
@@ -103,7 +103,7 @@ public class FriendController {
     @Parameter(name = "query", description = "친구 목록 검색을 위한 소환사명 string으로, 100자 이하여야 합니다.")
     @GetMapping("/search")
     public ApiResponse<List<FriendInfoResponse>> searchFriend(@RequestParam(name = "query") String query,
-            @AuthMember Member member) {
+                                                              @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.searchFriend(member, query));
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/repository/FriendRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/repository/FriendRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.gamegoo.gamegoo_v2.social.friend.domain.Friend;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
+import java.util.Map;
 
 public interface FriendRepositoryCustom {
 
@@ -12,5 +13,7 @@ public interface FriendRepositoryCustom {
     List<Friend> findFriendsByQueryString(Long memberId, String queryString);
 
     boolean isFriend(Long memberId, Long targetMemberId);
+
+    Map<Long, Boolean> isFriendBatch(Long memberId, List<Long> targetMemberIds);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/repository/FriendRequestRepository.java
@@ -1,10 +1,13 @@
 package com.gamegoo.gamegoo_v2.social.friend.repository;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequest;
 import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequestStatus;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
@@ -12,6 +15,36 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     boolean existsByFromMemberAndToMemberAndStatus(Member fromMember, Member toMember, FriendRequestStatus status);
 
     Optional<FriendRequest> findByFromMemberAndToMemberAndStatus(Member fromMember, Member toMember,
-            FriendRequestStatus status);
+                                                                 FriendRequestStatus status);
+
+    @Query("""
+            SELECT fr
+            FROM FriendRequest fr
+            WHERE fr.status = :status
+            AND (
+                    (fr.fromMember = :member AND fr.toMember = :targetMember)
+                 OR (fr.toMember = :member AND fr.fromMember = :targetMember)
+              )
+            """)
+    Optional<FriendRequest> findBetweenTargetMemberAndStatus(
+            @Param("member") Member member,
+            @Param("targetMember") Member targetMember,
+            @Param("status") FriendRequestStatus status
+    );
+
+    @Query("""
+            SELECT fr
+            FROM FriendRequest fr
+            WHERE fr.status = :status
+            AND (
+                    (fr.fromMember = :member AND fr.toMember.id IN :targetMemberIds)
+                 OR (fr.toMember = :member AND fr.fromMember.id IN :targetMemberIds)
+              )
+            """)
+    List<FriendRequest> findAllBetweenTargetMembersAndStatus(
+            @Param("member") Member member,
+            @Param("targetMemberIds") List<Long> targetMemberIds,
+            @Param("status") FriendRequestStatus status
+    );
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/service/FriendService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/service/FriendService.java
@@ -320,7 +320,7 @@ public class FriendService {
             Member from = fr.getFromMember();
             Member to = fr.getToMember();
 
-            if (from.equals(member)) { // 내가 요청을 보낸 경우
+            if (from.getId().equals(member.getId())) { // 내가 요청을 보낸 경우
                 Long targetId = to.getId();
                 resultMap.put(targetId, member.getId());
             } else { // 상대가 요청을 보낸 경우

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/chat/ChatControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/chat/ChatControllerTest.java
@@ -7,6 +7,8 @@ import com.gamegoo.gamegoo_v2.chat.dto.request.SystemFlagRequest;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatCreateResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageListResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomListResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse.SystemFlagResponse;
 import com.gamegoo.gamegoo_v2.chat.service.ChatFacadeService;
@@ -458,7 +460,6 @@ class ChatControllerTest extends ControllerTestSupport {
 
     }
 
-
     @DisplayName("채팅방 나가기 성공")
     @Test
     void ExitChatroomSucceeds() throws Exception {
@@ -472,6 +473,26 @@ class ChatControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andExpect(jsonPath("$.data").value("채팅방 나가기 성공"));
+    }
+
+    @DisplayName("채팅방 목록 조회")
+    @Test
+    void getChatroomSucceeds() throws Exception {
+        // given
+        List<ChatroomResponse> chatroomResponseList = new ArrayList<>();
+        ChatroomListResponse response = ChatroomListResponse.builder()
+                .chatroomResponseList(chatroomResponseList)
+                .listSize(0)
+                .build();
+
+        given(chatFacadeService.getChatrooms(any(Member.class))).willReturn(response);
+
+        // when // then
+        mockMvc.perform(get(API_URL_PREFIX + "/chatroom"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.chatroomResponseList").isArray())
+                .andExpect(jsonPath("$.data.listSize").isNumber());
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
@@ -1,5 +1,6 @@
 package com.gamegoo.gamegoo_v2.controller.friend;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
 import com.gamegoo.gamegoo_v2.core.exception.FriendException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
@@ -12,7 +13,6 @@ import com.gamegoo.gamegoo_v2.social.friend.dto.FriendListResponse;
 import com.gamegoo.gamegoo_v2.social.friend.dto.FriendRequestResponse;
 import com.gamegoo.gamegoo_v2.social.friend.dto.StarFriendResponse;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendFacadeService;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class FriendControllerTest extends ControllerTestSupport {
     @MockitoBean
     private FriendFacadeService friendFacadeService;
 
-    private static final String API_URL_PREFIX = "/api/v2/friends";
+    private static final String API_URL_PREFIX = "/api/v2/friend";
     private static final Long TARGET_MEMBER_ID = 2L;
 
     @Nested
@@ -174,7 +174,8 @@ class FriendControllerTest extends ControllerTestSupport {
                     .message("친구 요청 수락 성공")
                     .build();
 
-            given(friendFacadeService.acceptFriendRequest(any(Member.class), eq(TARGET_MEMBER_ID))).willReturn(response);
+            given(friendFacadeService.acceptFriendRequest(any(Member.class), eq(TARGET_MEMBER_ID))).willReturn(
+                    response);
 
             // when // then
             mockMvc.perform(patch(API_URL_PREFIX + "/request/{memberId}/accept", TARGET_MEMBER_ID))
@@ -225,7 +226,8 @@ class FriendControllerTest extends ControllerTestSupport {
                     .message("친구 요청 거절 성공")
                     .build();
 
-            given(friendFacadeService.rejectFriendRequest(any(Member.class), eq(TARGET_MEMBER_ID))).willReturn(response);
+            given(friendFacadeService.rejectFriendRequest(any(Member.class), eq(TARGET_MEMBER_ID))).willReturn(
+                    response);
 
             // when // then
             mockMvc.perform(patch(API_URL_PREFIX + "/request/{memberId}/reject", TARGET_MEMBER_ID))
@@ -276,7 +278,8 @@ class FriendControllerTest extends ControllerTestSupport {
                     .message("친구 요청 취소 성공")
                     .build();
 
-            given(friendFacadeService.cancelFriendRequest(any(Member.class), eq(TARGET_MEMBER_ID))).willReturn(response);
+            given(friendFacadeService.cancelFriendRequest(any(Member.class), eq(TARGET_MEMBER_ID))).willReturn(
+                    response);
 
             // when // then
             mockMvc.perform(delete(API_URL_PREFIX + "/request/{memberId}", TARGET_MEMBER_ID))

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/chat/ChatFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/chat/ChatFacadeServiceTest.java
@@ -11,6 +11,8 @@ import com.gamegoo.gamegoo_v2.chat.domain.MemberChatroom;
 import com.gamegoo.gamegoo_v2.chat.dto.request.ChatCreateRequest;
 import com.gamegoo.gamegoo_v2.chat.dto.request.SystemFlagRequest;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageListResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomListResponse;
+import com.gamegoo.gamegoo_v2.chat.dto.response.ChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.repository.ChatRepository;
 import com.gamegoo.gamegoo_v2.chat.repository.ChatroomRepository;
@@ -27,6 +29,10 @@ import com.gamegoo.gamegoo_v2.core.exception.common.GlobalException;
 import com.gamegoo.gamegoo_v2.external.socket.SocketService;
 import com.gamegoo.gamegoo_v2.social.block.domain.Block;
 import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.social.friend.domain.Friend;
+import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequest;
+import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRepository;
+import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRequestRepository;
 import com.gamegoo.gamegoo_v2.utils.TimestampUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +84,12 @@ class ChatFacadeServiceTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private FriendRequestRepository friendRequestRepository;
+
     @MockitoSpyBean
     private MemberRepository memberRepository;
 
@@ -107,6 +119,8 @@ class ChatFacadeServiceTest {
         chatroomRepository.deleteAllInBatch();
         blockRepository.deleteAllInBatch();
         boardRepository.deleteAllInBatch();
+        friendRequestRepository.deleteAllInBatch();
+        friendRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
 
@@ -914,6 +928,96 @@ class ChatFacadeServiceTest {
 
     }
 
+    @Nested
+    @DisplayName("채팅방 목록 조회")
+    class GetChatroomsTest {
+
+        @DisplayName("성공: 입장 상태인 채팅방이 없는 경우")
+        @Test
+        void getChatroomsSucceedsWhenNoActiveChatroom() {
+            // when
+            ChatroomListResponse response = chatFacadeService.getChatrooms(member);
+
+            // then
+            assertThat(response.getChatroomResponseList()).isEmpty();
+            assertThat(response.getListSize()).isEqualTo(0);
+        }
+
+        @DisplayName("성공")
+        @Test
+        void getChatroomsSucceeds() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+
+            // targetMember1 생성
+            Member targetMember1 = createMember("targetMember1@gmail.com", "targetMember1");
+            Chatroom chatroom1 = createChatroom();
+            createMemberChatroom(targetMember1, chatroom1, now, now);
+            createMemberChatroom(member, chatroom1, now, now);
+            Chat chat1 = createChat(targetMember1, "message 1", chatroom1);
+            updateLastChat(chatroom1, chat1);
+
+            friendRepository.save(Friend.create(member, targetMember1));
+            friendRepository.save(Friend.create(targetMember1, member));
+
+            // targetMember2 생성
+            Member targetMember2 = createMember("targetmember2@gmail.com", "targetMember2");
+            Chatroom chatroom2 = createChatroom();
+            createMemberChatroom(member, chatroom2, now.plusHours(1), now);
+            createMemberChatroom(targetMember2, chatroom2, now.plusHours(1), now);
+            Chat chat2 = createChat(targetMember2, "message 2", chatroom2);
+            updateLastChat(chatroom2, chat2);
+
+            friendRequestRepository.save(FriendRequest.create(member, targetMember2));
+
+            // targetMember3 생성
+            Member targetMember3 = createMember("targetmember3@gmail.com", "targetMember3");
+            Chatroom chatroom3 = createChatroom();
+            createMemberChatroom(member, chatroom3, now, now);
+            createMemberChatroom(targetMember3, chatroom3, now, now);
+            Chat chat3 = createChat(targetMember3, "message 3", chatroom3);
+            updateLastChat(chatroom3, chat3);
+
+            blockMember(targetMember3, member);
+
+            // targetMember4 생성
+            Member targetMember4 = createMember("targetmember4@gmail.com", "targetMember4");
+            Chatroom chatroom4 = createChatroom();
+            createMemberChatroom(member, chatroom4, null);
+            createMemberChatroom(targetMember4, chatroom4, now);
+
+            // when
+            ChatroomListResponse response = chatFacadeService.getChatrooms(member);
+
+            // then
+            assertThat(response.getChatroomResponseList()).hasSize(3);
+            assertThat(response.getListSize()).isEqualTo(3);
+
+            ChatroomResponse chatroomResponse1 = response.getChatroomResponseList().get(0);
+            ChatroomResponse chatroomResponse2 = response.getChatroomResponseList().get(1);
+            ChatroomResponse chatroomResponse3 = response.getChatroomResponseList().get(2);
+
+            assertThat(chatroomResponse1.getChatroomId()).isEqualTo(chatroom3.getId());
+            assertThat(chatroomResponse1.getLastMsg()).isEqualTo(chat3.getContents());
+            assertThat(chatroomResponse1.getLastMsgTimestamp()).isEqualTo(chat3.getTimestamp());
+            assertThat(chatroomResponse1.getNotReadMsgCnt()).isEqualTo(1);
+            assertThat(chatroomResponse1.isBlocked()).isTrue();
+
+            assertThat(chatroomResponse2.getChatroomId()).isEqualTo(chatroom2.getId());
+            assertThat(chatroomResponse2.getLastMsg()).isEqualTo(chat2.getContents());
+            assertThat(chatroomResponse2.getLastMsgTimestamp()).isEqualTo(chat2.getTimestamp());
+            assertThat(chatroomResponse2.getNotReadMsgCnt()).isEqualTo(0);
+            assertThat(chatroomResponse2.getFriendRequestMemberId()).isEqualTo(member.getId());
+
+            assertThat(chatroomResponse3.getChatroomId()).isEqualTo(chatroom1.getId());
+            assertThat(chatroomResponse3.getLastMsg()).isEqualTo(chat1.getContents());
+            assertThat(chatroomResponse3.getLastMsgTimestamp()).isEqualTo(chat1.getTimestamp());
+            assertThat(chatroomResponse3.getNotReadMsgCnt()).isEqualTo(1);
+            assertThat(chatroomResponse3.isFriend()).isTrue();
+        }
+
+    }
+
     private void assertEnterChatroomResponse(EnterChatroomResponse response, Chatroom chatroom, Member targetMember) {
         assertThat(response.getUuid()).isEqualTo(chatroom.getUuid());
         assertThat(response.getMemberId()).isEqualTo(targetMember.getId());
@@ -957,6 +1061,16 @@ class ChatFacadeServiceTest {
                 .build());
     }
 
+    private MemberChatroom createMemberChatroom(Member member, Chatroom chatroom, LocalDateTime lastViewDate,
+                                                LocalDateTime lastJoinDate) {
+        return memberChatroomRepository.save(MemberChatroom.builder()
+                .chatroom(chatroom)
+                .member(member)
+                .lastViewDate(lastViewDate)
+                .lastJoinDate(lastJoinDate)
+                .build());
+    }
+
     private Board createBoard(Member member) {
         return boardRepository.save(Board.builder()
                 .member(member)
@@ -989,6 +1103,12 @@ class ChatFacadeServiceTest {
     private void blindMember(Member member) {
         member.updateBlind(true);
         memberRepository.save(member);
+    }
+
+    private void updateLastChat(Chatroom chatroom, Chat chat) {
+        chatroom.updateLastChatId(chat.getId());
+        chatroom.updateLastChatAt(chat.getCreatedAt());
+        chatroomRepository.save(chatroom);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/chat/ChatFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/chat/ChatFacadeServiceTest.java
@@ -616,6 +616,14 @@ class ChatFacadeServiceTest {
             List<Chat> chats = chatRepository.findByChatroomIdAndFromMemberId(chatroom.getId(), member.getId());
             assertThat(chats).hasSize(1);
 
+            // chatroom의 lastChat, lastChatAt 업데이트 검증
+            Chatroom updatedChatroom = chatroomRepository.findById(chatroom.getId()).orElseThrow();
+
+            Chat lastChat = chats.get(chats.size() - 1);
+            assertThat(updatedChatroom.getLastChatAt()).isCloseTo(lastChat.getCreatedAt(),
+                    within(1, ChronoUnit.SECONDS));
+            assertThat(updatedChatroom.getLastChatId()).isEqualTo(lastChat.getId());
+
             // 시스템 메시지 저장 되었는지 검증
             if (systemMessage) {
                 List<Chat> systemChats = chatRepository.findByChatroomIdAndFromMemberId(chatroom.getId(),
@@ -751,6 +759,7 @@ class ChatFacadeServiceTest {
 
             assertThat(result).isEmpty();
         }
+
     }
 
     @Nested
@@ -851,6 +860,7 @@ class ChatFacadeServiceTest {
             assertThat(memberChatroom.getLastViewDate()).isNotNull();
             assertThat(memberChatroom.getLastViewDate()).isCloseTo(chat.getCreatedAt(), within(1, ChronoUnit.MILLIS));
         }
+
     }
 
     @Nested
@@ -901,6 +911,7 @@ class ChatFacadeServiceTest {
                     chatroom.getId()).orElseThrow();
             assertThat(memberChatroom.getLastJoinDate()).isNull();
         }
+
     }
 
     private void assertEnterChatroomResponse(EnterChatroomResponse response, Chatroom chatroom, Member targetMember) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
@@ -123,28 +123,27 @@ class BlockRepositoryTest extends RepositoryTestSupport {
         // given
         List<Long> targetMemberIds = new ArrayList<>();
 
-        // 회원 9명 차단
-        List<Member> blockedMembers = new ArrayList<>();
+        // 회원 9명이 나를 차단
+        List<Member> blockerMembers = new ArrayList<>();
         for (int i = 1; i <= 9; i++) {
-            Member blocked = createMember("member" + i + "@gmail.com", "member" + i);
-            blockMember(blocker, blocked);
-            targetMemberIds.add(blocked.getId());
-            blockedMembers.add(blocked);
+            Member blocker = createMember("member" + i + "@gmail.com", "member" + i);
+            blockMember(blocker, member);
+            targetMemberIds.add(blocker.getId());
         }
 
-        // 회원 1명 차단하지 않음
-        Member notBlocked = createMember("notBlocked@gmail.com", "notBlocked");
-        targetMemberIds.add(notBlocked.getId());
+        // 회원 1명 나를 차단하지 않음
+        Member notBlocker = createMember("notBlocked@gmail.com", "notBlocked");
+        targetMemberIds.add(notBlocker.getId());
 
         // when
-        Map<Long, Boolean> blockedMap = blockRepository.isBlockedBatch(targetMemberIds, blocker.getId());
+        Map<Long, Boolean> blockedMap = blockRepository.isBlockedByTargetMembersBatch(targetMemberIds, member.getId());
 
         // then
         assertThat(blockedMap).hasSize(targetMemberIds.size());
-        for (Member blocked : blockedMembers) {
-            assertThat(blockedMap.get(blocked.getId())).isTrue();
+        for (Member blocker : blockerMembers) {
+            assertThat(blockedMap.get(blocker.getId())).isTrue();
         }
-        assertThat(blockedMap.get(notBlocked.getId())).isFalse();
+        assertThat(blockedMap.get(notBlocker.getId())).isFalse();
     }
 
     private Block blockMember(Member blocker, Member blocked) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
@@ -129,6 +129,7 @@ class BlockRepositoryTest extends RepositoryTestSupport {
             Member blocker = createMember("member" + i + "@gmail.com", "member" + i);
             blockMember(blocker, member);
             targetMemberIds.add(blocker.getId());
+            blockerMembers.add(blocker);
         }
 
         // 회원 1명 나를 차단하지 않음

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/block/BlockRepositoryTest.java
@@ -1,9 +1,9 @@
 package com.gamegoo.gamegoo_v2.repository.block;
 
-import com.gamegoo.gamegoo_v2.social.block.domain.Block;
-import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.repository.RepositoryTestSupport;
+import com.gamegoo.gamegoo_v2.social.block.domain.Block;
+import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,6 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -111,6 +115,36 @@ class BlockRepositoryTest extends RepositoryTestSupport {
             assertThat(blockedMembers.isLast()).isTrue();
         }
 
+    }
+
+    @DisplayName("회원 차단 여부 배치 조회")
+    @Test
+    void isBlockedBatch() {
+        // given
+        List<Long> targetMemberIds = new ArrayList<>();
+
+        // 회원 9명 차단
+        List<Member> blockedMembers = new ArrayList<>();
+        for (int i = 1; i <= 9; i++) {
+            Member blocked = createMember("member" + i + "@gmail.com", "member" + i);
+            blockMember(blocker, blocked);
+            targetMemberIds.add(blocked.getId());
+            blockedMembers.add(blocked);
+        }
+
+        // 회원 1명 차단하지 않음
+        Member notBlocked = createMember("notBlocked@gmail.com", "notBlocked");
+        targetMemberIds.add(notBlocked.getId());
+
+        // when
+        Map<Long, Boolean> blockedMap = blockRepository.isBlockedBatch(targetMemberIds, blocker.getId());
+
+        // then
+        assertThat(blockedMap).hasSize(targetMemberIds.size());
+        for (Member blocked : blockedMembers) {
+            assertThat(blockedMap.get(blocked.getId())).isTrue();
+        }
+        assertThat(blockedMap.get(notBlocked.getId())).isFalse();
     }
 
     private Block blockMember(Member blocker, Member blocked) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/chat/ChatRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/chat/ChatRepositoryTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -326,9 +327,9 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createMemberChatroom(targetMember, chatroom);
 
             // 읽은 메시지 생성
-            createChatWithCreatedAt(member, "old message", chatroom, now.minusMinutes(20));
-            createChatWithCreatedAt(member, "old message", chatroom, now.minusMinutes(20).plusSeconds(1));
-            createChatWithCreatedAt(member, "old message", chatroom, now.minusMinutes(20).plusSeconds(2));
+            createChatWithCreatedAt(targetMember, "old message", chatroom, now.minusMinutes(20));
+            createChatWithCreatedAt(targetMember, "old message", chatroom, now.minusMinutes(20).plusSeconds(1));
+            createChatWithCreatedAt(targetMember, "old message", chatroom, now.minusMinutes(20).plusSeconds(2));
 
             // when
             int result = chatRepository.countUnreadChats(chatroom.getId(), member.getId());
@@ -347,9 +348,9 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createMemberChatroom(targetMember, chatroom);
 
             // 안읽은 메시지 생성
-            createChatWithCreatedAt(member, "old message", chatroom, now.plusMinutes(20));
-            createChatWithCreatedAt(member, "old message", chatroom, now.plusMinutes(20).plusSeconds(1));
-            createChatWithCreatedAt(member, "old message", chatroom, now.plusMinutes(20).plusSeconds(2));
+            createChatWithCreatedAt(targetMember, "old message", chatroom, now.plusMinutes(20));
+            createChatWithCreatedAt(targetMember, "old message", chatroom, now.plusMinutes(20).plusSeconds(1));
+            createChatWithCreatedAt(targetMember, "old message", chatroom, now.plusMinutes(20).plusSeconds(2));
 
             // when
             int result = chatRepository.countUnreadChats(chatroom.getId(), member.getId());
@@ -358,6 +359,39 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             assertThat(result).isEqualTo(3);
         }
 
+    }
+
+    @DisplayName("안읽은 메시지 개수 배치 조회")
+    @Test
+    void countUnreadChatsBatch() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime lastJoinDate = now.minusDays(1);
+
+        // chatroom1 및 메시지 생성
+        Chatroom chatroom1 = createChatroom();
+        createMemberChatroom(member, chatroom1, now, lastJoinDate);
+        createMemberChatroom(targetMember, chatroom1, now, lastJoinDate);
+
+        createChatWithCreatedAt(targetMember, "old message", chatroom1, now.plusMinutes(20));
+        createChatWithCreatedAt(targetMember, "old message", chatroom1, now.plusMinutes(20).plusSeconds(1));
+        createChatWithCreatedAt(targetMember, "old message", chatroom1, now.plusMinutes(20).plusSeconds(2));
+
+        // chatroom2 생성
+        Member targetMember2 = createMember("targetMember2@gmail.com", "targetMember2");
+        Chatroom chatroom2 = createChatroom();
+        createMemberChatroom(member, chatroom2);
+        createMemberChatroom(targetMember2, chatroom2);
+
+        List<Long> chatroomIds = List.of(chatroom1.getId(), chatroom2.getId());
+
+        // when
+        Map<Long, Integer> unreadCountMap = chatRepository.countUnreadChatsBatch(chatroomIds, member.getId());
+
+        // then
+        assertThat(unreadCountMap).hasSize(2);
+        assertThat(unreadCountMap.get(chatroom1.getId())).isEqualTo(3);
+        assertThat(unreadCountMap.get(chatroom2.getId())).isEqualTo(0);
     }
 
     private Chatroom createChatroom() {

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/chat/ChatRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/chat/ChatRepositoryTest.java
@@ -80,8 +80,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             }
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -118,8 +117,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             }
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -148,8 +146,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createChatWithCreatedAt(member, "new message 3", chatroom, now.minusMinutes(5).plusSeconds(2));
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -179,8 +176,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createChatWithCreatedAt(member, "new message 3", chatroom, lastJoinDate.plusMinutes(3));
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -207,8 +203,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             Chat memberSystemChat = createSystemChat(member, chatroom, 0);
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -228,8 +223,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createMemberChatroom(targetMember, chatroom);
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findRecentChats(chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             assertThat(chatSlice).isEmpty();
@@ -257,8 +251,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             }
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findChatsByCursor(null, chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findChatsByCursor(null, chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -288,8 +281,8 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             Long cursor = chatList.get(20).getTimestamp();
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findChatsByCursor(cursor, chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findChatsByCursor(cursor, chatroom.getId(), member.getId(),
+                    PAGE_SIZE);
 
             // then
             List<Chat> chats = chatSlice.getContent();
@@ -310,8 +303,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createMemberChatroom(targetMember, chatroom);
 
             // when
-            Slice<Chat> chatSlice = chatRepository.findChatsByCursor(null, chatroom.getId(), memberChatroom.getId(),
-                    member.getId(), PAGE_SIZE);
+            Slice<Chat> chatSlice = chatRepository.findChatsByCursor(null, chatroom.getId(), member.getId(), PAGE_SIZE);
 
             // then
             assertThat(chatSlice).isEmpty();
@@ -339,7 +331,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createChatWithCreatedAt(member, "old message", chatroom, now.minusMinutes(20).plusSeconds(2));
 
             // when
-            int result = chatRepository.countUnreadChats(chatroom.getId(), memberChatroom.getId(), member.getId());
+            int result = chatRepository.countUnreadChats(chatroom.getId(), member.getId());
 
             // then
             assertThat(result).isEqualTo(0);
@@ -360,7 +352,7 @@ public class ChatRepositoryTest extends RepositoryTestSupport {
             createChatWithCreatedAt(member, "old message", chatroom, now.plusMinutes(20).plusSeconds(2));
 
             // when
-            int result = chatRepository.countUnreadChats(chatroom.getId(), memberChatroom.getId(), member.getId());
+            int result = chatRepository.countUnreadChats(chatroom.getId(), member.getId());
 
             // then
             assertThat(result).isEqualTo(3);

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/chat/MemberChatroomRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/chat/MemberChatroomRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.gamegoo.gamegoo_v2.repository.chat;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
+import com.gamegoo.gamegoo_v2.chat.domain.MemberChatroom;
+import com.gamegoo.gamegoo_v2.chat.repository.ChatroomRepository;
+import com.gamegoo.gamegoo_v2.chat.repository.MemberChatroomRepository;
+import com.gamegoo.gamegoo_v2.repository.RepositoryTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemberChatroomRepositoryTest extends RepositoryTestSupport {
+
+    @Autowired
+    private ChatroomRepository chatroomRepository;
+
+    @Autowired
+    private MemberChatroomRepository memberChatroomRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberChatroomRepository.deleteAllInBatch();
+        chatroomRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("채팅 상대 회원 배치 조회")
+    @Test
+    void findTargetMembersBatch() {
+        // given
+        List<Long> chatroomIds = new ArrayList<>();
+        List<Member> targetMembers = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            Member targetMember = createMember("targetMember" + i + "@gmail.com", "targetMember" + i);
+            Chatroom chatroom = createChatroom();
+            createMemberChatroom(member, chatroom);
+            createMemberChatroom(targetMember, chatroom);
+            chatroomIds.add(chatroom.getId());
+            targetMembers.add(targetMember);
+        }
+
+        // when
+        Map<Long, Member> targetMemberMap = memberChatroomRepository.findTargetMembersBatch(chatroomIds,
+                member.getId());
+
+        // then
+        assertThat(targetMemberMap).hasSize(chatroomIds.size());
+        for (Member targetMember : targetMembers) {
+            assertThat(targetMember).isIn(targetMemberMap.values());
+        }
+    }
+
+    private Chatroom createChatroom() {
+        return em.persist(Chatroom.builder()
+                .uuid(UUID.randomUUID().toString())
+                .build());
+    }
+
+    private MemberChatroom createMemberChatroom(Member member, Chatroom chatroom) {
+        return em.persist(MemberChatroom.builder()
+                .chatroom(chatroom)
+                .member(member)
+                .lastViewDate(null)
+                .lastJoinDate(null)
+                .build());
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/friend/FriendRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/friend/FriendRepositoryTest.java
@@ -1,9 +1,9 @@
 package com.gamegoo.gamegoo_v2.repository.friend;
 
-import com.gamegoo.gamegoo_v2.social.friend.domain.Friend;
-import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRepository;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.repository.RepositoryTestSupport;
+import com.gamegoo.gamegoo_v2.social.friend.domain.Friend;
+import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Slice;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -142,7 +143,8 @@ class FriendRepositoryTest extends RepositoryTestSupport {
             assertThat(friendSlice.hasNext()).isFalse();
             List<String> orderedGameName = Arrays.asList("가", "가가", "가a", "가aa", "가a1", "가1", "가10", "가2", "a", "123");
             for (int i = 0; i < orderedGameName.size(); i++) {
-                assertThat(friendSlice.getContent().get(i).getToMember().getGameName()).isEqualTo(orderedGameName.get(i));
+                assertThat(friendSlice.getContent().get(i).getToMember().getGameName()).isEqualTo(
+                        orderedGameName.get(i));
             }
         }
 
@@ -190,6 +192,36 @@ class FriendRepositoryTest extends RepositoryTestSupport {
             assertThat(friendList).hasSize(3);
         }
 
+    }
+
+    @DisplayName("친구 여부 배치 조회")
+    @Test
+    void isFriendBatch() {
+        // given
+        List<Long> targetMemberIds = new ArrayList<>();
+
+        // 친구 회원 9명 생성
+        List<Member> friendMembers = new ArrayList<>();
+        for (int i = 1; i <= 9; i++) {
+            Member toMember = createMember("member" + i + "@gmail.com", "member" + i);
+            createFriend(member, toMember);
+            friendMembers.add(toMember);
+            targetMemberIds.add(toMember.getId());
+        }
+
+        // 친구가 아닌 회원 1명 생성
+        Member notFriend = createMember("member10@gmail.com", "member10");
+        targetMemberIds.add(notFriend.getId());
+
+        // when
+        Map<Long, Boolean> friendMap = friendRepository.isFriendBatch(member.getId(), targetMemberIds);
+
+        // then
+        assertThat(friendMap).hasSize(targetMemberIds.size());
+        for (Member friend : friendMembers) {
+            assertThat(friendMap.get(friend.getId())).isTrue();
+        }
+        assertThat(friendMap.get(notFriend.getId())).isFalse();
     }
 
     private Friend createFriend(Member fromMember, Member toMember) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/friend/FriendServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/friend/FriendServiceTest.java
@@ -1,0 +1,90 @@
+package com.gamegoo.gamegoo_v2.service.friend;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequest;
+import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRequestRepository;
+import com.gamegoo.gamegoo_v2.social.friend.service.FriendService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class FriendServiceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    FriendRequestRepository friendRequestRepository;
+
+    @Autowired
+    FriendService friendService;
+
+    @AfterEach
+    void tearDown() {
+        friendRequestRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("친구 요청 배치 조회")
+    @Test
+    void getFriendRequestMemberIdBatch() {
+        // given
+        List<Long> targetMemberIds = new ArrayList<>();
+        Member member = createMember("test@gmail.com", "member");
+
+        // member -> targetMember1 친구 요청 생성
+        Member targetMember1 = createMember("test@gmail.com", "member1");
+        friendRequestRepository.save(FriendRequest.create(member, targetMember1));
+        targetMemberIds.add(targetMember1.getId());
+
+        // targetMember2 -> member 친구 요청 생성
+        Member targetMember2 = createMember("test2@gmail.com", "member2");
+        friendRequestRepository.save(FriendRequest.create(targetMember2, member));
+        targetMemberIds.add(targetMember2.getId());
+
+        // targetMember3 생성
+        Member targetMember3 = createMember("test3@gmail.com", "member3");
+        targetMemberIds.add(targetMember3.getId());
+
+        // when
+        Map<Long, Long> friendRequestMemberIdMap = friendService.getFriendRequestMemberIdBatch(member,
+                targetMemberIds);
+
+        // then
+        assertThat(friendRequestMemberIdMap.get(targetMember1.getId())).isEqualTo(member.getId());
+        assertThat(friendRequestMemberIdMap.get(targetMember2.getId())).isEqualTo(targetMember2.getId());
+        assertThat(friendRequestMemberIdMap.get(targetMember3.getId())).isNull();
+    }
+
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 채팅방 목록 조회 API 구현 및 테스트

## ⏳ 작업 상세 내용

- [x] chatroom 엔티티에 lastChatId, lastChatAt 필드 추가
- [x] 기존 커스텀 쿼리에서 memberChatroomId 파라미터 제거
- [x] 안읽은 메시지 개수 배치 조회 메소드 구현 및 테스트
- [x] 채팅 상대 회원 배치 조회 메소드 구현 및 테스트
- [x] 친구 여부 배치 조회 메소드 구현 및 테스트
- [x] 친구 요청 전송한 회원 id 배치 조회 메소드 구현 및 테스트
- [x] 상대 회원에게 차단 당했는지 여부 배치 조회 메소드 구현 및 테스트
- [x] id로 chat 엔티티 배치 조회 메소드 구현 및 테스트
- [x] 채팅방 목록 조회 API 구현
- [x] 채팅방 목록 조회 통합 테스트
- [x] 채팅방 목록 조회 API 컨트롤러 테스트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] v1에서는 채팅방 목록 조회 시 해당 채팅방의 마지막 메시지 시각 내림차순으로 정렬한 후에 페이징을 했어야해서 모든 채팅방마다 각 채팅방의 마지막 메시지를 서브쿼리로 조회했었는데, 이 부분을 v2에서는 채팅방 엔티티 자체가 마지막 메시지 시각, 마지막 메시지 id를 갖고있도록 수정했습니다. 새로운 채팅 등록 시에 계속 이 값들을 업데이트해야 하는 부담이 있지만 조회를 더 편리하게 하는게 이득이라고 생각했습니다..!
- [x] v1에서는 채팅방 list를 조회한 다음, list를 돌면서 각 채팅방에 대해 
        상대 회원 조회
        채팅방 엔티티 조회
        가장 마지막 채팅 메시지 조회
        안읽은 메시지 개수 조회
        상대 회원과의 친구 여부 조회
        상대 회원에게 차단 당했는지 여부 조회
        두 회원 사이 친구 요청 보낸 회원의 id 조회
       이렇게 쿼리를 각각 실행하다보니 채팅방 목록 조회 요청 한 번 당 거의 8~90번의 쿼리가 실행되고 있었더라구요..
       이걸 v2에서는 배치 조회로 각각 딱 한 번의 쿼리로 조회해오고 Map에 저장 -> Map에서 값을 뽑아서 dto 생성하도록 변경했습니다. 이렇게 하니까 이제는 쿼리를 7번만 실행하고 있습니다.
- [x] 채팅방 목록 조회는 v1에서는 10개씩 페이징 -> v2에서 현재는 페이징 없이 전체 조회 이렇게 구현했는데,, 채팅방 목록 조회에 페이징이 필요할지 아직 고민입니다.....! 이론상 채팅방 목록은 전체 회원 수 만큼 생길 수 있는데 페이징을 그래도 하는게 나을까요...?!
        

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
