### PR TITLE
[Feat/116] 매칭을 통한 채팅방 시작 메소드 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
@@ -1,0 +1,71 @@
+package com.gamegoo.gamegoo_v2.matching.service;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
+import com.gamegoo.gamegoo_v2.chat.service.ChatCommandService;
+import com.gamegoo.gamegoo_v2.chat.service.ChatQueryService;
+import com.gamegoo.gamegoo_v2.core.common.validator.BlockValidator;
+import com.gamegoo.gamegoo_v2.core.common.validator.MemberValidator;
+import com.gamegoo.gamegoo_v2.core.exception.ChatException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchingFacadeService {
+
+    private final ChatQueryService chatQueryService;
+    private final ChatCommandService chatCommandService;
+    private final MemberValidator memberValidator;
+    private final BlockValidator blockValidator;
+
+    /**
+     * 두 회원 사이 매칭을 통한 채팅방 시작 Facade 메소드
+     *
+     * @param member1 회원
+     * @param member2 회원
+     * @return 채팅방 uuid
+     */
+    @Transactional
+    public String startChatroomByMatching(Member member1, Member member2) {
+        memberValidator.throwIfEqual(member1, member2);
+
+        // 탈퇴하지 않았는지 검증
+        memberValidator.throwIfBlind(member1);
+        memberValidator.throwIfBlind(member2);
+
+        // 서로의 차단 여부 검증
+        validateBlockStatus(member1, member2);
+
+        // 채팅방 조회, 생성 및 입장 처리
+        Chatroom chatroom = chatQueryService.findExistingChatroom(member1, member2)
+                .orElseGet(() -> chatCommandService.createChatroom(member1, member2));
+
+        chatCommandService.updateLastJoinDate(member1, chatroom.getId(), LocalDateTime.now());
+        chatCommandService.updateLastJoinDate(member2, chatroom.getId(), LocalDateTime.now());
+
+        // 매칭 시스템 메시지 생성
+        chatCommandService.createMatchingSystemChat(member1, member2, chatroom);
+
+        return chatroom.getUuid();
+    }
+
+    /**
+     * 두 회원의 서로 차단 여부 검증
+     *
+     * @param member1 회원
+     * @param member2 회원
+     */
+    private void validateBlockStatus(Member member1, Member member2) {
+        blockValidator.throwIfBlocked(member1, member2, ChatException.class,
+                ErrorCode.CHAT_START_FAILED_TARGET_IS_BLOCKED);
+        blockValidator.throwIfBlocked(member2, member1, ChatException.class,
+                ErrorCode.CHAT_START_FAILED_BLOCKED_BY_TARGET);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
@@ -1,10 +1,10 @@
 package com.gamegoo.gamegoo_v2.notification.controller;
 
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationCursorListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
@@ -33,7 +33,7 @@ public class NotificationController {
     @Operation(summary = "알림 읽음 처리 API", description = "특정 알림을 읽음 처리하는 API 입니다.")
     @Parameter(name = "notificationId", description = "읽음 처리할 알림의 id 입니다.")
     @PatchMapping("/{notificationId}")
-    public ApiResponse<ReadNotificationResponse> getTotalNotificationList(
+    public ApiResponse<ReadNotificationResponse> readNotification(
             @PathVariable(name = "notificationId") Long notificationId, @AuthMember Member member) {
         return ApiResponse.ok(notificationFacadeService.readNotification(member, notificationId));
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/matching/MatchingFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/matching/MatchingFacadeServiceTest.java
@@ -1,0 +1,262 @@
+package com.gamegoo.gamegoo_v2.integration.matching;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.chat.domain.Chat;
+import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
+import com.gamegoo.gamegoo_v2.chat.domain.MemberChatroom;
+import com.gamegoo.gamegoo_v2.chat.domain.SystemMessageType;
+import com.gamegoo.gamegoo_v2.chat.repository.ChatRepository;
+import com.gamegoo.gamegoo_v2.chat.repository.ChatroomRepository;
+import com.gamegoo.gamegoo_v2.chat.repository.MemberChatroomRepository;
+import com.gamegoo.gamegoo_v2.core.exception.ChatException;
+import com.gamegoo.gamegoo_v2.core.exception.MemberException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.core.exception.common.GlobalException;
+import com.gamegoo.gamegoo_v2.external.socket.SocketService;
+import com.gamegoo.gamegoo_v2.matching.service.MatchingFacadeService;
+import com.gamegoo.gamegoo_v2.social.block.domain.Block;
+import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class MatchingFacadeServiceTest {
+
+    @MockitoSpyBean
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private ChatroomRepository chatroomRepository;
+
+    @Autowired
+    private MemberChatroomRepository memberChatroomRepository;
+
+    @Autowired
+    private ChatRepository chatRepository;
+
+    @Autowired
+    private MatchingFacadeService matchingFacadeService;
+
+    @MockitoBean
+    private SocketService socketService;
+
+    private Member member;
+    private Member targetMember;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember("test@gmail.com", "member");
+        targetMember = createMember("target@gmail.com", "targetMember");
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatRepository.deleteAllInBatch();
+        memberChatroomRepository.deleteAllInBatch();
+        chatroomRepository.deleteAllInBatch();
+        blockRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("매칭을 통한 채팅방 시작")
+    class StartChatroomByMatchingTest {
+
+        @DisplayName("실패: 두 회원이 동일한 경우 예외가 발생한다.")
+        @Test
+        void startChatroomByMatching_shouldThrownWhenTargetMemberIsSelf() {
+            // when // then
+            assertThatThrownBy(() -> matchingFacadeService.startChatroomByMatching(member, member))
+                    .isInstanceOf(GlobalException.class);
+        }
+
+        @DisplayName("실패: 회원이 탈퇴한 경우 예외가 발생한다.")
+        @Test
+        void startChatroomByMatching_shouldThrownWhenMemberIsBlind() {
+            // given
+            blindMember(targetMember);
+
+            // when // then
+            assertThatThrownBy(() -> matchingFacadeService.startChatroomByMatching(member, targetMember))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage());
+        }
+
+        @DisplayName("실패: 상대 회원을 차단한 경우 예외가 발생한다.")
+        @Test
+        void startChatroomByMatching_shouldThrownWhenTargetIsBlocked() {
+            // given
+            blockMember(member, targetMember);
+
+            // when // then
+            assertThatThrownBy(() -> matchingFacadeService.startChatroomByMatching(member, targetMember))
+                    .isInstanceOf(ChatException.class)
+                    .hasMessage(ErrorCode.CHAT_START_FAILED_TARGET_IS_BLOCKED.getMessage());
+        }
+
+        @DisplayName("실패: 상대 회원에게 차단 당한 경우 예외가 발생한다.")
+        @Test
+        void startChatroomByMatching_shouldThrownWhenBlockedByTarget() {
+            // given
+            blockMember(targetMember, member);
+
+            // when // then
+            assertThatThrownBy(() -> matchingFacadeService.startChatroomByMatching(member, targetMember))
+                    .isInstanceOf(ChatException.class)
+                    .hasMessage(ErrorCode.CHAT_START_FAILED_BLOCKED_BY_TARGET.getMessage());
+        }
+
+        @DisplayName("성공: 기존 채팅방이 존재하는 경우")
+        @Test
+        void startChatroomByMatchingSucceedsWhenChatroomExists() {
+            // given
+            Chatroom chatroom = createChatroom();
+
+            LocalDateTime lastJoinDate = LocalDateTime.now().minusDays(1);
+            createMemberChatroom(member, chatroom, null);
+            createMemberChatroom(targetMember, chatroom, lastJoinDate);
+
+            Member systemMember = createMember("systemMember@gmail.com", "systemMember");
+            given(memberRepository.findById(0L)).willReturn(Optional.of(systemMember));
+
+            // when
+            String result = matchingFacadeService.startChatroomByMatching(member, targetMember);
+
+            // then
+            assertThat(result).isEqualTo(chatroom.getUuid());
+
+            // member의 lastJoinDate 업데이트 검증
+            MemberChatroom memberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(member.getId(),
+                    chatroom.getId()).orElseThrow();
+            assertThat(memberChatroom.getLastJoinDate()).isNotNull();
+
+            // socket service 호출 여부 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(socketService, times(1)).joinSocketToChatroom(eq(member.getId()), eq(chatroom.getUuid()));
+            });
+
+            // targetMember의 lastJoinDate 검증
+            MemberChatroom targetMemberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(
+                    targetMember.getId(), chatroom.getId()).orElseThrow();
+            assertThat(targetMemberChatroom.getLastJoinDate()).isCloseTo(lastJoinDate, within(1, ChronoUnit.SECONDS));
+
+            // 매칭 시스템 메시지 생성 검증
+            List<Chat> systemChats = chatRepository.findByChatroomIdAndFromMemberId(chatroom.getId(),
+                    systemMember.getId());
+            assertThat(systemChats).hasSize(2);
+            systemChats.forEach(systemChat -> {
+                assertThat(systemChat.getContents()).isEqualTo(SystemMessageType.MATCH_SUCCESS_MESSAGE.getMessage());
+            });
+        }
+
+        @DisplayName("성공: 기존 채팅방이 존재하지 않는 경우")
+        @Test
+        void startChatroomByMatchingSucceedsWhenChatroomNotExists() {
+            // given
+            Member systemMember = createMember("systemMember@gmail.com", "systemMember");
+            given(memberRepository.findById(0L)).willReturn(Optional.of(systemMember));
+
+            // when
+            String result = matchingFacadeService.startChatroomByMatching(member, targetMember);
+
+            // then
+            Chatroom chatroom = chatroomRepository.findByUuid(result).orElseThrow();
+
+            // lastJoinDate 업데이트 검증
+            MemberChatroom memberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(member.getId(),
+                    chatroom.getId()).orElseThrow();
+            assertThat(memberChatroom.getLastJoinDate()).isNotNull();
+
+            MemberChatroom targetMemberChatroom = memberChatroomRepository.findByMemberIdAndChatroomId(
+                    targetMember.getId(), chatroom.getId()).orElseThrow();
+            assertThat(targetMemberChatroom.getLastJoinDate()).isNotNull();
+
+            // socket service 호출 여부 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(socketService, times(2)).joinSocketToChatroom(any(Long.class), eq(chatroom.getUuid()));
+            });
+
+            // 매칭 시스템 메시지 생성 검증
+            List<Chat> systemChats = chatRepository.findByChatroomIdAndFromMemberId(chatroom.getId(),
+                    systemMember.getId());
+            assertThat(systemChats).hasSize(2);
+            systemChats.forEach(systemChat -> {
+                assertThat(systemChat.getContents()).isEqualTo(SystemMessageType.MATCH_SUCCESS_MESSAGE.getMessage());
+            });
+        }
+
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private Chatroom createChatroom() {
+        return chatroomRepository.save(Chatroom.builder()
+                .uuid(UUID.randomUUID().toString())
+                .build());
+    }
+
+    private MemberChatroom createMemberChatroom(Member member, Chatroom chatroom, LocalDateTime lastJoinDate) {
+        return memberChatroomRepository.save(MemberChatroom.builder()
+                .chatroom(chatroom)
+                .member(member)
+                .lastViewDate(null)
+                .lastJoinDate(lastJoinDate)
+                .build());
+    }
+
+    private void blindMember(Member member) {
+        member.updateBlind(true);
+        memberRepository.save(member);
+    }
+
+    private Block blockMember(Member member, Member targetMember) {
+        return blockRepository.save(Block.create(member, targetMember));
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 매칭을 통한 채팅방 시작 메소드 구현 및 테스트

## ⏳ 작업 상세 내용

- [x] 매칭을 통한 채팅방 시작 facade 메소드 구현
- [x] 매칭을 통한 채팅방 시작 통합 테스트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 매칭 success 로직에서 마지막에 채팅방 시작까지 해줘야해서 MatchingFacadeService에 startChatroomByMatching 메소드로 구현했습니다..! 나중에 매칭 success facade 메소드 만드실때 사용하시면 될 것 같아요

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
