### PR TITLE
[Feat/158] 회원 매너 랭크 업데이트 스케줄러 구현 및 테스트

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.account.member.repository;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -10,5 +12,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    @Query("SELECT m.id FROM Member m WHERE m.mannerScore IS NOT NULL ORDER BY m.mannerScore desc")
+    List<Long> getMemberIdsOrderByMannerScoreIsNotNull();
+
+    List<Long> getMemberIdsWhereMannerScoreIsNullAndMannerRankIsNotNull();
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
@@ -16,6 +16,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m.id FROM Member m WHERE m.mannerScore IS NOT NULL ORDER BY m.mannerScore desc")
     List<Long> getMemberIdsOrderByMannerScoreIsNotNull();
 
+    @Query("SELECT m.id FROM Member m WHERE m.mannerScore IS NULL AND m.mannerRank IS NOT NULL")
     List<Long> getMemberIdsWhereMannerScoreIsNullAndMannerRankIsNotNull();
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/batch/BatchFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/batch/BatchFacadeService.java
@@ -50,25 +50,27 @@ public class BatchFacadeService {
     public void updateMannerRanks() {
         List<Long> memberIds = mannerService.getMannerRankUpdateTargets();
 
-        if (!memberIds.isEmpty()) {
-            int totalMembers = memberIds.size();
+        int totalMembers = memberIds.size();
 
-            // mannerRank를 계산해 Map 생성
-            Map<Long, Double> mannerRankMap = IntStream.range(0, totalMembers)
-                    .boxed()
-                    .collect(Collectors.toMap(memberIds::get, i -> (double) i / totalMembers));
+        // mannerRank를 계산해 Map 생성
+        Map<Long, Double> mannerRankMap = IntStream.range(0, totalMembers)
+                .boxed()
+                .collect(Collectors.toMap(
+                        memberIds::get,
+                        i -> Math.round((double) (i + 1) / totalMembers * 1000) / 10.0
+                ));
 
-            // 전체 데이터 list 생성
-            List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
+        // 전체 데이터 list 생성
+        List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
 
-            // batch로 나누어 업데이트 처리
-            for (int i = 0; i < entries.size(); i += BATCH_SIZE) {
-                int end = Math.min(i + BATCH_SIZE, entries.size());
-                List<Map.Entry<Long, Double>> batch = entries.subList(i, end);
+        // batch로 나누어 업데이트 처리
+        for (int i = 0; i < entries.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, entries.size());
+            List<Map.Entry<Long, Double>> batch = entries.subList(i, end);
 
-                batchService.batchUpdateMannerRanks(batch);
-            }
+            batchService.batchUpdateMannerRanks(batch);
         }
+
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/batch/BatchFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/batch/BatchFacadeService.java
@@ -1,0 +1,74 @@
+package com.gamegoo.gamegoo_v2.core.batch;
+
+import com.gamegoo.gamegoo_v2.social.manner.service.MannerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class BatchFacadeService {
+
+    private final BatchService batchService;
+    private final MannerService mannerService;
+
+    @Value("${batch_size.manner_rank}")
+    private int BATCH_SIZE;
+
+    /**
+     * mannerScore가 null인 모든 회원의 mannerRank를 null로 업데이트하는 facade 메소드
+     */
+    public void resetMannerRanks() {
+        List<Long> memberIds = mannerService.getMannerRankResetTargets();
+
+        // mannerRank를 null로 설정하는 Map 생성
+        Map<Long, Double> mannerRankMap = new HashMap<>();
+        memberIds.forEach(memberId -> mannerRankMap.put(memberId, null));
+
+        // 전체 데이터 list 생성
+        List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
+
+        // batch로 나누어 업데이트 처리
+        for (int i = 0; i < entries.size(); i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, entries.size());
+            List<Map.Entry<Long, Double>> batch = entries.subList(i, end);
+
+            batchService.batchUpdateMannerRanks(batch);
+        }
+    }
+
+    /**
+     * mannerScore가 null이 아닌 모든 회원의 mannerRank를 계산해 업데이트하는 facade 메소드
+     */
+    public void updateMannerRanks() {
+        List<Long> memberIds = mannerService.getMannerRankUpdateTargets();
+
+        if (!memberIds.isEmpty()) {
+            int totalMembers = memberIds.size();
+
+            // mannerRank를 계산해 Map 생성
+            Map<Long, Double> mannerRankMap = IntStream.range(0, totalMembers)
+                    .boxed()
+                    .collect(Collectors.toMap(memberIds::get, i -> (double) i / totalMembers));
+
+            // 전체 데이터 list 생성
+            List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
+
+            // batch로 나누어 업데이트 처리
+            for (int i = 0; i < entries.size(); i += BATCH_SIZE) {
+                int end = Math.min(i + BATCH_SIZE, entries.size());
+                List<Map.Entry<Long, Double>> batch = entries.subList(i, end);
+
+                batchService.batchUpdateMannerRanks(batch);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/batch/BatchService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/batch/BatchService.java
@@ -1,0 +1,51 @@
+package com.gamegoo.gamegoo_v2.core.batch;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BatchService {
+
+    private final EntityManager entityManager;
+
+    /**
+     * 배치별 mannerRank 업데이트
+     *
+     * @param batch 배치로 처리할 데이터
+     */
+    @Transactional
+    public void batchUpdateMannerRanks(List<Map.Entry<Long, Double>> batch) {
+        if (batch == null || batch.isEmpty()) {
+            return;
+        }
+
+        String query = buildMannerRankBatchUpdateQuery(batch);
+        entityManager.createNativeQuery(query).executeUpdate();
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    /**
+     * mannerRank batch update 쿼리 생성
+     */
+    private String buildMannerRankBatchUpdateQuery(List<Map.Entry<Long, Double>> batch) {
+        String cases = batch.stream()
+                .map(entry -> String.format("WHEN member_id = %d THEN %s", entry.getKey(),
+                        entry.getValue() == null ? "NULL" : entry.getValue()))
+                .collect(Collectors.joining(" "));
+
+        String ids = batch.stream()
+                .map(entry -> String.valueOf(entry.getKey()))
+                .collect(Collectors.joining(", "));
+
+        return String.format("UPDATE member SET manner_rank = CASE %s END WHERE member_id IN (%s)", cases, ids);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SchedulerConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.gamegoo.gamegoo_v2.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/scheduler/MannerScheduler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/scheduler/MannerScheduler.java
@@ -1,6 +1,6 @@
-package com.gamegoo.gamegoo_v2.scheduler;
+package com.gamegoo.gamegoo_v2.core.scheduler;
 
-import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
+import com.gamegoo.gamegoo_v2.core.batch.BatchFacadeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MannerScheduler {
 
-    private final MannerFacadeService mannerFacadeService;
+    private final BatchFacadeService batchFacadeService;
 
     /**
      * 회원 mannerRank 업데이트
@@ -22,10 +22,10 @@ public class MannerScheduler {
     public void updateMannerRank() {
         try {
             // mannerScore가 있는 회원 업데이트
-            mannerFacadeService.updateMannerRanks();
+            batchFacadeService.updateMannerRanks();
 
             // mannerScore가 없는 회원 업데이트
-            mannerFacadeService.resetMannerRanks();
+            batchFacadeService.resetMannerRanks();
         } catch (Exception e) {
             log.error("failed to updateMannerRank Scheduler:", e);
         }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/scheduler/MannerScheduler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/scheduler/MannerScheduler.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Profile("dev")
 @Slf4j
@@ -19,7 +18,6 @@ public class MannerScheduler {
     /**
      * 회원 mannerRank 업데이트
      */
-    @Transactional
     @Scheduled(cron = "0 0 4 * * *")
     public void updateMannerRank() {
         try {

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/scheduler/MannerScheduler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/scheduler/MannerScheduler.java
@@ -3,10 +3,12 @@ package com.gamegoo.gamegoo_v2.core.scheduler;
 import com.gamegoo.gamegoo_v2.core.batch.BatchFacadeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Profile("dev")
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/gamegoo/gamegoo_v2/scheduler/MannerScheduler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/scheduler/MannerScheduler.java
@@ -1,0 +1,34 @@
+package com.gamegoo.gamegoo_v2.scheduler;
+
+import com.gamegoo.gamegoo_v2.social.manner.service.MannerFacadeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MannerScheduler {
+
+    private final MannerFacadeService mannerFacadeService;
+
+    /**
+     * 회원 mannerRank 업데이트
+     */
+    @Transactional
+    @Scheduled(cron = "0 0 4 * * *")
+    public void updateMannerRank() {
+        try {
+            // mannerScore가 있는 회원 업데이트
+            mannerFacadeService.updateMannerRanks();
+
+            // mannerScore가 없는 회원 업데이트
+            mannerFacadeService.resetMannerRanks();
+        } catch (Exception e) {
+            log.error("failed to updateMannerRank Scheduler:", e);
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -154,7 +154,7 @@ public class MannerFacadeService {
      */
     @Transactional
     public void resetMannerRanks() {
-        List<Long> memberIds = mannerService.getMannerRankNullUpdateTargets();
+        List<Long> memberIds = mannerService.getMannerRankResetTargets();
         Map<Long, Double> mannerRankMap = new HashMap<>();
         memberIds.forEach(memberId -> mannerRankMap.put(memberId, null));
         mannerService.batchUpdateMannerRanks(mannerRankMap);

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -14,12 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -147,32 +144,6 @@ public class MannerFacadeService {
                 .toList();
 
         return MannerResponse.of(mannerLevel, mannerRank, mannerRatingCount, mannerKeywordResponses);
-    }
-
-    /**
-     * 매너 점수가 null인 모든 회원의 mannerRank를 null로 업데이트하는 facade 메소드
-     */
-    @Transactional
-    public void resetMannerRanks() {
-        List<Long> memberIds = mannerService.getMannerRankResetTargets();
-        Map<Long, Double> mannerRankMap = new HashMap<>();
-        memberIds.forEach(memberId -> mannerRankMap.put(memberId, null));
-        mannerService.batchUpdateMannerRanks(mannerRankMap);
-    }
-
-    /**
-     * 매너 점수가 null이 아닌 모든 회원의 mannerRank를 계산해 업데이트하는 facade 메소드
-     */
-    @Transactional
-    public void updateMannerRanks() {
-        List<Long> memberIds = mannerService.getMannerRankUpdateTargets();
-        if (!memberIds.isEmpty()) {
-            int totalMembers = memberIds.size();
-            Map<Long, Double> mannerRankMap = IntStream.range(0, totalMembers)
-                    .boxed()
-                    .collect(Collectors.toMap(memberIds::get, i -> (double) i / totalMembers));
-            mannerService.batchUpdateMannerRanks(mannerRankMap);
-        }
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -14,9 +14,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -126,7 +129,7 @@ public class MannerFacadeService {
      */
     public MannerResponse getMannerInfo(Long memberId) {
         Member member = memberService.findMemberById(memberId);
-        
+
         // 매너 레벨 조회
         int mannerLevel = member.getMannerLevel();
 
@@ -144,6 +147,32 @@ public class MannerFacadeService {
                 .toList();
 
         return MannerResponse.of(mannerLevel, mannerRank, mannerRatingCount, mannerKeywordResponses);
+    }
+
+    /**
+     * 매너 점수가 null인 모든 회원의 mannerRank를 null로 업데이트하는 facade 메소드
+     */
+    @Transactional
+    public void resetMannerRanks() {
+        List<Long> memberIds = mannerService.getMannerRankNullUpdateTargets();
+        Map<Long, Double> mannerRankMap = new HashMap<>();
+        memberIds.forEach(memberId -> mannerRankMap.put(memberId, null));
+        mannerService.batchUpdateMannerRanks(mannerRankMap);
+    }
+
+    /**
+     * 매너 점수가 null이 아닌 모든 회원의 mannerRank를 계산해 업데이트하는 facade 메소드
+     */
+    @Transactional
+    public void updateMannerRanks() {
+        List<Long> memberIds = mannerService.getMannerRankUpdateTargets();
+        if (!memberIds.isEmpty()) {
+            int totalMembers = memberIds.size();
+            Map<Long, Double> mannerRankMap = IntStream.range(0, totalMembers)
+                    .boxed()
+                    .collect(Collectors.toMap(memberIds::get, i -> (double) i / totalMembers));
+            mannerService.batchUpdateMannerRanks(mannerRankMap);
+        }
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
@@ -14,7 +14,6 @@ import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRatingKeyword;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerKeywordRepository;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingKeywordRepository;
 import com.gamegoo.gamegoo_v2.social.manner.repository.MannerRatingRepository;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -39,7 +38,6 @@ public class MannerService {
     private final MannerRatingKeywordRepository mannerRatingKeywordRepository;
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final EntityManager entityManager;
 
     private final int MANNER_KEYWORD_ID_MAX = 12;
     private final int MANNER_KEYWORD_ID_MIN = 1;
@@ -200,37 +198,6 @@ public class MannerService {
      */
     public List<Long> getMannerRankResetTargets() {
         return memberRepository.getMemberIdsWhereMannerScoreIsNullAndMannerRankIsNotNull();
-    }
-
-    /**
-     * id에 해당하는 회원의 mannerRank를 batch update
-     *
-     * @param mannerRankUpdates Map<회원 id,mannerRank>
-     */
-    @Transactional
-    public void batchUpdateMannerRanks(Map<Long, Double> mannerRankUpdates) {
-        if (mannerRankUpdates == null || mannerRankUpdates.isEmpty()) {
-            return;
-        }
-
-        // Native Query 생성
-        StringBuilder queryBuilder = new StringBuilder("UPDATE my_entity SET manner_rank = CASE ");
-
-        for (Map.Entry<Long, Double> entry : mannerRankUpdates.entrySet()) {
-            queryBuilder.append("WHEN id = ").append(entry.getKey())
-                    .append(" THEN ")
-                    .append(entry.getValue() == null ? "NULL" : entry.getValue())
-                    .append(" ");
-        }
-
-        queryBuilder.append("END WHERE id IN (")
-                .append(mannerRankUpdates.keySet().stream()
-                        .map(String::valueOf)
-                        .collect(Collectors.joining(", ")))
-                .append(")");
-
-        // Native Query 실행
-        entityManager.createNativeQuery(queryBuilder.toString()).executeUpdate();
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerService.java
@@ -185,7 +185,7 @@ public class MannerService {
     }
 
     /**
-     * mannerRank를 null이 아닌 값으로 업데이트할 대상 회원 id list 조회
+     * mannerRank를 업데이트할 대상 회원 id list 조회
      *
      * @return 회원 id list
      */
@@ -194,11 +194,11 @@ public class MannerService {
     }
 
     /**
-     * mannerRank를 null로 업데이트할 대상 회원 id list 조회
+     * mannerRank를 null로 초기화 할 대상 회원 id list 조회
      *
      * @return 회원 id list
      */
-    public List<Long> getMannerRankNullUpdateTargets() {
+    public List<Long> getMannerRankResetTargets() {
         return memberRepository.getMemberIdsWhereMannerScoreIsNullAndMannerRankIsNotNull();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,12 +20,9 @@ spring:
     api:
       key: ${RIOT_API}
 
-  # batch update 설정
-  jpa:
-    properties:
-      hibernate:
-        jdbc:
-          batch_size: 30
+# batch size 설정
+batch_size:
+  manner_rank: 30
 
 springdoc:
   swagger-ui:
@@ -45,6 +42,7 @@ socket:
 email:
   report_email_to: gamegoo2025@gmail.com
   report_email_template_path: templates/new-report.html
+
 
 ---
 # 로컬 환경

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,13 @@ spring:
     api:
       key: ${RIOT_API}
 
+  # batch update 설정
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 30
+
 springdoc:
   swagger-ui:
     tags-sorter: alpha            # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/batch/BatchFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/batch/BatchFacadeServiceTest.java
@@ -1,0 +1,217 @@
+package com.gamegoo.gamegoo_v2.integration.batch;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.core.batch.BatchFacadeService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class BatchFacadeServiceTest {
+
+    @Autowired
+    private BatchFacadeService batchFacadeService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockitoSpyBean
+    private EntityManager entityManager;
+
+    @Value("${batch_size.manner_rank}")
+    private int BATCH_SIZE;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("매너 랭크 초기화")
+    class ResetMannerRanksTest {
+
+        @DisplayName("초기화 대상이 없는 경우")
+        @Test
+        void resetMannerRanksWhenNoTarget() {
+            // given
+            Member member1 = createMember("member1@gmail.com", "member1");
+            Member member2 = createMember("member2@gmail.com", "member2");
+            updateMannerScore(member2, 1);
+            updateMannerRank(member2, 50.0);
+
+            // when
+            batchFacadeService.resetMannerRanks();
+
+            // then
+            assertThat(member1.getMannerRank()).isNull();
+            assertThat(member2.getMannerRank()).isEqualTo(50.0);
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(0)).createNativeQuery(anyString());
+
+        }
+
+        @DisplayName("초기화 대상이 batch size 이하인 경우")
+        @Test
+        void resetMannerRanksWhenLessThanBatchSize() {
+            // given
+            Member member1 = createMember("member1@gmail.com", "member1");
+            Member member2 = createMember("member2@gmail.com", "member2");
+            updateMannerRank(member1, 25.0);
+            updateMannerRank(member2, 50.0);
+
+            // when
+            batchFacadeService.resetMannerRanks();
+
+            // then
+            Member updatedMember1 = memberRepository.findById(member1.getId()).orElseThrow();
+            Member updatedMember2 = memberRepository.findById(member2.getId()).orElseThrow();
+            assertThat(updatedMember1.getMannerRank()).isNull();
+            assertThat(updatedMember2.getMannerRank()).isNull();
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(1)).createNativeQuery(anyString());
+        }
+
+        @DisplayName("초기화 대상이 batch size 이상인 경우")
+        @Test
+        void resetMannerRanksWhenGreaterThanBatchSize() {
+            // given
+            List<Long> memberIds = new ArrayList<>();
+            for (int i = 0; i < BATCH_SIZE + 10; i++) {
+                Member member = createMember("member1@gmail.com", "member1");
+                updateMannerRank(member, (double) i);
+                memberIds.add(member.getId());
+            }
+
+            // when
+            batchFacadeService.resetMannerRanks();
+
+            // then
+            memberIds.forEach(id -> {
+                assertThat(memberRepository.findById(id).orElseThrow().getMannerRank()).isNull();
+            });
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(2)).createNativeQuery(anyString());
+        }
+
+    }
+
+    @Nested
+    @DisplayName("매너 랭크 업데이트")
+    class UpdateMannerRanksTest {
+
+        @DisplayName("업데이트 대상이 없는 경우")
+        @Test
+        void updateMannerRanksWhenNoTarget() {
+            // given
+            Member member1 = createMember("member1@gmail.com", "member1");
+            Member member2 = createMember("member2@gmail.com", "member2");
+
+            // when
+            batchFacadeService.updateMannerRanks();
+
+            // then
+            assertThat(member1.getMannerRank()).isNull();
+            assertThat(member2.getMannerRank()).isNull();
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(0)).createNativeQuery(anyString());
+
+        }
+
+        @DisplayName("업데이트 대상이 batch size 이하인 경우")
+        @Test
+        void updateMannerRanksWhenLessThanBatchSize() {
+            // given
+            Member member1 = createMember("member1@gmail.com", "member1");
+            Member member2 = createMember("member2@gmail.com", "member2");
+            updateMannerScore(member1, 1);
+            updateMannerScore(member2, 2);
+
+            // when
+            batchFacadeService.updateMannerRanks();
+
+            // then
+            Member updatedMember1 = memberRepository.findById(member1.getId()).orElseThrow();
+            Member updatedMember2 = memberRepository.findById(member2.getId()).orElseThrow();
+            assertThat(updatedMember1.getMannerRank()).isEqualTo(100.0);
+            assertThat(updatedMember2.getMannerRank()).isEqualTo(50.0);
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(1)).createNativeQuery(anyString());
+        }
+
+        @DisplayName("업데이트 대상이 batch size 이상인 경우")
+        @Test
+        void updateMannerRanksWhenGreaterThanBatchSize() {
+            // given
+            List<Long> memberIds = new ArrayList<>();
+            for (int i = 0; i < BATCH_SIZE + 20; i++) {
+                Member member = createMember("member1@gmail.com", "member1");
+                updateMannerScore(member, BATCH_SIZE + 20 - i);
+                memberIds.add(member.getId());
+            }
+
+            // when
+            batchFacadeService.updateMannerRanks();
+
+            // then
+            for (int i = 0; i < BATCH_SIZE + 20; i++) {
+                Member member = memberRepository.findById(memberIds.get(i)).orElseThrow();
+                assertThat(member.getMannerRank()).isEqualTo(2.0 * (i + 1));
+            }
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(2)).createNativeQuery(anyString());
+        }
+
+    }
+
+    private void updateMannerRank(Member member, Double rank) {
+        member.updateMannerRank(rank);
+        memberRepository.save(member);
+    }
+
+    private void updateMannerScore(Member member, Integer score) {
+        member.updateMannerScore(score);
+        memberRepository.save(member);
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/batch/BatchServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/batch/BatchServiceTest.java
@@ -1,0 +1,161 @@
+package com.gamegoo.gamegoo_v2.service.batch;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.core.batch.BatchService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class BatchServiceTest {
+
+    @Autowired
+    BatchService batchService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @MockitoSpyBean
+    EntityManager entityManager;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("매너 랭크 배치 업데이트")
+    class BatchUpdateMannerRanksTest {
+
+        @DisplayName("map이 비어있는 경우")
+        @Test
+        void batchUpdateMannerRanksWhenMapIsEmpty() {
+            // given
+            Member member = createMember("member1@gmail.com", "member1");
+
+            Map<Long, Double> emptyMap = Collections.emptyMap();
+            List<Map.Entry<Long, Double>> entries = new ArrayList<>(emptyMap.entrySet());
+
+            // when
+            batchService.batchUpdateMannerRanks(entries);
+
+            // then
+            Member resultMember = memberRepository.findById(member.getId()).orElseThrow();
+            assertThat(resultMember.getMannerRank()).isNull();
+        }
+
+        @DisplayName("mannerRank 값이 null인 경우")
+        @Test
+        void batchUpdateMannerRanksWhenValueIsNull() {
+            // given
+            Member member = createMember("test@email.com", "testMember");
+            updateMannerRank(member, 1.0);
+
+            Map<Long, Double> mannerRankMap = new HashMap<>();
+            mannerRankMap.put(member.getId(), null);
+
+            List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
+
+            // when
+            batchService.batchUpdateMannerRanks(entries);
+
+            // then
+            Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+            assertThat(updatedMember.getMannerRank()).isNull();
+        }
+
+        @DisplayName("mannerRank 값이 null이 아닌 경우")
+        @Test
+        void batchUpdateMannerRanksWhenValueIsNotNull() {
+            // given
+            Member member = createMember("test@email.com", "testMember");
+            updateMannerRank(member, 1.0);
+
+            Map<Long, Double> mannerRankMap = new HashMap<>();
+            mannerRankMap.put(member.getId(), 50.0);
+
+            List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
+
+            // when
+            batchService.batchUpdateMannerRanks(entries);
+
+            // then
+            Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+            assertThat(updatedMember.getMannerRank()).isEqualTo(50.0);
+        }
+
+        @DisplayName("batch size만큼의 업데이트 요청인 경우")
+        @Test
+        void batchUpdateMannerRanksWithMaxSize() {
+            // given
+            int batchSize = 30;
+            List<Member> members = new ArrayList<>();
+            Map<Long, Double> mannerRankMap = new HashMap<>();
+
+            for (int i = 0; i < batchSize; i++) {
+                Member member = createMember("member" + i + "@gmail.com", "member" + i);
+                members.add(member);
+                mannerRankMap.put(member.getId(), (double) (i + 1));
+            }
+
+            List<Map.Entry<Long, Double>> entries = new ArrayList<>(mannerRankMap.entrySet());
+
+            // when
+            batchService.batchUpdateMannerRanks(entries);
+
+            // then
+            // mannerRank 업데이트 검증
+            for (int i = 0; i < batchSize; i++) {
+                Member updatedMember = memberRepository.findById(members.get(i).getId()).orElseThrow();
+                assertThat(updatedMember.getMannerRank()).isEqualTo((double) (i + 1));
+            }
+
+            // 쿼리 실행 횟수 검증
+            verify(entityManager, Mockito.times(1)).createNativeQuery(anyString());
+        }
+
+    }
+
+    private void updateMannerRank(Member member, Double rank) {
+        member.updateMannerRank(rank);
+        memberRepository.save(member);
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/manner/MannerServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/manner/MannerServiceTest.java
@@ -1,0 +1,138 @@
+package com.gamegoo.gamegoo_v2.service.manner;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.social.manner.service.MannerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class MannerServiceTest {
+
+    @Autowired
+    MannerService mannerService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("매너 랭크 업데이트 대상 회원 조회")
+    class GetMannerRankUpdateTargetsTest {
+
+        @DisplayName("대상 회원이 없는 경우")
+        @Test
+        void getMannerRankUpdateTargetsSucceedsWhenNoTarget() {
+            // given
+            createMember("member1@gmail.com", "member1");
+
+            // when
+            List<Long> memberIds = mannerService.getMannerRankUpdateTargets();
+
+            // then
+            assertThat(memberIds).isEmpty();
+        }
+
+        @DisplayName("대상 회원이 있는 경우")
+        @Test
+        void getMannerRankUpdateTargetsSucceeds() {
+            // given
+            List<Long> memberIds = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                Member member = createMember("member@email", "member" + i);
+                updateMannerScore(member, i + 1);
+                memberIds.add(member.getId());
+            }
+
+            // when
+            List<Long> resultIds = mannerService.getMannerRankUpdateTargets();
+
+            // then
+            Collections.reverse(memberIds);
+            assertThat(resultIds).isEqualTo(memberIds);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("매너 랭크 초기화 대상 회원 조회")
+    class GetMannerRankResetTargetsTest {
+
+        @DisplayName("대상 회원이 없는 경우")
+        @Test
+        void getMannerRankResetTargetsSucceedsWhenNoTarget() {
+            // given
+            Member member1 = createMember("member1@gmail.com", "member1");
+            updateMannerScore(member1, 1);
+            createMember("member2@gmail.com", "member2");
+
+            // when
+            List<Long> memberIds = mannerService.getMannerRankResetTargets();
+
+            // then
+            assertThat(memberIds).isEmpty();
+        }
+
+        @DisplayName("대상 회원이 있는 경우")
+        @Test
+        void getMannerRankResetTargetsSucceeds() {
+            // given
+            Member member1 = createMember("member1@gmail.com", "member1");
+            updateMannerRank(member1, 1.0);
+
+            // when
+            List<Long> memberIds = mannerService.getMannerRankResetTargets();
+
+            // then
+            assertThat(memberIds).hasSize(1);
+            assertThat(memberIds.get(0)).isEqualTo(member1.getId());
+        }
+
+    }
+
+
+    private void updateMannerScore(Member member, Integer score) {
+        member.updateMannerScore(score);
+        memberRepository.save(member);
+    }
+
+    private void updateMannerRank(Member member, Double rank) {
+        member.updateMannerRank(rank);
+        memberRepository.save(member);
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .tier(Tier.IRON)
+                .gameRank(0)
+                .winRate(0.0)
+                .gameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/manner/MannerServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/manner/MannerServiceTest.java
@@ -108,7 +108,6 @@ public class MannerServiceTest {
 
     }
 
-
     private void updateMannerScore(Member member, Integer score) {
         member.updateMannerScore(score);
         memberRepository.save(member);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,10 @@ spring:
     api:
       key: key
 
+# batch size 설정
+batch_size:
+  manner_rank: 30
+
 jwt:
   secret: "secretjwttestjwtsecretsecretjwttestjwtsecretsecretjwttestjwtsecretsecretjwttestjwtsecretsecretjwttestjwtsecret"
   access_expiration_time: 600000 # 10분 (10 * 60 * 1000 밀리초)


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 회원 매너 랭크 업데이트 스케줄러 구현 및 테스트

## ⏳ 작업 상세 내용
- [x] mannerRank 업데이트 대상 조회 메소드 구현
- [x] mannerRank 업데이트 대상 조회 메소드 테스트
- [x] mannerRank 업데이트 서비스 메소드 테스트
- [x] mannerRank 업데이트 facade 메소드 구현
- [x] mannerRank 업데이트 facade 메소드 테스트
- [x] 회원 mannerRank 업데이트 스케줄러 구현 

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 배치 업데이트 작업을 담당하는 BatchFacadeService를 별도로 만들었습니다.
- [ ] 스케줄러로 오전 4시에 회원의 mannerRank를 업데이트 하도록 해두었는데, 스케줄러는 개발 배포 환경에서만 활성화되도록 했습니다.
- [ ] 각 회원마다 update 쿼리가 한번씩 실행되는게 아니라 batch size를 30으로 두어서 한번의 쿼리에 최대 30명의 mannerRank를 update할 수 있도록 했습니다. 트랜잭션도 전체 회원 업데이트에 대해서가 아니라 각 배치마다 각각 트랜잭션이 생성되도록 했습니다.


## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
