### PR TITLE
[Feat/138] 비매너 평가 등록 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/core/common/annotation/NotDuplicated.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/common/annotation/NotDuplicated.java
@@ -1,0 +1,23 @@
+package com.gamegoo.gamegoo_v2.core.common.annotation;
+
+import com.gamegoo.gamegoo_v2.core.common.annotationValidator.NotDuplicatedAnnotationValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = NotDuplicatedAnnotationValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotDuplicated {
+
+    String message() default "중복된 값을 포함할 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/common/annotationValidator/NotDuplicatedAnnotationValidator.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/common/annotationValidator/NotDuplicatedAnnotationValidator.java
@@ -1,0 +1,31 @@
+package com.gamegoo.gamegoo_v2.core.common.annotationValidator;
+
+import com.gamegoo.gamegoo_v2.core.common.annotation.NotDuplicated;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class NotDuplicatedAnnotationValidator implements ConstraintValidator<NotDuplicated, List<?>> {
+
+    @Override
+    public void initialize(NotDuplicated constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<?> value, ConstraintValidatorContext context) {
+        // 값이 null이면 검증 통과 처리
+        if (value == null) {
+            return true;
+        }
+
+        // Set으로 변환하여 size 비교
+        Set<?> set = new HashSet<>(value);
+        return (set.size() == value.size());
+    }
+
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -35,4 +35,14 @@ public class MannerController {
         return ApiResponse.ok(mannerFacadeService.insertPositiveMannerRating(member, targetMemberId, request));
     }
 
+    @Operation(summary = "비매너 평가 등록 API", description = "비매너 평가를 등록하는 API 입니다.")
+    @Parameter(name = "memberId", description = "비매너 평가를 등록할 대상 회원의 id 입니다.")
+    @PostMapping("/negative/{memberId}")
+    public ApiResponse<MannerInsertResponse> addNegativeMannerRating(
+            @PathVariable(name = "memberId") Long targetMemberId,
+            @Valid @RequestBody MannerInsertRequest request,
+            @AuthMember Member member) {
+        return ApiResponse.ok(mannerFacadeService.insertNegativeMannerRating(member, targetMemberId, request));
+    }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/request/MannerInsertRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/request/MannerInsertRequest.java
@@ -1,5 +1,6 @@
 package com.gamegoo.gamegoo_v2.social.manner.dto.request;
 
+import com.gamegoo.gamegoo_v2.core.common.annotation.NotDuplicated;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import java.util.List;
 @Builder
 public class MannerInsertRequest {
 
+    @NotDuplicated
     @NotEmpty(message = "매너 키워드 리스트는 비워둘 수 없습니다.")
     List<Long> mannerKeywordIdList;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -40,5 +40,29 @@ public class MannerFacadeService {
         return MannerInsertResponse.of(mannerRating, request.getMannerKeywordIdList());
     }
 
+    /**
+     * 비매너 평가 등록 facade 메소드
+     *
+     * @param member         회원
+     * @param targetMemberId 상대 회원 id
+     * @param request        매너 평가 요청
+     * @return MannerInsertResponse
+     */
+    @Transactional
+    public MannerInsertResponse insertNegativeMannerRating(Member member, Long targetMemberId,
+                                                           MannerInsertRequest request) {
+        Member targetMember = memberService.findMemberById(targetMemberId);
+
+        // 비매너 평가 등록
+        MannerRating mannerRating = mannerService.insertMannerRating(member, targetMember,
+                request.getMannerKeywordIdList(), false);
+
+        // 매너 점수 및 레벨 업데이트
+        int score = -2 * request.getMannerKeywordIdList().size();
+        mannerService.updateMannerScoreAndLevel(targetMember, score);
+
+        return MannerInsertResponse.of(mannerRating, request.getMannerKeywordIdList());
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
@@ -56,13 +56,13 @@ public class MannerService {
         memberValidator.throwIfBlind(targetMember);
 
         // 매너 평가 최초 여부 검증
-        validateMannerRatingNotExists(member, targetMember, true);
+        validateMannerRatingNotExists(member, targetMember, isPositive);
 
         // 매너 키워드 엔티티 조회
         List<MannerKeyword> mannerKeywordList = getMannerKeywordList(mannerKeywordIdList);
 
         // MannerRating 엔티티 생성 및 저장
-        MannerRating mannerRating = MannerRating.create(member, targetMember, true);
+        MannerRating mannerRating = MannerRating.create(member, targetMember, isPositive);
         mannerRatingRepository.save(mannerRating);
 
         // MannerRatingKeyword 엔티티 생성 및 저장

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
@@ -63,6 +63,34 @@ public class MannerControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.message").value("매너 키워드 리스트는 비워둘 수 없습니다."));
         }
 
+        @DisplayName("실패: 매너 키워드 리스트에 중복 값이 있는 경우 에러 응답을 반환한다.")
+        @Test
+        void addPositiveMannerRatingFailedWhenKeywordListIsDuplicated() throws Exception {
+            // given
+            List<Long> mannerKeywordIds = List.of(1L, 1L);
+
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            MannerInsertResponse response = MannerInsertResponse.builder()
+                    .targetMemberId(TARGET_MEMBER_ID)
+                    .mannerRatingId(1L)
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            given(mannerFacadeService.insertPositiveMannerRating(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(MannerInsertRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/positive/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.message").value("중복된 값을 포함할 수 없습니다."));
+        }
+
         @DisplayName("성공")
         @Test
         void addPositiveMannerRatingSucceeds() throws Exception {

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
@@ -123,5 +123,97 @@ public class MannerControllerTest extends ControllerTestSupport {
 
     }
 
+    @Nested
+    @DisplayName("비매너 평가 등록")
+    class AddNegativeMannerRatingTest {
+
+        @DisplayName("실패: 매너 키워드 리스트가 빈 리스트인 경우 에러 응답을 반환한다.")
+        @Test
+        void addNegativeMannerRatingFailedWhenKeywordListIsEmpty() throws Exception {
+            // given
+            List<Long> mannerKeywordIds = List.of();
+
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            MannerInsertResponse response = MannerInsertResponse.builder()
+                    .targetMemberId(TARGET_MEMBER_ID)
+                    .mannerRatingId(1L)
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            given(mannerFacadeService.insertNegativeMannerRating(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(MannerInsertRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/negative/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.message").value("매너 키워드 리스트는 비워둘 수 없습니다."));
+        }
+
+        @DisplayName("실패: 매너 키워드 리스트에 중복 값이 있는 경우 에러 응답을 반환한다.")
+        @Test
+        void addNegativeMannerRatingFailedWhenKeywordListIsDuplicated() throws Exception {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 7L);
+
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            MannerInsertResponse response = MannerInsertResponse.builder()
+                    .targetMemberId(TARGET_MEMBER_ID)
+                    .mannerRatingId(1L)
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            given(mannerFacadeService.insertNegativeMannerRating(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(MannerInsertRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/negative/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.message").value("중복된 값을 포함할 수 없습니다."));
+        }
+
+        @DisplayName("성공")
+        @Test
+        void addNegativeMannerRatingSucceeds() throws Exception {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            MannerInsertResponse response = MannerInsertResponse.builder()
+                    .targetMemberId(TARGET_MEMBER_ID)
+                    .mannerRatingId(1L)
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            given(mannerFacadeService.insertNegativeMannerRating(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(MannerInsertRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/negative/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.targetMemberId").value(TARGET_MEMBER_ID))
+                    .andExpect(jsonPath("$.data.mannerRatingId").value(1L))
+                    .andExpect(jsonPath("$.data.mannerKeywordIdList").isArray());
+        }
+
+    }
+
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
@@ -257,6 +257,183 @@ class MannerFacadeServiceTest {
 
     }
 
+    @Nested
+    @DisplayName("비매너 평가 등록")
+    class InsertNegativeMannerRatingTest {
+
+        @DisplayName("실패: 대상 회원을 찾을 수 없는 경우 예외가 발생한다.")
+        @Test
+        void insertNegativeMannerRating_shouldThrownWhenMemberNotFound() {
+            // givenL
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            // when // then
+            assertThatThrownBy(() -> mannerFacadeService.insertNegativeMannerRating(member, 1000L, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("실패: 매너 키워드 id에 6 이하의 값이 들어간 경우 예외가 발생한다.")
+        @Test
+        void insertNegativeMannerRating_shouldThrownWhenMannerKeywordIsNotValid() {
+            // given
+            List<Long> mannerKeywordIds = List.of(1L, 7L, 8L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertNegativeMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MannerException.class)
+                    .hasMessage(ErrorCode.MANNER_KEYWORD_INVALID.getMessage());
+        }
+
+        @DisplayName("실패: 매너 키워드 id에 13 이상의 값이 들어간 경우 예외가 발생한다.")
+        @Test
+        void insertNegativeMannerRating_shouldThrownWhenMannerKeywordIdIsLargerThanMax() {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 15L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertNegativeMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MannerException.class)
+                    .hasMessage(ErrorCode.MANNER_KEYWORD_INVALID.getMessage());
+        }
+
+        @DisplayName("실패: 평가 대상으로 본인 id를 입력한 경우 예외가 발생한다.")
+        @Test
+        void insertNegativeMannerRating_shouldThrownWhenTargetIsSelf() {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            // when // then
+            assertThatThrownBy(() -> mannerFacadeService.insertNegativeMannerRating(member, member.getId(), request))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage(ErrorCode._BAD_REQUEST.getMessage());
+        }
+
+        @DisplayName("실패: 대상 회원이 탈퇴한 경우 예외가 발생한다.")
+        @Test
+        void insertNegativeMannerRating_shouldThrownWhenTargetIsBlind() {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            // 대상 회원 탈퇴 처리
+            targetMember.updateBlind(true);
+            memberRepository.save(targetMember);
+
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertNegativeMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage());
+        }
+
+        @DisplayName("실패: 대상 회원에게 등록한 비매너 평가가 존재하는 경우 예외가 발생한다.")
+        @Test
+        void insertNegativeMannerRating_shouldThrownWhenMannerRatingExists() {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            mannerRatingRepository.save(MannerRating.create(member, targetMember, false));
+
+            // when // then
+            assertThatThrownBy(
+                    () -> mannerFacadeService.insertNegativeMannerRating(member, targetMember.getId(), request))
+                    .isInstanceOf(MannerException.class)
+                    .hasMessage(ErrorCode.MANNER_RATING_EXISTS.getMessage());
+        }
+
+        @DisplayName("성공: 엔티티 생성 및 저장, 매너 평가 등록 알림이 생성되어야 한다.")
+        @Test
+        void insertNegativeMannerRatingSucceeds() {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            // when
+            MannerInsertResponse response = mannerFacadeService.insertNegativeMannerRating(member, targetMember.getId(),
+                    request);
+
+            // then
+            assertThat(response.getTargetMemberId()).isEqualTo(targetMember.getId());
+            assertThat(response.getMannerKeywordIdList()).isEqualTo(mannerKeywordIds);
+
+            // mannerRating 엔티티 검증
+            MannerRating mannerRating = mannerRatingRepository.findById(response.getMannerRatingId()).orElseThrow();
+            assertThat(mannerRating.getFromMember().getId()).isEqualTo(member.getId());
+            assertThat(mannerRating.getToMember().getId()).isEqualTo(targetMember.getId());
+            assertThat(mannerRating.isPositive()).isFalse();
+
+            // mannerRatingKeyword 엔티티 검증
+            List<MannerRatingKeyword> mannerRatingKeywords = mannerRatingKeywordRepository.findByMannerRatingId(
+                    mannerRating.getId());
+            assertThat(mannerRatingKeywords).hasSize(mannerKeywordIds.size());
+
+            // member의 매너 점수 업데이트 검증
+            Member updatedMember = memberRepository.findById(targetMember.getId()).orElseThrow();
+            assertThat(updatedMember.getMannerScore()).isEqualTo(-2 * mannerKeywordIds.size());
+
+            // event로 인해 알림 1개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationService, times(1)).createMannerRatingNotification(any(), any(Member.class));
+            });
+        }
+
+        @DisplayName("성공: 비매너 평가 등록으로 인해 매너 레벨이 하락한 경우, 매너 레벨 업데이트 및 알림이 생성되어야 한다.")
+        @Test
+        void insertNegativeMannerRatingSucceedsWhenMannerLevelDown() {
+            // given
+            List<Long> mannerKeywordIds = List.of(7L, 8L, 9L);
+            MannerInsertRequest request = MannerInsertRequest.builder()
+                    .mannerKeywordIdList(mannerKeywordIds)
+                    .build();
+
+            targetMember.updateMannerScore(11);
+            targetMember.updateMannerLevel(2);
+            memberRepository.save(targetMember);
+
+            // when
+            mannerFacadeService.insertNegativeMannerRating(member, targetMember.getId(), request);
+
+            // then
+            // targetMember의 매너 점수 업데이트 검증
+            Member updatedMember = memberRepository.findById(targetMember.getId()).orElseThrow();
+            assertThat(updatedMember.getMannerScore()).isEqualTo(5);
+
+            // targetMember의 매너 레벨 업데이트 검증
+            assertThat(updatedMember.getMannerLevel()).isEqualTo(1);
+
+            // event로 인해 알림 2개가 저장되었는지 검증
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationService, times(1)).createMannerRatingNotification(any(), any(Member.class));
+            });
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(notificationService, times(1)).createMannerLevelNotification(
+                        eq(NotificationTypeTitle.MANNER_LEVEL_DOWN), any(Member.class), eq(1));
+            });
+        }
+    }
+
 
     private Member createMember(String email, String gameName) {
         return memberRepository.save(Member.builder()


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 비매너 평가 등록 API 구현 및 테스트

## ⏳ 작업 상세 내용
- [x] 비매너 평가 등록 API 구현
- [x] 비매너 평가 등록 API 통합 테스트
- [x] 비매너 평가 등록 API 컨트롤러 테스트
- [x] @NotDuplicated 커스텀 어노테이션 구현

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] List 안에 중복된 값이 있으면 에러 발생시키는 커스텀 어노테이션 @NotDuplicated 구현했습니다. List<?> 타입에 대해 검증 가능하도록 해두었는데, 만약에 특정 객체로 이루어진 리스트라면 해당 객체에 equals 메소드 오버라이드해서 구현되어 있어야 제대로 중복 검증이 가능합니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
