### PR TITLE
[Feat/149] 매너 정보 조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -171,4 +171,9 @@ public class Member extends BaseDateTimeEntity {
         return this.mannerLevel;
     }
 
+    public Double updateMannerRank(Double mannerRank) {
+        this.mannerRank = mannerRank;
+        return this.mannerRank;
+    }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -47,6 +47,8 @@ public class Member extends BaseDateTimeEntity {
 
     private Integer mannerScore;
 
+    private Double mannerRank;
+
     @Column(nullable = false)
     private boolean blind = false;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -7,6 +7,7 @@ import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerUpdateResponse;
 import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -81,7 +82,7 @@ public class MannerController {
     @Operation(summary = "특정 회원의 매너 정보 조회 API", description = "특정 회원의 매너 정보를 조회하는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
     @GetMapping("/{memberId}")
-    public ApiResponse<Object> getMyManner(@PathVariable(name = "memberId") Long memberId) {
+    public ApiResponse<MannerResponse> getMannerInfo(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(mannerFacadeService.getMannerInfo(memberId));
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -77,4 +77,10 @@ public class MannerController {
             @AuthMember Member member) {
         return ApiResponse.ok(mannerFacadeService.getMannerRating(member, targetMemberId, false));
     }
+
+    @Operation(summary = "나의 매너 정보 조회 API", description = "나의 매너 정보를 조회하는 API 입니다.")
+    @GetMapping
+    public ApiResponse<Object> getMyManner(@AuthMember Member member) {
+        return ApiResponse.ok(mannerFacadeService.getMannerInfo(member));
+    }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -78,9 +78,10 @@ public class MannerController {
         return ApiResponse.ok(mannerFacadeService.getMannerRating(member, targetMemberId, false));
     }
 
-    @Operation(summary = "나의 매너 정보 조회 API", description = "나의 매너 정보를 조회하는 API 입니다.")
-    @GetMapping
-    public ApiResponse<Object> getMyManner(@AuthMember Member member) {
-        return ApiResponse.ok(mannerFacadeService.getMannerInfo(member));
+    @Operation(summary = "특정 회원의 매너 정보 조회 API", description = "특정 회원의 매너 정보를 조회하는 API 입니다.")
+    @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
+    @GetMapping("/{memberId}")
+    public ApiResponse<Object> getMyManner(@PathVariable(name = "memberId") Long memberId) {
+        return ApiResponse.ok(mannerFacadeService.getMannerInfo(memberId));
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerKeywordResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerKeywordResponse.java
@@ -1,0 +1,20 @@
+package com.gamegoo.gamegoo_v2.social.manner.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MannerKeywordResponse {
+
+    Long mannerKeywordId;
+    int count;
+
+    public static MannerKeywordResponse of(Long MannerKeywordId, int count) {
+        return MannerKeywordResponse.builder()
+                .mannerKeywordId(MannerKeywordId)
+                .count(count)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerResponse.java
@@ -1,0 +1,27 @@
+package com.gamegoo.gamegoo_v2.social.manner.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MannerResponse {
+
+    int mannerLevel;
+    Double mannerRank;
+    int mannerRatingCount;
+    List<MannerKeywordResponse> mannerKeywords;
+
+    public static MannerResponse of(int mannerLevel, Double mannerRank, int mannerRatingCount,
+                                    List<MannerKeywordResponse> mannerKeywords) {
+        return MannerResponse.builder()
+                .mannerLevel(mannerLevel)
+                .mannerRank(mannerRank)
+                .mannerRatingCount(mannerRatingCount)
+                .mannerKeywords(mannerKeywords)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepository.java
@@ -5,7 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface MannerRatingKeywordRepository extends JpaRepository<MannerRatingKeyword, Long> {
+public interface MannerRatingKeywordRepository extends JpaRepository<MannerRatingKeyword, Long>,
+        MannerRatingKeywordRepositoryCustom {
 
     List<MannerRatingKeyword> findByMannerRatingId(Long id);
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.gamegoo.gamegoo_v2.social.manner.repository;
+
+import java.util.Map;
+
+public interface MannerRatingKeywordRepositoryCustom {
+
+    /**
+     * 해당 회원이 받은 매너 키워드 별 개수 조회
+     *
+     * @param memberId 회원 id
+     * @return Map<매너 키워드 id, 개수>
+     */
+    Map<Long, Integer> countMannerKeywordByToMemberId(Long memberId);
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingKeywordRepositoryCustomImpl.java
@@ -1,0 +1,52 @@
+package com.gamegoo.gamegoo_v2.social.manner.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.gamegoo.gamegoo_v2.social.manner.domain.QMannerKeyword.mannerKeyword;
+import static com.gamegoo.gamegoo_v2.social.manner.domain.QMannerRating.mannerRating;
+import static com.gamegoo.gamegoo_v2.social.manner.domain.QMannerRatingKeyword.mannerRatingKeyword;
+
+@RequiredArgsConstructor
+public class MannerRatingKeywordRepositoryCustomImpl implements MannerRatingKeywordRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, Integer> countMannerKeywordByToMemberId(Long memberId) {
+        // 매너 키워드 개수 map 초기화
+        Map<Long, Integer> resultMap = new HashMap<>();
+        for (long i = 1L; i <= 12L; i++) {
+            resultMap.put(i, 0);
+        }
+
+        List<Tuple> result = queryFactory
+                .select(mannerKeyword.id,
+                        mannerRatingKeyword.id.count()
+                )
+                .from(mannerKeyword)
+                .leftJoin(mannerRatingKeyword).on(mannerRatingKeyword.mannerKeyword.id.eq(mannerKeyword.id))
+                .leftJoin(mannerRating).on(
+                        mannerRatingKeyword.mannerRating.id.eq(mannerRating.id)
+                                .and(mannerRating.toMember.id.eq(memberId))
+                )
+                .groupBy(mannerKeyword.id)
+                .fetch();
+
+        for (Tuple t : result) {
+            Long keywordId = t.get(mannerKeyword.id);
+            Long countVal = t.get(mannerRatingKeyword.id.count());
+            if (keywordId != null) {
+                resultMap.put(keywordId, countVal != null ? countVal.intValue() : 0);
+            }
+        }
+
+        return resultMap;
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/repository/MannerRatingRepository.java
@@ -2,6 +2,8 @@ package com.gamegoo.gamegoo_v2.social.manner.repository;
 
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,5 +13,13 @@ public interface MannerRatingRepository extends JpaRepository<MannerRating, Long
 
     Optional<MannerRating> findByFromMemberIdAndToMemberIdAndPositive(Long fromMemberId, Long toMemberId,
                                                                       boolean positive);
+
+    @Query("""
+            SELECT COUNT(DISTINCT mr.fromMember.id)
+            FROM MannerRating mr
+            WHERE mr.toMember.id = :memberId
+            AND mr.positive = :positive
+            """)
+    int countFromMemberByToMemberIdAndPositive(@Param("memberId") Long memberId, @Param("positive") boolean positive);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -121,10 +121,12 @@ public class MannerFacadeService {
     /**
      * 해당 회원의 매너 정보 조회 facade 메소드
      *
-     * @param member 회원
+     * @param memberId 회원 id
      * @return MannerResponse
      */
-    public MannerResponse getMannerInfo(Member member) {
+    public MannerResponse getMannerInfo(Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+        
         // 매너 레벨 조회
         int mannerLevel = member.getMannerLevel();
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -6,12 +6,16 @@ import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerKeywordResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -112,6 +116,32 @@ public class MannerFacadeService {
         Optional<MannerRating> mannerRating = mannerService.getMannerRatingByMember(member, targetMember, positive);
 
         return MannerRatingResponse.of(mannerRating);
+    }
+
+    /**
+     * 해당 회원의 매너 정보 조회 facade 메소드
+     *
+     * @param member 회원
+     * @return MannerResponse
+     */
+    public MannerResponse getMannerInfo(Member member) {
+        // 매너 레벨 조회
+        int mannerLevel = member.getMannerLevel();
+
+        // 매너 랭크 조회
+        Double mannerRank = member.getMannerRank();
+
+        // 매너 평가 개수 조회
+        int mannerRatingCount = mannerService.countMannerRatingByMember(member, true);
+
+        // 매너 키워드별 받은 개수 조회
+        Map<Long, Integer> mannerKeywordMap = mannerService.countMannerKeyword(member);
+
+        List<MannerKeywordResponse> mannerKeywordResponses = mannerKeywordMap.entrySet().stream()
+                .map(entry -> MannerKeywordResponse.of(entry.getKey(), entry.getValue()))
+                .toList();
+
+        return MannerResponse.of(mannerLevel, mannerRank, mannerRatingCount, mannerKeywordResponses);
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -156,6 +157,27 @@ public class MannerService {
     public Optional<MannerRating> getMannerRatingByMember(Member member, Member targetMember, boolean positive) {
         return mannerRatingRepository.findByFromMemberIdAndToMemberIdAndPositive(member.getId(), targetMember.getId(),
                 positive);
+    }
+
+    /**
+     * 회원이 받은 매너/비매너 평가 개수 조회
+     *
+     * @param member   회원
+     * @param positive 매너/비매너 평가 여부
+     * @return 매너/비매너 평가 개수
+     */
+    public int countMannerRatingByMember(Member member, boolean positive) {
+        return mannerRatingRepository.countFromMemberByToMemberIdAndPositive(member.getId(), positive);
+    }
+
+    /**
+     * 회원이 받은 매너 키워드 별 개수 조회
+     *
+     * @param member 회원
+     * @return Map<매너 키워드 id, 개수>
+     */
+    public Map<Long, Integer> countMannerKeyword(Member member) {
+        return mannerRatingKeywordRepository.countMannerKeywordByToMemberId(member.getId());
     }
 
     /**

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
@@ -7,6 +7,7 @@ import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerUpdateResponse;
 import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
 import org.junit.jupiter.api.DisplayName;
@@ -350,6 +351,24 @@ public class MannerControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andExpect(jsonPath("$.data.mannerRatingId").value(1L))
                 .andExpect(jsonPath("$.data.mannerKeywordIdList").isArray());
+    }
+
+    @DisplayName("특정 회원의 매너 정보 조회")
+    @Test
+    void getMannerInfoSucceeds() throws Exception {
+        // given
+        MannerResponse response = MannerResponse.of(1, 50.0, 2, List.of());
+
+        given(mannerFacadeService.getMannerInfo(TARGET_MEMBER_ID)).willReturn(response);
+
+        // when // then
+        mockMvc.perform(get(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.mannerLevel").value(1))
+                .andExpect(jsonPath("$.data.mannerRank").value(50.0))
+                .andExpect(jsonPath("$.data.mannerRatingCount").value(2))
+                .andExpect(jsonPath("$.data.mannerKeywords").isArray());
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
@@ -890,11 +890,20 @@ class MannerFacadeServiceTest {
     @DisplayName("회원 매너 정보 조회")
     class GetMannerInfoTest {
 
+        @DisplayName("실패: 대상 회원을 찾을 수 없는 경우 예외가 발생한다.")
+        @Test
+        void getMannerInfo_shouldThrownWhenMemberNotFound() {
+            // when // then
+            assertThatThrownBy(() -> mannerFacadeService.getMannerInfo(1000L))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
         @DisplayName("성공: 받은 매너 평가가 없는 경우")
         @Test
         void getMannerInfoSucceedsWhenNoMannerRating() {
             // when
-            MannerResponse response = mannerFacadeService.getMannerInfo(member);
+            MannerResponse response = mannerFacadeService.getMannerInfo(member.getId());
 
             // then
             assertThat(response.getMannerLevel()).isEqualTo(1);
@@ -920,9 +929,10 @@ class MannerFacadeServiceTest {
 
             member.updateMannerScore(5);
             member.updateMannerRank(50.0);
+            memberRepository.save(member);
 
             // when
-            MannerResponse response = mannerFacadeService.getMannerInfo(member);
+            MannerResponse response = mannerFacadeService.getMannerInfo(member.getId());
 
             // then
             assertThat(response.getMannerLevel()).isEqualTo(1);

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
@@ -18,6 +18,7 @@ import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerUpdateResponse;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingKeywordRepository;
@@ -33,7 +34,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -881,6 +884,72 @@ class MannerFacadeServiceTest {
             assertThat(response.getMannerRatingId()).isNull();
             assertThat(response.getMannerKeywordIdList()).isEmpty();
         }
+    }
+
+    @Nested
+    @DisplayName("회원 매너 정보 조회")
+    class GetMannerInfoTest {
+
+        @DisplayName("성공: 받은 매너 평가가 없는 경우")
+        @Test
+        void getMannerInfoSucceedsWhenNoMannerRating() {
+            // when
+            MannerResponse response = mannerFacadeService.getMannerInfo(member);
+
+            // then
+            assertThat(response.getMannerLevel()).isEqualTo(1);
+            assertThat(response.getMannerRank()).isNull();
+            assertThat(response.getMannerRatingCount()).isEqualTo(0);
+            assertThat(response.getMannerKeywords())
+                    .isNotNull()
+                    .hasSize(12)
+                    .allSatisfy(mannerKeywordResponse -> assertThat(mannerKeywordResponse.getCount()).isEqualTo(0));
+        }
+
+        @DisplayName("성공: 받은 매너 평가가 있는 경우")
+        @Test
+        void getMannerInfoSucceeds() {
+            // given
+            Member targetMember1 = createMember("targetMember1@gmail.com", "targetMember1");
+            Member targetMember2 = createMember("targetMember2@gmail.com", "targetMember2");
+            Member targetMember3 = createMember("targetMember3@gmail.com", "targetMember3");
+
+            createMannerRating(List.of(1L, 2L, 3L, 4L, 5L, 6L), targetMember1, member, true);
+            createMannerRating(List.of(1L, 2L, 3L), targetMember2, member, true);
+            createMannerRating(List.of(7L, 8L), targetMember3, member, false);
+
+            member.updateMannerScore(5);
+            member.updateMannerRank(50.0);
+
+            // when
+            MannerResponse response = mannerFacadeService.getMannerInfo(member);
+
+            // then
+            assertThat(response.getMannerLevel()).isEqualTo(1);
+            assertThat(response.getMannerRank()).isEqualTo(50.0);
+            assertThat(response.getMannerRatingCount()).isEqualTo(2);
+
+            Map<Long, Integer> assertMap = new HashMap<>();
+            assertMap.put(1L, 2);
+            assertMap.put(2L, 2);
+            assertMap.put(3L, 2);
+            assertMap.put(4L, 1);
+            assertMap.put(5L, 1);
+            assertMap.put(6L, 1);
+            assertMap.put(7L, 1);
+            assertMap.put(8L, 1);
+            assertMap.put(9L, 0);
+            assertMap.put(10L, 0);
+            assertMap.put(11L, 0);
+            assertMap.put(12L, 0);
+
+            assertThat(response.getMannerKeywords())
+                    .hasSize(assertMap.size())
+                    .allMatch(mannerKeywordResponse ->
+                            assertMap.get(mannerKeywordResponse.getMannerKeywordId())
+                                    .equals(mannerKeywordResponse.getCount()));
+        }
+
     }
 
     private Member createMember(String email, String gameName) {

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/manner/MannerRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/manner/MannerRepositoryTest.java
@@ -1,0 +1,125 @@
+package com.gamegoo.gamegoo_v2.repository.manner;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.repository.RepositoryTestSupport;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
+import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRatingKeyword;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingKeywordRepository;
+import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MannerRepositoryTest extends RepositoryTestSupport {
+
+    @Autowired
+    MannerRatingKeywordRepository mannerRatingKeywordRepository;
+
+    @Autowired
+    MannerKeywordRepository mannerKeywordRepository;
+
+    @Autowired
+    MannerRatingRepository mannerRatingRepository;
+
+    private final List<Long> mannerKeywordIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L);
+
+    @Nested
+    @DisplayName("회원이 받은 매너 키워드 별 개수 조회")
+    class CountMannerKeywordByToMemberIdTest {
+
+        @DisplayName("받은 매너 키워드가 없는 경우")
+        @Test
+        void countMannerKeywordByToMemberIdWhenNoMannerKeyword() {
+            // when
+            Map<Long, Integer> resultMap = mannerRatingKeywordRepository.countMannerKeywordByToMemberId(member.getId());
+
+            // then
+            assertThat(resultMap)
+                    .isNotNull()
+                    .hasSize(mannerKeywordIds.size())
+                    .containsKeys(mannerKeywordIds.toArray(new Long[0]))
+                    .allSatisfy((key, value) -> assertThat(value).isEqualTo(0));
+        }
+
+        @DisplayName("받은 매너 키워드가 있는 경우")
+        @Test
+        void countMannerKeywordByToMemberId() {
+            // given
+            initMannerKeyword();
+            Member targetMember1 = createMember("targetMember1@gmail.com", "targetMember1");
+            Member targetMember2 = createMember("targetMember2@gmail.com", "targetMember2");
+            Member targetMember3 = createMember("targetMember3@gmail.com", "targetMember3");
+
+            createMannerRating(List.of(1L, 2L, 3L, 4L, 5L, 6L), targetMember1, member, true);
+            createMannerRating(List.of(1L, 2L, 3L), targetMember2, member, true);
+            createMannerRating(List.of(7L, 8L), targetMember3, member, false);
+
+            // when
+            Map<Long, Integer> resultMap = mannerRatingKeywordRepository.countMannerKeywordByToMemberId(member.getId());
+
+            // then
+            assertThat(resultMap)
+                    .isNotNull()
+                    .hasSize(mannerKeywordIds.size())
+                    .containsKeys(mannerKeywordIds.toArray(new Long[0]));
+
+            assertThat(resultMap.get(1L)).isEqualTo(2);
+            assertThat(resultMap.get(2L)).isEqualTo(2);
+            assertThat(resultMap.get(3L)).isEqualTo(2);
+            assertThat(resultMap.get(4L)).isEqualTo(1);
+            assertThat(resultMap.get(5L)).isEqualTo(1);
+            assertThat(resultMap.get(6L)).isEqualTo(1);
+            assertThat(resultMap.get(7L)).isEqualTo(1);
+            assertThat(resultMap.get(8L)).isEqualTo(1);
+            assertThat(resultMap.get(9L)).isEqualTo(0);
+            assertThat(resultMap.get(10L)).isEqualTo(0);
+            assertThat(resultMap.get(11L)).isEqualTo(0);
+            assertThat(resultMap.get(12L)).isEqualTo(0);
+        }
+
+    }
+
+    private MannerRating createMannerRating(List<Long> mannerKeywordIds, Member member, Member targetMember,
+                                            boolean positive) {
+        // 매너 키워드 엔티티 조회
+        List<MannerKeyword> mannerKeywordList = mannerKeywordRepository.findAllById(mannerKeywordIds);
+
+        // MannerRating 엔티티 생성 및 저장
+        MannerRating mannerRating = mannerRatingRepository.save(MannerRating.create(member, targetMember, positive));
+
+        // MannerRatingKeyword 엔티티 생성 및 저장
+        List<MannerRatingKeyword> mannerRatingKeywordList = mannerKeywordList.stream()
+                .map(mannerKeyword -> MannerRatingKeyword.create(mannerRating, mannerKeyword))
+                .toList();
+        mannerRatingKeywordRepository.saveAll(mannerRatingKeywordList);
+
+        return mannerRating;
+    }
+
+    private void initMannerKeyword() {
+        List<MannerKeyword> mannerKeywords = List.of(
+                MannerKeyword.create("캐리했어요", true),
+                MannerKeyword.create("1인분 이상은 해요", true),
+                MannerKeyword.create("욕 안해요", true),
+                MannerKeyword.create("남탓 안해요", true),
+                MannerKeyword.create("매너 있어요", true),
+                MannerKeyword.create("답장 빠름", true),
+                MannerKeyword.create("탈주", false),
+                MannerKeyword.create("욕설", false),
+                MannerKeyword.create("고의 트롤", false),
+                MannerKeyword.create("대리 사용자", false),
+                MannerKeyword.create("소환사명 불일치", false),
+                MannerKeyword.create("답장이 없어요", false)
+        );
+        mannerKeywordRepository.saveAll(mannerKeywords);
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 매너 정보 조회 API 구현 및 테스트

## ⏳ 작업 상세 내용
- [x] 회원이 받은 매너 키워드별 개수 조회 쿼리 구현
- [x] 회원이 받은 매너 키워드별 개수 조회 쿼리 repository 테스트
- [x] 특정 회원의 매너 정보 조회 API 구현
- [x] 특정 회원의 매너 정보 조회 API 통합 테스트
- [x] 특정 회원의 매너 정보 조회 API 컨트롤러 테스트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] member 엔티티에 mannerRank (매너 점수 상위 n% 정보) 필드 추가했습니다. 기존에는 매너 정보 조회할 때마다 db 조회로 상위 몇퍼센트인지 계산해서 응답했었는데 이걸 그냥 member 테이블에서 바로 가져오는게 나을 것 같아서 수정했어요..! 앞으로는 스케줄러로 주기적으로 mannerRank 갱신해주려고 합니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
