### PR TITLE
[Fix/165] 신고 등록 시 관리자 메일 발송 버그 수정

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/email/service/EmailService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/email/service/EmailService.java
@@ -100,7 +100,7 @@ public class EmailService {
             javaMailSender.send(message);
 
         } catch (Exception e) {
-            log.error("이메일 전송에 실패했습니다.");
+            log.error("이메일 전송에 실패했습니다.", e);
             throw new EmailException(ErrorCode.EMAIL_SEND_FAIL);
         }
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportRequest.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.core.common.annotation.NotDuplicated;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
@@ -27,6 +28,7 @@ public class ReportRequest {
 
     @Min(value = 1, message = "path code는 1 이상의 값이어야 합니다.")
     @Max(value = 3, message = "path code는 3 이하의 값이어야 합니다.")
+    @NotNull(message = "path code는 필수 값 입니다.")
     Integer pathCode;
 
     Long boardId;

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/event/listener/EmailEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/event/listener/EmailEventListener.java
@@ -46,7 +46,7 @@ public class EmailEventListener {
             placeholders.put("REPORT_TO_MEMBER_ID", event.getToMemberId().toString());
             placeholders.put("REPORT_PATH", report.getPath().name());
             placeholders.put("REPORT_TYPE", reportService.getReportTypeString(event.getReportId()));
-            placeholders.put("REPORT_CONTENT", report.getContent());
+            placeholders.put("REPORT_CONTENT", report.getContent() != null ? report.getContent() : "null");
 
             emailService.sendEmail(reportEmailTo, subject, reportTemplatePath, placeholders);
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/report/ReportControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/report/ReportControllerTest.java
@@ -185,6 +185,37 @@ public class ReportControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.message").value("contents는 1000자 이내여야 합니다."));
         }
 
+        @DisplayName("실패: 경로 코드 값이 없는 경우 에러 응답을 반환한다.")
+        @Test
+        void addReportFailedWhenPathCodeIsNull() throws Exception {
+            // given
+            List<Integer> reportCodeList = List.of(1, 2, 3);
+
+            ReportRequest request = ReportRequest.builder()
+                    .reportCodeList(reportCodeList)
+                    .contents("contents")
+                    .pathCode(null)
+                    .boardId(null)
+                    .build();
+
+            ReportInsertResponse response = ReportInsertResponse.builder()
+                    .reportId(1L)
+                    .message("신고가 정상적으로 접수 되었습니다.")
+                    .build();
+
+            given(reportFacadeService.addReport(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(ReportRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("VALID_ERROR"))
+                    .andExpect(jsonPath("$.message").value("path code는 필수 값 입니다."));
+
+        }
+
         @DisplayName("실패: 경로 코드가 1보다 작은 경우 에러 응답을 반환한다.")
         @Test
         void addReportFailedWhenPathCodeLessThanMin() throws Exception {
@@ -277,7 +308,7 @@ public class ReportControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.data.message").value("신고가 정상적으로 접수 되었습니다."));
         }
 
-        @DisplayName("텍스트, 경로 코드, 게시글 id가 null일 때 성공")
+        @DisplayName("텍스트, 게시글 id가 null일 때 성공")
         @Test
         void addReportFailedSucceedsWhenNull() throws Exception {
             // given
@@ -286,7 +317,7 @@ public class ReportControllerTest extends ControllerTestSupport {
             ReportRequest request = ReportRequest.builder()
                     .reportCodeList(reportCodeList)
                     .contents(null)
-                    .pathCode(null)
+                    .pathCode(1)
                     .boardId(null)
                     .build();
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/report/ReportControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/report/ReportControllerTest.java
@@ -277,6 +277,37 @@ public class ReportControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.data.message").value("신고가 정상적으로 접수 되었습니다."));
         }
 
+        @DisplayName("텍스트, 경로 코드, 게시글 id가 null일 때 성공")
+        @Test
+        void addReportFailedSucceedsWhenNull() throws Exception {
+            // given
+            List<Integer> reportCodeList = List.of(1, 2, 3);
+
+            ReportRequest request = ReportRequest.builder()
+                    .reportCodeList(reportCodeList)
+                    .contents(null)
+                    .pathCode(null)
+                    .boardId(null)
+                    .build();
+
+            ReportInsertResponse response = ReportInsertResponse.builder()
+                    .reportId(1L)
+                    .message("신고가 정상적으로 접수 되었습니다.")
+                    .build();
+
+            given(reportFacadeService.addReport(any(Member.class), eq(TARGET_MEMBER_ID),
+                    any(ReportRequest.class))).willReturn(response);
+
+            // when // then
+            mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("OK"))
+                    .andExpect(jsonPath("$.data.reportId").value(1L))
+                    .andExpect(jsonPath("$.data.message").value("신고가 정상적으로 접수 되었습니다."));
+        }
+
     }
 
 }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 신고 등록 시 관리자 메일 발송 버그 수정

## ⏳ 작업 상세 내용

- [x] report content가 null일 때 Map에 넣는 로직 수정
- [x] ReportRequest의 pathCode @NotNull 검증 추가
- [x] 관련 테스트 케이스 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
