### PR TITLE
[Feat/163] 매너 정보 및 매너 키워드 개수 조회 API 분리

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerKeywordListResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerUpdateResponse;
@@ -79,11 +80,18 @@ public class MannerController {
         return ApiResponse.ok(mannerFacadeService.getMannerRating(member, targetMemberId, false));
     }
 
-    @Operation(summary = "특정 회원의 매너 정보 조회 API", description = "특정 회원의 매너 정보를 조회하는 API 입니다.")
+    @Operation(summary = "특정 회원의 매너 레벨 정보 조회 API", description = "특정 회원의 매너 레벨 정보를 조회하는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
-    @GetMapping("/{memberId}")
-    public ApiResponse<MannerResponse> getMannerInfo(@PathVariable(name = "memberId") Long memberId) {
+    @GetMapping("/level/{memberId}")
+    public ApiResponse<MannerResponse> getMannerLevelInfo(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(mannerFacadeService.getMannerInfo(memberId));
+    }
+
+    @Operation(summary = "특정 회원의 매너 키워드 정보 조회 API", description = "특정 회원의 매너 키워드 정보를 조회하는 API 입니다.")
+    @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
+    @GetMapping("/keyword/{memberId}")
+    public ApiResponse<MannerKeywordListResponse> getMannerKeywordInfo(@PathVariable(name = "memberId") Long memberId) {
+        return ApiResponse.ok(mannerFacadeService.getMannerKeywordInfo(memberId));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -84,7 +84,7 @@ public class MannerController {
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
     @GetMapping("/level/{memberId}")
     public ApiResponse<MannerResponse> getMannerLevelInfo(@PathVariable(name = "memberId") Long memberId) {
-        return ApiResponse.ok(mannerFacadeService.getMannerInfo(memberId));
+        return ApiResponse.ok(mannerFacadeService.getMannerLevelInfo(memberId));
     }
 
     @Operation(summary = "특정 회원의 매너 키워드 정보 조회 API", description = "특정 회원의 매너 키워드 정보를 조회하는 API 입니다.")

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerKeywordListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerKeywordListResponse.java
@@ -1,0 +1,20 @@
+package com.gamegoo.gamegoo_v2.social.manner.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MannerKeywordListResponse {
+
+    List<MannerKeywordResponse> mannerKeywords;
+
+    public static MannerKeywordListResponse of(List<MannerKeywordResponse> mannerKeywords) {
+        return MannerKeywordListResponse.builder()
+                .mannerKeywords(mannerKeywords)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/dto/response/MannerResponse.java
@@ -3,8 +3,6 @@ package com.gamegoo.gamegoo_v2.social.manner.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @Builder
 public class MannerResponse {
@@ -12,15 +10,12 @@ public class MannerResponse {
     int mannerLevel;
     Double mannerRank;
     int mannerRatingCount;
-    List<MannerKeywordResponse> mannerKeywords;
 
-    public static MannerResponse of(int mannerLevel, Double mannerRank, int mannerRatingCount,
-                                    List<MannerKeywordResponse> mannerKeywords) {
+    public static MannerResponse of(int mannerLevel, Double mannerRank, int mannerRatingCount) {
         return MannerResponse.builder()
                 .mannerLevel(mannerLevel)
                 .mannerRank(mannerRank)
                 .mannerRatingCount(mannerRatingCount)
-                .mannerKeywords(mannerKeywords)
                 .build();
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -120,12 +120,12 @@ public class MannerFacadeService {
     }
 
     /**
-     * 해당 회원의 매너 정보 조회 facade 메소드
+     * 해당 회원의 매너 레벨 정보 조회 facade 메소드
      *
      * @param memberId 회원 id
      * @return MannerResponse
      */
-    public MannerResponse getMannerInfo(Long memberId) {
+    public MannerResponse getMannerLevelInfo(Long memberId) {
         Member member = memberService.findMemberById(memberId);
 
         // 매너 레벨 조회

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/service/MannerFacadeService.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerKeywordListResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerKeywordResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
@@ -126,7 +127,7 @@ public class MannerFacadeService {
      */
     public MannerResponse getMannerInfo(Long memberId) {
         Member member = memberService.findMemberById(memberId);
-        
+
         // 매너 레벨 조회
         int mannerLevel = member.getMannerLevel();
 
@@ -136,6 +137,18 @@ public class MannerFacadeService {
         // 매너 평가 개수 조회
         int mannerRatingCount = mannerService.countMannerRatingByMember(member, true);
 
+        return MannerResponse.of(mannerLevel, mannerRank, mannerRatingCount);
+    }
+
+    /**
+     * 해당 회원의 매너 키워드별 받은 개수 정보 조회 facade 메소드
+     *
+     * @param memberId 회원 id
+     * @return MannerKewordListResponse
+     */
+    public MannerKeywordListResponse getMannerKeywordInfo(Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+
         // 매너 키워드별 받은 개수 조회
         Map<Long, Integer> mannerKeywordMap = mannerService.countMannerKeyword(member);
 
@@ -143,7 +156,7 @@ public class MannerFacadeService {
                 .map(entry -> MannerKeywordResponse.of(entry.getKey(), entry.getValue()))
                 .toList();
 
-        return MannerResponse.of(mannerLevel, mannerRank, mannerRatingCount, mannerKeywordResponses);
+        return MannerKeywordListResponse.of(mannerKeywordResponses);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.social.manner.controller.MannerController;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
+import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerKeywordListResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerRatingResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerResponse;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerUpdateResponse;
@@ -353,21 +354,37 @@ public class MannerControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.mannerKeywordIdList").isArray());
     }
 
-    @DisplayName("특정 회원의 매너 정보 조회")
+    @DisplayName("특정 회원의 매너 레벨 정보 조회")
     @Test
-    void getMannerInfoSucceeds() throws Exception {
+    void getMannerLevelInfoSucceeds() throws Exception {
         // given
-        MannerResponse response = MannerResponse.of(1, 50.0, 2, List.of());
+        MannerResponse response = MannerResponse.of(1, 50.0, 2);
 
-        given(mannerFacadeService.getMannerInfo(TARGET_MEMBER_ID)).willReturn(response);
+        given(mannerFacadeService.getMannerLevelInfo(TARGET_MEMBER_ID)).willReturn(response);
 
         // when // then
-        mockMvc.perform(get(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID))
+        mockMvc.perform(get(API_URL_PREFIX + "/level/{memberId}", TARGET_MEMBER_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andExpect(jsonPath("$.data.mannerLevel").value(1))
                 .andExpect(jsonPath("$.data.mannerRank").value(50.0))
-                .andExpect(jsonPath("$.data.mannerRatingCount").value(2))
+                .andExpect(jsonPath("$.data.mannerRatingCount").value(2));
+    }
+
+    @DisplayName("특정 회원의 매너 키워드 정보 조회")
+    @Test
+    void getMannerKeywordInfoSucceeds() throws Exception {
+        // given
+        MannerKeywordListResponse response = MannerKeywordListResponse.builder()
+                .mannerKeywords(List.of())
+                .build();
+
+        given(mannerFacadeService.getMannerKeywordInfo(TARGET_MEMBER_ID)).willReturn(response);
+
+        // when // then
+        mockMvc.perform(get(API_URL_PREFIX + "/keyword/{memberId}", TARGET_MEMBER_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"))
                 .andExpect(jsonPath("$.data.mannerKeywords").isArray());
     }
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 매너 정보 및 매너 키워드 개수 조회 API 분리

## ⏳ 작업 상세 내용

- [x] 기존 매너 정보 조회 API를 매너 레벨 정보 조회 API, 매너 키워드 정보 조회 API로 분리
- [x] 관련 테스트 코드 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
