### PR TITLE
[Feat/129] 매너평가 등록 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -45,7 +45,7 @@ public class Member extends BaseDateTimeEntity {
     @Column(nullable = false)
     private int mannerLevel = 1;
 
-    private int mannerScore = 0;
+    private Integer mannerScore;
 
     @Column(nullable = false)
     private boolean blind = false;
@@ -157,6 +157,16 @@ public class Member extends BaseDateTimeEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public Integer updateMannerScore(int mannerScore) {
+        this.mannerScore = mannerScore;
+        return this.mannerScore;
+    }
+
+    public int updateMannerLevel(int mannerLevel) {
+        this.mannerLevel = mannerLevel;
+        return this.mannerLevel;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/event/MannerLevelDownEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/event/MannerLevelDownEvent.java
@@ -1,0 +1,13 @@
+package com.gamegoo.gamegoo_v2.core.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MannerLevelDownEvent {
+
+    Long memberId;
+    int mannerLevel;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/event/MannerLevelUpEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/event/MannerLevelUpEvent.java
@@ -1,0 +1,13 @@
+package com.gamegoo.gamegoo_v2.core.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MannerLevelUpEvent {
+
+    Long memberId;
+    int mannerLevel;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/event/MannerRatingInsertEvent.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/event/MannerRatingInsertEvent.java
@@ -1,0 +1,15 @@
+package com.gamegoo.gamegoo_v2.core.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MannerRatingInsertEvent {
+
+    Long memberId;
+    List<Long> mannerKeywordIdList;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/event/listener/MannerRatingEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/event/listener/MannerRatingEventListener.java
@@ -1,0 +1,69 @@
+package com.gamegoo.gamegoo_v2.core.event.listener;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
+import com.gamegoo.gamegoo_v2.core.event.MannerLevelDownEvent;
+import com.gamegoo.gamegoo_v2.core.event.MannerLevelUpEvent;
+import com.gamegoo.gamegoo_v2.core.event.MannerRatingInsertEvent;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MannerRatingEventListener {
+
+    private final NotificationService notificationService;
+    private final MemberService memberService;
+
+    @Async
+    @Transactional
+    @EventListener
+    public void handleMannerRatingInsertEvent(MannerRatingInsertEvent event) {
+        try {
+            Member member = memberService.findMemberById(event.getMemberId());
+
+            // 매너 평가 등록 알림 생성
+            notificationService.createMannerRatingNotification(event.getMannerKeywordIdList(), member);
+        } catch (Exception e) {
+            log.error("Failed to create manner rating notifications", e);
+        }
+    }
+
+    @Async
+    @Transactional
+    @EventListener
+    public void handleMannerLevelUpEvent(MannerLevelUpEvent event) {
+        try {
+            Member member = memberService.findMemberById(event.getMemberId());
+
+            // 매너 레벨 상승 알림 생성
+            notificationService.createMannerLevelNotification(NotificationTypeTitle.MANNER_LEVEL_UP, member,
+                    event.getMannerLevel());
+        } catch (Exception e) {
+            log.error("Failed to create manner level up notifications", e);
+        }
+    }
+
+    @Async
+    @Transactional
+    @EventListener
+    public void handlerMannerLevelDownEvent(MannerLevelDownEvent event) {
+        try {
+            Member member = memberService.findMemberById(event.getMemberId());
+
+            // 매너 레벨 하락 알림 생성
+            notificationService.createMannerLevelNotification(NotificationTypeTitle.MANNER_LEVEL_DOWN, member,
+                    event.getMannerLevel());
+        } catch (Exception e) {
+            log.error("Failed to create manner level down notifications", e);
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/MannerException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/MannerException.java
@@ -1,0 +1,12 @@
+package com.gamegoo.gamegoo_v2.core.exception;
+
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.core.exception.common.GlobalException;
+
+public class MannerException extends GlobalException {
+
+    public MannerException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
@@ -128,6 +128,12 @@ public enum ErrorCode {
     BOARD_GAME_STYLE_NOT_FOUND(NOT_FOUND, "BOARD_406", "게임 스타일을 찾을 수 없습니다."),
     BOARD_GAME_MODE_BAD_REQUEST(BAD_REQUEST, "BOARD_406", "게임모드 값은 1~4만 가능합니다."),
 
+    /**
+     * 매너평가 관련 에러
+     */
+    MANNER_KEYWORD_INVALID(BAD_REQUEST, "MANNER_401", "잘못된 매너 키워드 값입니다."),
+    MANNER_KEYWORD_NOT_FOUND(NOT_FOUND, "MANNER_402", "매너 키워드를 찾을 수 없습니다."),
+    MANNER_RATING_EXISTS(BAD_REQUEST, "MANNER_403", "매너/비매너 평가는 최초 1회만 가능합니다."),
 
     /**
      * socket 서버 관련 에러

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/service/NotificationService.java
@@ -9,6 +9,7 @@ import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,6 +27,7 @@ public class NotificationService {
 
     private final NotificationTypeRepository notificationTypeRepository;
     private final NotificationRepository notificationRepository;
+    private final MannerKeywordRepository mannerKeywordRepository;
 
     private static final String PLACEHOLDER = "n";
     private final static int PAGE_SIZE = 10;
@@ -115,14 +117,17 @@ public class NotificationService {
     /**
      * 매너 평가 등록됨 알림 생성 메소드
      *
-     * @param mannerKeywordList 매너 키워드 list
-     * @param member            알림 전송 대상 회원
+     * @param mannerKeywordIdList 매너 키워드 id list
+     * @param member              알림 전송 대상 회원
      * @return Notification
      */
     @Transactional
-    public Notification createMannerRatingNotification(List<MannerKeyword> mannerKeywordList, Member member) {
+    public Notification createMannerRatingNotification(List<Long> mannerKeywordIdList, Member member) {
         validateMember(member);
-        validateMannerKeywordList(mannerKeywordList);
+        validateMannerKeywordList(mannerKeywordIdList);
+
+        // 매너 키워드 엔티티 조회
+        List<MannerKeyword> mannerKeywordList = mannerKeywordRepository.findAllById(mannerKeywordIdList);
 
         NotificationType notificationType = findNotificationType(NotificationTypeTitle.MANNER_KEYWORD_RATED);
 
@@ -231,10 +236,10 @@ public class NotificationService {
     /**
      * mannerKeywordList에 키워드가 1개 이상 있는지 검증하는 메소드
      *
-     * @param mannerKeywordList 매너 레벨 키워드 list
+     * @param mannerKeywordIdList 매너 레벨 키워드 id list
      */
-    private void validateMannerKeywordList(List<MannerKeyword> mannerKeywordList) {
-        if (mannerKeywordList.isEmpty()) {
+    private void validateMannerKeywordList(List<Long> mannerKeywordIdList) {
+        if (mannerKeywordIdList.isEmpty()) {
             throw new NotificationException(ErrorCode.NOTIFICATION_METHOD_BAD_REQUEST);
         }
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/scripts/MannerKeywordInitializer.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/scripts/MannerKeywordInitializer.java
@@ -1,0 +1,56 @@
+package com.gamegoo.gamegoo_v2.scripts;
+
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MannerKeywordInitializer implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final MannerKeywordRepository mannerKeywordRepository;
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (isCreateMode(event)) {
+            try {
+                initializeMannerKeywords();
+            } catch (IOException e) {
+                System.out.println(e.getClass());
+            }
+        }
+    }
+
+    private boolean isCreateMode(ApplicationReadyEvent event) {
+        // jpa.hibernate.ddl-auto 값이 create인지 확인
+        String ddlAuto = event.getApplicationContext().getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto");
+        return "create".equalsIgnoreCase(ddlAuto);
+    }
+
+    private void initializeMannerKeywords() throws IOException {
+        List<MannerKeyword> mannerKeywords = new ArrayList<>();
+
+        mannerKeywords.add(MannerKeyword.create("캐리했어요", true));
+        mannerKeywords.add(MannerKeyword.create("1인분 이상은 해요", true));
+        mannerKeywords.add(MannerKeyword.create("욕 안해요", true));
+        mannerKeywords.add(MannerKeyword.create("남탓 안해요", true));
+        mannerKeywords.add(MannerKeyword.create("매너 있어요", true));
+        mannerKeywords.add(MannerKeyword.create("답장 빠름", true));
+        mannerKeywords.add(MannerKeyword.create("탈주", false));
+        mannerKeywords.add(MannerKeyword.create("욕설", false));
+        mannerKeywords.add(MannerKeyword.create("고의 트롤", false));
+        mannerKeywords.add(MannerKeyword.create("대리 사용자", false));
+        mannerKeywords.add(MannerKeyword.create("소환사명 불일치", false));
+        mannerKeywords.add(MannerKeyword.create("답장이 없어요", false));
+
+        mannerKeywordRepository.saveAll(mannerKeywords);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/controller/BlockController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/controller/BlockController.java
@@ -1,12 +1,12 @@
 package com.gamegoo.gamegoo_v2.social.block.controller;
 
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockResponse;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockFacadeService;
-import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
-import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,7 +33,7 @@ public class BlockController {
     @Parameter(name = "memberId", description = "차단할 대상 회원의 id 입니다.")
     @PostMapping("/{memberId}")
     public ApiResponse<BlockResponse> blockMember(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                  @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.blockMember(member, targetMemberId));
     }
 
@@ -41,7 +41,7 @@ public class BlockController {
     @Parameter(name = "page", description = "페이지 번호, 1 이상의 숫자를 입력해 주세요.")
     @GetMapping
     public ApiResponse<BlockListResponse> getBlockList(@ValidPage @RequestParam(name = "page") Integer page,
-            @AuthMember Member member) {
+                                                       @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.getBlockList(member, page));
     }
 
@@ -49,7 +49,7 @@ public class BlockController {
     @Parameter(name = "memberId", description = "차단을 해제할 대상 회원의 id 입니다.")
     @DeleteMapping("/{memberId}")
     public ApiResponse<BlockResponse> unblockMember(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                    @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.unBlockMember(member, targetMemberId));
     }
 
@@ -57,7 +57,7 @@ public class BlockController {
     @Parameter(name = "memberId", description = "목록에서 삭제할 대상 회원의 id 입니다.")
     @DeleteMapping("/delete/{memberId}")
     public ApiResponse<BlockResponse> deleteBlockMember(@PathVariable(name = "memberId") Long targetMemberId,
-            @AuthMember Member member) {
+                                                        @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.deleteBlock(member, targetMemberId));
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -1,0 +1,38 @@
+package com.gamegoo.gamegoo_v2.social.manner.controller;
+
+import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Manner", description = "매너 평가 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/manner")
+public class MannerController {
+
+    private final MannerFacadeService mannerFacadeService;
+
+    @Operation(summary = "매너 평가 등록 API", description = "매너 평가를 등록하는 API 입니다.")
+    @Parameter(name = "memberId", description = "매너 평가를 등록할 대상 회원의 id 입니다.")
+    @PostMapping("/positive/{memberId}")
+    public ApiResponse<MannerInsertResponse> addPositiveMannerRating(
+            @PathVariable(name = "memberId") Long targetMemberId,
+            @Valid @RequestBody MannerInsertRequest request,
+            @AuthMember Member member) {
+        return ApiResponse.ok(mannerFacadeService.insertPositiveMannerRating(member, targetMemberId, request));
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/domain/MannerRating.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/domain/MannerRating.java
@@ -1,7 +1,8 @@
 package com.gamegoo.gamegoo_v2.social.manner.domain;
 
-import com.gamegoo.gamegoo_v2.core.common.BaseDateTimeEntity;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.core.common.BaseDateTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,9 +11,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,7 +31,7 @@ public class MannerRating extends BaseDateTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private boolean isPositive;
+    private boolean positive;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "from_member_id", nullable = false)
@@ -35,5 +41,22 @@ public class MannerRating extends BaseDateTimeEntity {
     @JoinColumn(name = "to_member_id", nullable = false)
     private Member toMember;
 
+    @OneToMany(mappedBy = "mannerRating", cascade = CascadeType.ALL)
+    private List<MannerRatingKeyword> mannerRatingKeywordList = new ArrayList<>();
+
+    public static MannerRating create(Member fromMember, Member toMember, boolean positive) {
+        return MannerRating.builder()
+                .fromMember(fromMember)
+                .toMember(toMember)
+                .positive(positive)
+                .build();
+    }
+
+    @Builder
+    private MannerRating(boolean positive, Member fromMember, Member toMember) {
+        this.positive = positive;
+        this.fromMember = fromMember;
+        this.toMember = toMember;
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/domain/MannerRatingKeyword.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/domain/MannerRatingKeyword.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,5 +31,26 @@ public class MannerRatingKeyword extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manner_keyword_id", nullable = false)
     private MannerKeyword mannerKeyword;
+
+    public static MannerRatingKeyword create(MannerRating mannerRating, MannerKeyword mannerKeyword) {
+        MannerRatingKeyword mannerRatingKeyword = MannerRatingKeyword.builder()
+                .mannerKeyword(mannerKeyword)
+                .build();
+        mannerRatingKeyword.setMannerRating(mannerRating); // 양방향 관계 설정
+        return mannerRatingKeyword;
+    }
+
+    @Builder
+    private MannerRatingKeyword(MannerKeyword mannerKeyword) {
+        this.mannerKeyword = mannerKeyword;
+    }
+
+    public void setMannerRating(MannerRating mannerRating) {
+        if (this.mannerRating != null) {
+            this.mannerRating.getMannerRatingKeywordList().remove(this);
+        }
+        this.mannerRating = mannerRating;
+        this.mannerRating.getMannerRatingKeywordList().add(this);
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/request/MannerInsertRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/request/MannerInsertRequest.java
@@ -1,0 +1,16 @@
+package com.gamegoo.gamegoo_v2.social.manner.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MannerInsertRequest {
+
+    @NotEmpty
+    List<Long> mannerKeywordIdList;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/request/MannerInsertRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/request/MannerInsertRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Builder
 public class MannerInsertRequest {
 
-    @NotEmpty
+    @NotEmpty(message = "매너 키워드 리스트는 비워둘 수 없습니다.")
     List<Long> mannerKeywordIdList;
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerInsertResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerInsertResponse.java
@@ -1,0 +1,25 @@
+package com.gamegoo.gamegoo_v2.social.manner.dto.response;
+
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MannerInsertResponse {
+
+    Long mannerRatingId;
+    Long targetMemberId;
+    List<Long> mannerKeywordIdList;
+
+    public static MannerInsertResponse of(MannerRating mannerRating, List<Long> mannerKeywordIdList) {
+        return MannerInsertResponse.builder()
+                .mannerRatingId(mannerRating.getId())
+                .targetMemberId(mannerRating.getToMember().getId())
+                .mannerKeywordIdList(mannerKeywordIdList)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepository.java
@@ -1,0 +1,8 @@
+package com.gamegoo.gamegoo_v2.social.manner.repository;
+
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRatingKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MannerRatingKeywordRepository extends JpaRepository<MannerRatingKeyword, Long> {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepository.java
@@ -3,6 +3,10 @@ package com.gamegoo.gamegoo_v2.social.manner.repository;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRatingKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MannerRatingKeywordRepository extends JpaRepository<MannerRatingKeyword, Long> {
+
+    List<MannerRatingKeyword> findByMannerRatingId(Long id);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingRepository.java
@@ -1,0 +1,10 @@
+package com.gamegoo.gamegoo_v2.social.manner.repository;
+
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MannerRatingRepository extends JpaRepository<MannerRating, Long> {
+
+    boolean existsByFromMemberIdAndToMemberIdAndPositive(Long fromMemberId, Long toMemberId, boolean positive);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -35,7 +35,7 @@ public class MannerFacadeService {
                 request.getMannerKeywordIdList(), true);
 
         // 매너 점수 및 레벨 업데이트
-        mannerService.updateMannerScoreAndLevel(member, request.getMannerKeywordIdList().size());
+        mannerService.updateMannerScoreAndLevel(targetMember, request.getMannerKeywordIdList().size());
 
         return MannerInsertResponse.of(mannerRating, request.getMannerKeywordIdList());
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -1,0 +1,44 @@
+package com.gamegoo.gamegoo_v2.social.manner.service;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
+import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MannerFacadeService {
+
+    private final MemberService memberService;
+    private final MannerService mannerService;
+
+    /**
+     * 매너 평가 등록 facade 메소드
+     *
+     * @param member         회원
+     * @param targetMemberId 상대 회원 id
+     * @param request        매너 평가 요청
+     * @return MannerInsertResponse
+     */
+    @Transactional
+    public MannerInsertResponse insertPositiveMannerRating(Member member, Long targetMemberId,
+                                                           MannerInsertRequest request) {
+        Member targetMember = memberService.findMemberById(targetMemberId);
+
+        // 매너 평가 등록
+        MannerRating mannerRating = mannerService.insertMannerRating(member, targetMember,
+                request.getMannerKeywordIdList(), true);
+
+        // 매너 점수 및 레벨 업데이트
+        mannerService.updateMannerScoreAndLevel(member, request.getMannerKeywordIdList().size());
+
+        return MannerInsertResponse.of(mannerRating, request.getMannerKeywordIdList());
+    }
+
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
@@ -1,0 +1,172 @@
+package com.gamegoo.gamegoo_v2.social.manner.service;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.core.common.validator.MemberValidator;
+import com.gamegoo.gamegoo_v2.core.event.MannerLevelDownEvent;
+import com.gamegoo.gamegoo_v2.core.event.MannerLevelUpEvent;
+import com.gamegoo.gamegoo_v2.core.event.MannerRatingInsertEvent;
+import com.gamegoo.gamegoo_v2.core.exception.MannerException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRatingKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingKeywordRepository;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MannerService {
+
+    private final MemberValidator memberValidator;
+    private final MannerRatingRepository mannerRatingRepository;
+    private final MannerKeywordRepository mannerKeywordRepository;
+    private final MannerRatingKeywordRepository mannerRatingKeywordRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    private final int MANNER_KEYWORD_ID_MAX = 12;
+    private final int MANNER_KEYWORD_ID_MIN = 1;
+
+    /**
+     * 매너 평가 등록 메소드
+     *
+     * @param member              회원
+     * @param targetMember        대상 회원
+     * @param mannerKeywordIdList 매너키워드 id list
+     * @param isPositive          매너/비매너 평가 여부
+     * @return MannerRating
+     */
+    @Transactional
+    public MannerRating insertMannerRating(Member member, Member targetMember, List<Long> mannerKeywordIdList,
+                                           boolean isPositive) {
+        // 매너 키워드 검증
+        validateMannerInsertRequest(mannerKeywordIdList, isPositive);
+
+        // targetMember로 나 자신을 요청한 경우 검증
+        memberValidator.throwIfEqual(member, targetMember);
+
+        // 상대방의 탈퇴 여부 검증
+        memberValidator.throwIfBlind(targetMember);
+
+        // 매너 평가 최초 여부 검증
+        validateMannerRatingNotExists(member, targetMember, true);
+
+        // 매너 키워드 엔티티 조회
+        List<MannerKeyword> mannerKeywordList = getMannerKeywordList(mannerKeywordIdList);
+
+        // MannerRating 엔티티 생성 및 저장
+        MannerRating mannerRating = MannerRating.create(member, targetMember, true);
+        mannerRatingRepository.save(mannerRating);
+
+        // MannerRatingKeyword 엔티티 생성 및 저장
+        List<MannerRatingKeyword> mannerRatingKeywordList = mannerKeywordList.stream()
+                .map(mannerKeyword -> MannerRatingKeyword.create(mannerRating, mannerKeyword))
+                .toList();
+        mannerRatingKeywordRepository.saveAll(mannerRatingKeywordList);
+
+        // 매너평가 등록됨 알림 생성
+        eventPublisher.publishEvent(new MannerRatingInsertEvent(member.getId(), mannerKeywordIdList));
+
+        return mannerRating;
+    }
+
+    /**
+     * 회원의 매너 점수 및 매너 레벨 업데이트
+     *
+     * @param member 회원
+     * @param score  매너 점수 증가/감소량
+     */
+    @Transactional
+    public void updateMannerScoreAndLevel(Member member, int score) {
+        // 매너 점수 업데이트
+        int currentScore = member.getMannerScore() != null ? member.getMannerScore() : 0;
+        Integer updatedScore = member.updateMannerScore(currentScore + score);
+
+        // 매너 레벨 업데이트
+        int currentLevel = member.getMannerLevel();
+        int updatedLevel = member.updateMannerLevel(calculateMannerLevel(updatedScore));
+
+        // 매너 레벨 알림 생성
+        if (currentLevel < updatedLevel) { // 매너 레벨 상승한 경우
+            eventPublisher.publishEvent(new MannerLevelUpEvent(member.getId(), updatedLevel));
+        } else if (currentLevel > updatedLevel) { // 매너 레벨 하락한 경우
+            eventPublisher.publishEvent(new MannerLevelDownEvent(member.getId(), updatedLevel));
+        }
+    }
+
+    /**
+     * id에 해당하는 매너 키워드 list 조회
+     *
+     * @param mannerKeywordIdList 매너 키워드 id list
+     * @return 매너 키워드 list
+     */
+    private List<MannerKeyword> getMannerKeywordList(List<Long> mannerKeywordIdList) {
+        return mannerKeywordIdList.stream()
+                .map(mannerKeywordId -> mannerKeywordRepository.findById(mannerKeywordId)
+                        .orElseThrow(() -> new MannerException(ErrorCode.MANNER_KEYWORD_NOT_FOUND))
+                ).toList();
+    }
+
+    /**
+     * 매너 키워드 id 값 검증
+     *
+     * @param mannerKeywordIdList 매너 키워드 id list
+     * @param isPositive          매너/비매너 평가 여부
+     */
+    private void validateMannerInsertRequest(List<Long> mannerKeywordIdList, boolean isPositive) {
+        boolean notValid;
+
+        if (isPositive) {
+            notValid = mannerKeywordIdList.stream().anyMatch(id -> id >= 7 || id < MANNER_KEYWORD_ID_MIN);
+        } else {
+            notValid = mannerKeywordIdList.stream().anyMatch(id -> id < 7 || id > MANNER_KEYWORD_ID_MAX);
+        }
+
+        if (notValid) {
+            throw new MannerException(ErrorCode.MANNER_KEYWORD_INVALID);
+        }
+    }
+
+    /**
+     * 회원이 상대 회원에게 등록한 매너 평가가 있는 경우 예외 발생
+     *
+     * @param member       회원
+     * @param targetMember 상대 회원
+     * @param isPositive   매너/비매너평가 여부
+     */
+    private void validateMannerRatingNotExists(Member member, Member targetMember, boolean isPositive) {
+        boolean exists = mannerRatingRepository.existsByFromMemberIdAndToMemberIdAndPositive(member.getId(),
+                targetMember.getId(), isPositive);
+        if (exists) {
+            throw new MannerException(ErrorCode.MANNER_RATING_EXISTS);
+        }
+    }
+
+    /**
+     * 매너 점수를 기반으로 매너 레벨 계산
+     *
+     * @param mannerScore 매너 점수
+     * @return 매너 레벨
+     */
+    private int calculateMannerLevel(int mannerScore) {
+        if (mannerScore < 10) {
+            return 1;
+        } else if (mannerScore < 20) {
+            return 2;
+        } else if (mannerScore < 30) {
+            return 3;
+        } else if (mannerScore < 40) {
+            return 4;
+        } else {
+            return 5;
+        }
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/TestSetup.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/TestSetup.java
@@ -1,0 +1,45 @@
+package com.gamegoo.gamegoo_v2;
+
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SpringBootTest
+public class TestSetup {
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        CommandLineRunner initData(MannerKeywordRepository mannerKeywordRepository) {
+            return args -> {
+                if (mannerKeywordRepository.count() == 0) { // 데이터 중복 방지
+                    List<MannerKeyword> mannerKeywords = new ArrayList<>();
+
+                    mannerKeywords.add(MannerKeyword.create("캐리했어요", true));
+                    mannerKeywords.add(MannerKeyword.create("1인분 이상은 해요", true));
+                    mannerKeywords.add(MannerKeyword.create("욕 안해요", true));
+                    mannerKeywords.add(MannerKeyword.create("남탓 안해요", true));
+                    mannerKeywords.add(MannerKeyword.create("매너 있어요", true));
+                    mannerKeywords.add(MannerKeyword.create("답장 빠름", true));
+                    mannerKeywords.add(MannerKeyword.create("탈주", false));
+                    mannerKeywords.add(MannerKeyword.create("욕설", false));
+                    mannerKeywords.add(MannerKeyword.create("고의 트롤", false));
+                    mannerKeywords.add(MannerKeyword.create("대리 사용자", false));
+                    mannerKeywords.add(MannerKeyword.create("소환사명 불일치", false));
+                    mannerKeywords.add(MannerKeyword.create("답장이 없어요", false));
+
+                    mannerKeywordRepository.saveAll(mannerKeywords);
+                }
+            };
+        }
+
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/TestSetup.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/TestSetup.java
@@ -1,5 +1,8 @@
 package com.gamegoo.gamegoo_v2;
 
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
 import org.springframework.boot.CommandLineRunner;
@@ -7,7 +10,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @SpringBootTest
@@ -17,26 +19,45 @@ public class TestSetup {
     static class TestConfig {
 
         @Bean
-        CommandLineRunner initData(MannerKeywordRepository mannerKeywordRepository) {
+        CommandLineRunner initMannerKeywords(MannerKeywordRepository mannerKeywordRepository) {
             return args -> {
-                if (mannerKeywordRepository.count() == 0) { // 데이터 중복 방지
-                    List<MannerKeyword> mannerKeywords = new ArrayList<>();
-
-                    mannerKeywords.add(MannerKeyword.create("캐리했어요", true));
-                    mannerKeywords.add(MannerKeyword.create("1인분 이상은 해요", true));
-                    mannerKeywords.add(MannerKeyword.create("욕 안해요", true));
-                    mannerKeywords.add(MannerKeyword.create("남탓 안해요", true));
-                    mannerKeywords.add(MannerKeyword.create("매너 있어요", true));
-                    mannerKeywords.add(MannerKeyword.create("답장 빠름", true));
-                    mannerKeywords.add(MannerKeyword.create("탈주", false));
-                    mannerKeywords.add(MannerKeyword.create("욕설", false));
-                    mannerKeywords.add(MannerKeyword.create("고의 트롤", false));
-                    mannerKeywords.add(MannerKeyword.create("대리 사용자", false));
-                    mannerKeywords.add(MannerKeyword.create("소환사명 불일치", false));
-                    mannerKeywords.add(MannerKeyword.create("답장이 없어요", false));
-
+                if (mannerKeywordRepository.count() == 0) {
+                    List<MannerKeyword> mannerKeywords = List.of(
+                            MannerKeyword.create("캐리했어요", true),
+                            MannerKeyword.create("1인분 이상은 해요", true),
+                            MannerKeyword.create("욕 안해요", true),
+                            MannerKeyword.create("남탓 안해요", true),
+                            MannerKeyword.create("매너 있어요", true),
+                            MannerKeyword.create("답장 빠름", true),
+                            MannerKeyword.create("탈주", false),
+                            MannerKeyword.create("욕설", false),
+                            MannerKeyword.create("고의 트롤", false),
+                            MannerKeyword.create("대리 사용자", false),
+                            MannerKeyword.create("소환사명 불일치", false),
+                            MannerKeyword.create("답장이 없어요", false)
+                    );
                     mannerKeywordRepository.saveAll(mannerKeywords);
                 }
+
+            };
+        }
+
+        @Bean
+        CommandLineRunner initNotificationTypes(NotificationTypeRepository notificationTypeRepository) {
+            return args -> {
+                if (notificationTypeRepository.count() == 0) {
+                    List<NotificationType> notificationTypes = List.of(
+                            NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_SEND),
+                            NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED),
+                            NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED),
+                            NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_REJECTED),
+                            NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_UP),
+                            NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_DOWN),
+                            NotificationType.create(NotificationTypeTitle.MANNER_KEYWORD_RATED)
+                    );
+                    notificationTypeRepository.saveAll(notificationTypes);
+                }
+
             };
         }
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
@@ -1,0 +1,99 @@
+package com.gamegoo.gamegoo_v2.controller.manner;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.social.manner.controller.MannerController;
+import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MannerController.class)
+public class MannerControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private MannerFacadeService mannerFacadeService;
+
+    private static final String API_URL_PREFIX = "/api/v2/manner";
+    private static final Long TARGET_MEMBER_ID = 2L;
+
+    @Nested
+    @DisplayName("매너 평가 등록")
+    class AddPositiveMannerRatingTest {
+
+        @DisplayName("실패: 매너 키워드 리스트가 빈 리스트인 경우 에러 응답을 반환한다.")
+        @Test
+        void addPositiveMannerRatingFailedWhenKeywordListIsEmpty() throws Exception {
+            // given
+            List<Long> mannerKeywordIds = List.of();
+
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            MannerInsertResponse response = MannerInsertResponse.builder()
+                    .targetMemberId(TARGET_MEMBER_ID)
+                    .mannerRatingId(1L)
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            given(mannerFacadeService.insertPositiveMannerRating(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(MannerInsertRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/positive/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.message").value("매너 키워드 리스트는 비워둘 수 없습니다."));
+        }
+
+        @DisplayName("성공")
+        @Test
+        void addPositiveMannerRatingSucceeds() throws Exception {
+            // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            MannerInsertResponse response = MannerInsertResponse.builder()
+                    .targetMemberId(TARGET_MEMBER_ID)
+                    .mannerRatingId(1L)
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            given(mannerFacadeService.insertPositiveMannerRating(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(MannerInsertRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/positive/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.targetMemberId").value(TARGET_MEMBER_ID))
+                    .andExpect(jsonPath("$.data.mannerRatingId").value(1L))
+                    .andExpect(jsonPath("$.data.mannerKeywordIdList").isArray());
+        }
+
+    }
+
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/auth/AuthFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/auth/AuthFacadeServiceTest.java
@@ -32,16 +32,16 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class AuthFacadeServiceTest {
+class AuthFacadeServiceTest {
 
     @Autowired
-    MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
-    RefreshTokenRepository refreshTokenRepository;
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Autowired
-    JwtProvider jwtProvider;
+    private JwtProvider jwtProvider;
 
     private Member member;
 
@@ -150,6 +150,7 @@ public class AuthFacadeServiceTest {
     @Nested
     @DisplayName("리프레시 토큰 테스트")
     class RefreshTokenTest {
+
         @DisplayName("리프레시 토큰으로 다른 토큰 업데이트 성공")
         @Test
         void updateToken() {
@@ -190,13 +191,15 @@ public class AuthFacadeServiceTest {
                     .build();
             refreshTokenRepository.save(refreshToken);
 
-            RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest.builder().refreshToken(INVALID_REFRESH_TOKEN).build();
+            RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest.builder().refreshToken(
+                    INVALID_REFRESH_TOKEN).build();
 
             // when
-            assertThatThrownBy(()->authFacadeService.updateToken(refreshTokenRequest))
+            assertThatThrownBy(() -> authFacadeService.updateToken(refreshTokenRequest))
                     .isInstanceOf(JwtAuthException.class)
                     .hasMessage(ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
         }
+
     }
 
     private Member createMember(String email, String gameName, String password) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/auth/PasswordFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/auth/PasswordFacadeServiceTest.java
@@ -23,16 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class PasswordFacadeServiceTest {
+class PasswordFacadeServiceTest {
 
     @Autowired
-    PasswordFacadeService passwordFacadeService;
+    private PasswordFacadeService passwordFacadeService;
 
     @Autowired
-    MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
-    EmailVerifyRecordRepository emailVerifyRecordRepository;
+    private EmailVerifyRecordRepository emailVerifyRecordRepository;
 
     private Member member;
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockFacadeServiceTest.java
@@ -1,21 +1,21 @@
 package com.gamegoo.gamegoo_v2.integration.block;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.core.exception.BlockException;
+import com.gamegoo.gamegoo_v2.core.exception.MemberException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.block.domain.Block;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockFacadeService;
-import com.gamegoo.gamegoo_v2.core.exception.BlockException;
-import com.gamegoo.gamegoo_v2.core.exception.MemberException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.friend.domain.Friend;
 import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequest;
 import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequestStatus;
 import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRepository;
 import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRequestRepository;
-import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
-import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
-import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -108,7 +108,8 @@ class BlockFacadeServiceTest {
 
             // then
             // 차단이 정상적으로 처리되었는지 검증
-            assertThat(blockRepository.existsByBlockerMemberAndBlockedMemberAndDeleted(member, targetMember, false)).isTrue();
+            assertThat(blockRepository.existsByBlockerMemberAndBlockedMemberAndDeleted(member, targetMember,
+                    false)).isTrue();
 
             // 채팅방에서 퇴장 처리 되었는지 검증
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestFacadeServiceTest.java
@@ -1,11 +1,17 @@
 package com.gamegoo.gamegoo_v2.integration.friend;
 
-import com.gamegoo.gamegoo_v2.social.block.domain.Block;
-import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.config.AsyncConfig;
 import com.gamegoo.gamegoo_v2.core.exception.FriendException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.notification.domain.Notification;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
+import com.gamegoo.gamegoo_v2.social.block.domain.Block;
+import com.gamegoo.gamegoo_v2.social.block.repository.BlockRepository;
 import com.gamegoo.gamegoo_v2.social.friend.domain.Friend;
 import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequest;
 import com.gamegoo.gamegoo_v2.social.friend.domain.FriendRequestStatus;
@@ -13,15 +19,6 @@ import com.gamegoo.gamegoo_v2.social.friend.dto.FriendRequestResponse;
 import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRepository;
 import com.gamegoo.gamegoo_v2.social.friend.repository.FriendRequestRepository;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendFacadeService;
-import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
-import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
-import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
-import com.gamegoo.gamegoo_v2.notification.domain.Notification;
-import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
-import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
-import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
-import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -64,10 +61,7 @@ class FriendRequestFacadeServiceTest {
 
     @MockitoSpyBean
     private NotificationRepository notificationRepository;
-
-    @Autowired
-    private NotificationTypeRepository notificationTypeRepository;
-
+    
     private static final String TARGET_EMAIL = "target@naver.com";
     private static final String TARGET_GAMENAME = "target";
 
@@ -84,18 +78,12 @@ class FriendRequestFacadeServiceTest {
         friendRequestRepository.deleteAllInBatch();
         blockRepository.deleteAllInBatch();
         notificationRepository.deleteAllInBatch();
-        notificationTypeRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
 
     @Nested
     @DisplayName("친구 요청 전송")
     class SendFriendRequestTest {
-
-        @BeforeEach
-        void setUp() {
-            initNotificationType();
-        }
 
         @DisplayName("친구 요청 전송 성공")
         @Test
@@ -229,11 +217,6 @@ class FriendRequestFacadeServiceTest {
     @DisplayName("친구 요청 수락")
     class AcceptFriendRequestTest {
 
-        @BeforeEach
-        void setUp() {
-            initNotificationType();
-        }
-
         @DisplayName("친구 요청 수락 성공")
         @Test
         void acceptFriendRequestSucceeds() {
@@ -291,11 +274,6 @@ class FriendRequestFacadeServiceTest {
     @Nested
     @DisplayName("친구 요청 거절")
     class RejectFriendRequestTest {
-
-        @BeforeEach
-        void setUp() {
-            initNotificationType();
-        }
 
         @DisplayName("친구 요청 거절 성공")
         @Test
@@ -410,16 +388,6 @@ class FriendRequestFacadeServiceTest {
                 .gameCount(0)
                 .isAgree(true)
                 .build());
-    }
-
-    private void initNotificationType() {
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_SEND));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_REJECTED));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_UP));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_DOWN));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_KEYWORD_RATED));
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
@@ -1,0 +1,139 @@
+package com.gamegoo.gamegoo_v2.integration.manner;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
+import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class MannerFacadeServiceTest {
+
+    @Autowired
+    MannerFacadeService mannerFacadeService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    MannerKeywordRepository mannerKeywordRepository;
+
+    private static final String TARGET_EMAIL = "target@naver.com";
+    private static final String TARGET_GAMENAME = "target";
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember("test@gmail.com", "member");
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("매너 평가 등록")
+    class InsertPositiveMannerRatingTest {
+
+        @DisplayName("실패: 대상 회원을 찾을 수 없는 경우 예외가 발생한다.")
+        @Test
+        void insertPositiveMannerRating_shouldThrownWhenMemberNotFound() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @DisplayName("실패: 매너 키워드 id에 7 이상의 값이 들어간 경우 예외가 발생한다.")
+        @Test
+        void insertPositiveMannerRating_shouldThrownWhenMannerKeywordIsNotValid() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @DisplayName("실패: 매너 키워드 id에 음수 값이 들어간 경우 예외가 발생한다.")
+        @Test
+        void insertPositiveMannerRating_shouldThrownWhenMannerKeywordIsNegative() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @DisplayName("실패: 평가 대상으로 본인 id를 입력한 경우 예외가 발생한다.")
+        @Test
+        void insertPositiveMannerRating_shouldThrownWhenTargetIsSelf() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @DisplayName("실패: 대상 회원이 탈퇴한 경우 예외가 발생한다.")
+        @Test
+        void insertPositiveMannerRating_shouldThrownWhenTargetIsBlind() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @DisplayName("실패: 대상 회원에게 등록한 매너 평가가 존재하는 경우 예외가 발생한다.")
+        @Test
+        void insertPositiveMannerRating_shouldThrownWhenMannerRatingExists() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @DisplayName("성공: 엔티티 생성 및 저장, 매너 평가 등록 알림이 생성되어야 한다.")
+        @Test
+        void insertPositiveMannerRatingSucceeds() {
+            // given
+
+            // when
+
+            // then
+        }
+
+    }
+
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
@@ -4,7 +4,19 @@ import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
-import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
+import com.gamegoo.gamegoo_v2.core.exception.MannerException;
+import com.gamegoo.gamegoo_v2.core.exception.MemberException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.core.exception.common.GlobalException;
+import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
+import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
+import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRatingKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingKeywordRepository;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingRepository;
 import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,32 +26,55 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ActiveProfiles("test")
 @SpringBootTest
 class MannerFacadeServiceTest {
 
     @Autowired
-    MannerFacadeService mannerFacadeService;
+    private MannerFacadeService mannerFacadeService;
 
     @Autowired
-    MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
-    MannerKeywordRepository mannerKeywordRepository;
+    private MannerRatingRepository mannerRatingRepository;
 
-    private static final String TARGET_EMAIL = "target@naver.com";
-    private static final String TARGET_GAMENAME = "target";
+    @Autowired
+    private MannerRatingKeywordRepository mannerRatingKeywordRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockitoSpyBean
+    private NotificationService notificationService;
 
     private Member member;
+    private Member targetMember;
 
     @BeforeEach
     void setUp() {
         member = createMember("test@gmail.com", "member");
+        targetMember = createMember("target@gmail.com", "targetMember");
     }
 
     @AfterEach
     void tearDown() {
+        notificationRepository.deleteAllInBatch();
+        mannerRatingKeywordRepository.deleteAllInBatch();
+        mannerRatingRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
 
@@ -51,70 +86,173 @@ class MannerFacadeServiceTest {
         @Test
         void insertPositiveMannerRating_shouldThrownWhenMemberNotFound() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
-            // when
-
-            // then
+            // when // then
+            assertThatThrownBy(() -> mannerFacadeService.insertPositiveMannerRating(member, 1000L, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
 
         @DisplayName("실패: 매너 키워드 id에 7 이상의 값이 들어간 경우 예외가 발생한다.")
         @Test
         void insertPositiveMannerRating_shouldThrownWhenMannerKeywordIsNotValid() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 7L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
-            // when
-
-            // then
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertPositiveMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MannerException.class)
+                    .hasMessage(ErrorCode.MANNER_KEYWORD_INVALID.getMessage());
         }
 
         @DisplayName("실패: 매너 키워드 id에 음수 값이 들어간 경우 예외가 발생한다.")
         @Test
         void insertPositiveMannerRating_shouldThrownWhenMannerKeywordIsNegative() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, -1L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
-            // when
-
-            // then
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertPositiveMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MannerException.class)
+                    .hasMessage(ErrorCode.MANNER_KEYWORD_INVALID.getMessage());
         }
 
         @DisplayName("실패: 평가 대상으로 본인 id를 입력한 경우 예외가 발생한다.")
         @Test
         void insertPositiveMannerRating_shouldThrownWhenTargetIsSelf() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
-            // when
-
-            // then
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertPositiveMannerRating(member, member.getId(), request))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(ErrorCode._BAD_REQUEST.getMessage());
         }
 
         @DisplayName("실패: 대상 회원이 탈퇴한 경우 예외가 발생한다.")
         @Test
         void insertPositiveMannerRating_shouldThrownWhenTargetIsBlind() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
-            // when
+            // 대상 회원 탈퇴 처리
+            targetMember.updateBlind(true);
+            memberRepository.save(targetMember);
 
-            // then
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertPositiveMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage());
         }
 
         @DisplayName("실패: 대상 회원에게 등록한 매너 평가가 존재하는 경우 예외가 발생한다.")
         @Test
         void insertPositiveMannerRating_shouldThrownWhenMannerRatingExists() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
-            // when
+            mannerRatingRepository.save(MannerRating.create(member, targetMember, true));
 
-            // then
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertPositiveMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MannerException.class)
+                    .hasMessage(ErrorCode.MANNER_RATING_EXISTS.getMessage());
         }
 
         @DisplayName("성공: 엔티티 생성 및 저장, 매너 평가 등록 알림이 생성되어야 한다.")
         @Test
         void insertPositiveMannerRatingSucceeds() {
             // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
 
             // when
+            MannerInsertResponse response = mannerFacadeService.insertPositiveMannerRating(member, targetMember.getId(),
+                    request);
 
             // then
+            assertThat(response.getTargetMemberId()).isEqualTo(targetMember.getId());
+            assertThat(response.getMannerKeywordIdList()).isEqualTo(mannerKeywordIds);
+
+            // mannerRating 엔티티 검증
+            MannerRating mannerRating = mannerRatingRepository.findById(response.getMannerRatingId()).orElseThrow();
+            assertThat(mannerRating.getFromMember().getId()).isEqualTo(member.getId());
+            assertThat(mannerRating.getToMember().getId()).isEqualTo(targetMember.getId());
+            assertThat(mannerRating.isPositive()).isTrue();
+
+            // mannerRatingKeyword 엔티티 검증
+            List<MannerRatingKeyword> mannerRatingKeywords = mannerRatingKeywordRepository.findByMannerRatingId(
+                    mannerRating.getId());
+            assertThat(mannerRatingKeywords).hasSize(mannerKeywordIds.size());
+
+            // member의 매너 점수 업데이트 검증
+            Member updatedMember = memberRepository.findById(targetMember.getId()).orElseThrow();
+            assertThat(updatedMember.getMannerScore()).isEqualTo(mannerKeywordIds.size());
+
+            // event로 인해 알림 1개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationService, times(1)).createMannerRatingNotification(any(), any(Member.class));
+            });
+        }
+
+        @DisplayName("성공: 매너 평가 등록으로 인해 매너 레벨이 상승한 경우, 매너 레벨 업데이트 및 알림이 생성되어야 한다.")
+        @Test
+        void insertPositiveMannerRatingSucceedsWhenMannerLevelUp() {
+            // given
+            List<Long> mannerKeywordIds = List.of(1L, 2L, 3L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            targetMember.updateMannerScore(8);
+            memberRepository.save(targetMember);
+
+            // when
+            mannerFacadeService.insertPositiveMannerRating(member, targetMember.getId(), request);
+
+            // then
+            // targetMember의 매너 점수 업데이트 검증
+            Member updatedMember = memberRepository.findById(targetMember.getId()).orElseThrow();
+            assertThat(updatedMember.getMannerScore()).isEqualTo(11);
+
+            // targetMember의 매너 레벨 업데이트 검증
+            assertThat(updatedMember.getMannerLevel()).isEqualTo(2);
+
+            // event로 인해 알림 2개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationService, times(1)).createMannerRatingNotification(any(), any(Member.class));
+            });
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationService, times(1)).createMannerLevelNotification(
+                        eq(NotificationTypeTitle.MANNER_LEVEL_UP), any(Member.class), eq(2));
+            });
+
         }
 
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class MemberServiceFacadeTest {
+class MemberServiceFacadeTest {
 
     @Autowired
     MemberFacadeService memberFacadeService;

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/notification/NotificationFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/notification/NotificationFacadeServiceTest.java
@@ -6,6 +6,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.core.exception.NotificationException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
 import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
 import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/notification/NotificationServiceTest.java
@@ -1,7 +1,5 @@
 package com.gamegoo.gamegoo_v2.service.notification;
 
-import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
-import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
@@ -12,6 +10,8 @@ import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -91,7 +91,8 @@ class NotificationServiceTest {
         Notification notification = notificationService.createReceivedFriendRequestNotification(sourceMember, member);
 
         // then
-        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED);
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(
+                NotificationTypeTitle.FRIEND_REQUEST_RECEIVED);
         assertThat(notification.isRead()).isFalse();
         assertThat(notification.getMember().getId()).isEqualTo(sourceMember.getId());
         assertThat(notification.getSourceMember().getId()).isEqualTo(member.getId());
@@ -109,7 +110,8 @@ class NotificationServiceTest {
         Notification notification = notificationService.createAcceptFriendRequestNotification(targetMember, member);
 
         // then
-        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED);
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(
+                NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED);
         assertThat(notification.isRead()).isFalse();
         assertThat(notification.getMember().getId()).isEqualTo(targetMember.getId());
         assertThat(notification.getSourceMember().getId()).isEqualTo(member.getId());
@@ -127,7 +129,8 @@ class NotificationServiceTest {
         Notification notification = notificationService.createRejectFriendRequestNotification(targetMember, member);
 
         // then
-        assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.FRIEND_REQUEST_REJECTED);
+        assertThat(notification.getNotificationType().getTitle()).isEqualTo(
+                NotificationTypeTitle.FRIEND_REQUEST_REJECTED);
         assertThat(notification.isRead()).isFalse();
         assertThat(notification.getMember().getId()).isEqualTo(targetMember.getId());
         assertThat(notification.getSourceMember().getId()).isEqualTo(member.getId());
@@ -184,8 +187,10 @@ class NotificationServiceTest {
         mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("1인분 이상은 해요", true)));
         mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("욕 안해요", true)));
 
+        List<Long> mannerKeywordIdList = mannerKeywordList.stream().map(MannerKeyword::getId).toList();
+
         // when
-        Notification notification = notificationService.createMannerRatingNotification(mannerKeywordList, member);
+        Notification notification = notificationService.createMannerRatingNotification(mannerKeywordIdList, member);
 
         // then
         assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.MANNER_KEYWORD_RATED);
@@ -204,8 +209,10 @@ class NotificationServiceTest {
         List<MannerKeyword> mannerKeywordList = new ArrayList<>();
         mannerKeywordList.add(mannerKeywordRepository.save(MannerKeyword.create("캐리했어요", true)));
 
+        List<Long> mannerKeywordIdList = mannerKeywordList.stream().map(MannerKeyword::getId).toList();
+
         // when
-        Notification notification = notificationService.createMannerRatingNotification(mannerKeywordList, member);
+        Notification notification = notificationService.createMannerRatingNotification(mannerKeywordIdList, member);
 
         // then
         assertThat(notification.getNotificationType().getTitle()).isEqualTo(NotificationTypeTitle.MANNER_KEYWORD_RATED);

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/notification/NotificationServiceTest.java
@@ -5,10 +5,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
-import com.gamegoo.gamegoo_v2.notification.domain.NotificationType;
 import com.gamegoo.gamegoo_v2.notification.domain.NotificationTypeTitle;
 import com.gamegoo.gamegoo_v2.notification.repository.NotificationRepository;
-import com.gamegoo.gamegoo_v2.notification.repository.NotificationTypeRepository;
 import com.gamegoo.gamegoo_v2.notification.service.NotificationService;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
@@ -36,9 +34,6 @@ class NotificationServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private NotificationTypeRepository notificationTypeRepository;
-
-    @Autowired
     private NotificationRepository notificationRepository;
 
     @Autowired
@@ -52,13 +47,11 @@ class NotificationServiceTest {
     @BeforeEach
     void setUp() {
         member = createMember("test@gmail.com", "member");
-        initNotificationType();
     }
 
     @AfterEach
     void tearDown() {
         notificationRepository.deleteAllInBatch();
-        notificationTypeRepository.deleteAllInBatch();
         mannerKeywordRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
@@ -238,16 +231,6 @@ class NotificationServiceTest {
                 .gameCount(0)
                 .isAgree(true)
                 .build());
-    }
-
-    private void initNotificationType() {
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_SEND));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_RECEIVED));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_ACCEPTED));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.FRIEND_REQUEST_REJECTED));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_UP));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_LEVEL_DOWN));
-        notificationTypeRepository.save(NotificationType.create(NotificationTypeTitle.MANNER_KEYWORD_RATED));
     }
 
 }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 매너평가 등록 API 구현 및 테스트

## ⏳ 작업 상세 내용
- [x] 매너평가 등록 API 구현
- [x] 매너평가 관련 이벤트 구현
- [x] 매너평가 등록 API 통합 테스트
- [x] 매너평가 등록 API 컨트롤러 테스트
- [x] MannerKeywordInitializer 구현
- [x] springboot test 설정 파일 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] springboot test (통합 테스트)를 돌릴 때 매너 키워드, 알림 타입 같은 정보들은 테스트 실행 전에 db에 한번만 insert되고 매 메소드마다 초기화할 필요 없도록 TestSetup 파일 추가했습니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
