### PR TITLE
[Test/169] 시큐리티 도입으로 인한 테스트코드 수정 및 SecurityConfig 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
@@ -44,6 +45,9 @@ dependencies {
     // rds ssh 접속
     implementation 'com.github.mwiede:jsch:0.2.16'
 
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
@@ -51,6 +55,7 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
@@ -2,10 +2,10 @@ package com.gamegoo.gamegoo_v2.account.auth.annotation.resolver;
 
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.account.auth.security.SecurityUtil;
-import com.gamegoo.gamegoo_v2.core.exception.MemberException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.core.exception.MemberException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -39,7 +39,6 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
         return memberRepository.findById(currentMemberId)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
@@ -5,20 +5,17 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import java.io.IOException;
-import java.util.List;
-
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
+import java.io.IOException;
+import java.util.List;
+
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
 
@@ -29,7 +26,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-
         String requestURI = request.getRequestURI();
 
         // JWT Filter를 사용하지 않는 Path는 제외
@@ -48,12 +44,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
             // UserDetails, Password, Role -> 접근권한 인증 Token 생성
             UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                    new UsernamePasswordAuthenticationToken(userDetails, null,
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null,
                             userDetails.getAuthorities());
 
             //현재 Request의 Security Context에 접근권한 설정
-            SecurityContextHolder.getContext()
-                    .setAuthentication(usernamePasswordAuthenticationToken);
+            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
         } else {
             SecurityContextHolder.getContext().setAuthentication(null);
         }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,16 +21,14 @@ import java.util.List;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final CustomUserDetailsService customUserDetailsService;
-    private final List<String> excludedPaths;
+    private final List<RequestMatcher> excludedRequestMatchers;
     private final JwtProvider jwtProvider;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        String requestURI = request.getRequestURI();
-
         // JWT Filter를 사용하지 않는 Path는 제외
-        if (excludedPaths.stream().anyMatch(requestURI::startsWith)) {
+        if (excludedRequestMatchers.stream().anyMatch(m -> m.matches(request))) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -34,11 +34,9 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService customUserDetailsService;
-    private final CustomAccessDeniedHandler accessDeniedHandler = new CustomAccessDeniedHandler();
-    private final EntryPointUnauthorizedHandler unauthorizedHandler = new EntryPointUnauthorizedHandler();
-    private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler =
-            new JwtAuthenticationExceptionHandler();
-
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final EntryPointUnauthorizedHandler unauthorizedHandler;
+    private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -49,8 +47,8 @@ public class SecurityConfig {
     public JwtAuthFilter jwtAuthFilter() {
         List<String> excludedPaths = Arrays.asList(
                 "/swagger-ui", "/v3/api-docs",
-                "/api/v2/auth/token/**", "/api/v2/email/send",
-                "/api/v2/internal/**", "/api/v2/email/verify", "/api/v2/riot/verify", "/api/v2/auth/join",
+                "/api/v2/auth/token/", "/api/v2/email/send",
+                "/api/v2/internal/", "/api/v2/email/verify", "/api/v2/riot/verify", "/api/v2/auth/join",
                 "/api/v2/auth/login", "/api/v2/password/reset", "/api/v2/auth/refresh", "/api/v2/posts/list"
         );
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -86,6 +86,9 @@ public class SecurityConfig {
                         "/api/v2/email/send/**",
                         "/api/v2/email/verify").permitAll()
                 .requestMatchers(
+                        "/api/v2/manner/keyword/*",
+                        "/api/v2/manner/level/*").permitAll()
+                .requestMatchers(
                         "/swagger-ui/**",
                         "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated());

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -18,12 +18,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -37,6 +39,7 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final EntryPointUnauthorizedHandler unauthorizedHandler;
     private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler;
+    private final SecurityJwtProperties securityJwtProperties;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -45,14 +48,11 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthFilter jwtAuthFilter() {
-        List<String> excludedPaths = Arrays.asList(
-                "/swagger-ui", "/v3/api-docs",
-                "/api/v2/auth/token/", "/api/v2/email/send",
-                "/api/v2/internal/", "/api/v2/email/verify", "/api/v2/riot/verify", "/api/v2/auth/join",
-                "/api/v2/auth/login", "/api/v2/password/reset", "/api/v2/auth/refresh", "/api/v2/posts/list"
-        );
+        List<RequestMatcher> excludedRequestMatchers = securityJwtProperties.getExcludedMatchers().stream()
+                .map(e -> new AntPathRequestMatcher(e.getPattern(), e.getMethod()))
+                .collect(Collectors.toList());
 
-        return new JwtAuthFilter(customUserDetailsService, excludedPaths, jwtProvider);
+        return new JwtAuthFilter(customUserDetailsService, excludedRequestMatchers, jwtProvider);
     }
 
     @Bean
@@ -71,31 +71,36 @@ public class SecurityConfig {
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         // 인증하지 않는 API 설정
-        http
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/").permitAll()
-                        .requestMatchers("/api/v2/internal/**").permitAll()
-                        .requestMatchers("/api/v2/auth/token/**", "/api/v2/email/send/**", "/api/v2/email/verify",
-                                "/api/v2/riot/verify", "/api/v2/auth/join", "/api/v2/auth/login", "/api/v2/auth" +
-                                        "/refresh").permitAll()   // Auth 관련
-                        .requestMatchers("/api/v2/password/reset").permitAll()  // Member 관련
-                        .requestMatchers("/api/v2/posts/list/**").permitAll()   // 게시판
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .anyRequest().authenticated());
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/").permitAll()
+                .requestMatchers("/api/v2/internal/**").permitAll() // internal
+                .requestMatchers("/api/v2/password/reset").permitAll() // password
+                .requestMatchers("/api/v2/riot/verify").permitAll() // riot
+                .requestMatchers("/api/v2/posts/list/**").permitAll() // board
+                .requestMatchers(
+                        "/api/v2/auth/token/**",
+                        "/api/v2/auth/join",
+                        "/api/v2/auth/login",
+                        "/api/v2/auth/refresh").permitAll()
+                .requestMatchers(
+                        "/api/v2/email/send/**",
+                        "/api/v2/email/verify").permitAll()
+                .requestMatchers(
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated());
 
-        // 필터 순서
+        // 커스텀 필터 추가
         http
                 .addFilterBefore(jwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationExceptionHandler, jwtAuthFilter.getClass());
 
         // 예외처리
         http
-                .exceptionHandling(
-                        (exceptionHandling) ->
-                                exceptionHandling
-                                        .accessDeniedHandler(accessDeniedHandler) // access deny 되었을 때 커스텀 응답 주기 위한 핸들러
-                                        .authenticationEntryPoint(unauthorizedHandler)); // 로그인되지 않은 요청에 대해 커스텀 응답 주기
-        // 위한 핸들러
+                .exceptionHandling((exceptionHandling) -> exceptionHandling
+                        .accessDeniedHandler(accessDeniedHandler) // access deny 되었을 때 커스텀 응답 핸들러
+                        .authenticationEntryPoint(unauthorizedHandler)); // 로그인되지 않은 요청에 대해 커스텀 응답 핸들러
+
         return http.build();
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityJwtProperties.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityJwtProperties.java
@@ -1,0 +1,25 @@
+package com.gamegoo.gamegoo_v2.core.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "security.jwt")
+public class SecurityJwtProperties {
+
+    private List<ExcludedMatcher> excludedMatchers = new ArrayList<>();
+
+    @Data
+    public static class ExcludedMatcher {
+
+        private String method;
+        private String pattern;
+
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   profiles:
     default: local
 
+  # excluded-paths.yml 파일 import
+  config:
+    import: "optional:classpath:excluded-paths.yml"
+
   # Gmail 설정
   mail:
     host: smtp.gmail.com

--- a/src/main/resources/excluded-paths.yml
+++ b/src/main/resources/excluded-paths.yml
@@ -1,0 +1,27 @@
+security:
+  jwt:
+    excluded-matchers:
+      - pattern: /swagger-ui/*
+      - pattern: /v3/api-docs/*
+      - pattern: /v3/api-docs
+      - pattern: /api/v2/internal/** # 모든 internal 엔드포인트
+      - method: GET
+        pattern: /api/v2/auth/token/* # 임시 access token 발급
+      - method: POST
+        pattern: /api/v2/auth/join # 회원 가입
+      - method: POST
+        pattern: /api/v2/auth/login # 로그인
+      - method: POST
+        pattern: /api/v2/auth/refresh # 토큰 재발급
+      - method: POST
+        pattern: /api/v2/password/reset # 비밀번호 재설정
+      - method: POST
+        pattern: /api/v2/email/send/** # 인증 메일 전송
+      - method: POST
+        pattern: /api/v2/email/verify # 이메일 인증코드 검증
+      - method: POST
+        pattern: /api/v2/riot/verify # riot 계정 검증
+      - method: GET
+        pattern: /api/v2/posts/list # 게시글 목록 조회
+      - method: GET
+        pattern: /api/v2/posts/list/* # 비회원용 특정 게시글 조회

--- a/src/main/resources/excluded-paths.yml
+++ b/src/main/resources/excluded-paths.yml
@@ -25,3 +25,7 @@ security:
         pattern: /api/v2/posts/list # 게시글 목록 조회
       - method: GET
         pattern: /api/v2/posts/list/* # 비회원용 특정 게시글 조회
+      - method: GET
+        pattern: /api/v2/manner/keyword/* # 매너 키워드 정보 조회
+      - method: GET
+        pattern: /api/v2/manner/level/* # 매너 레벨 정보 조회

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockAdmin.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockAdmin.java
@@ -1,0 +1,14 @@
+package com.gamegoo.gamegoo_v2.controller;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockAdminSecurityContextFactory.class)
+public @interface WithCustomMockAdmin {
+
+    Long memberId = 0L;
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockAdminSecurityContextFactory.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockAdminSecurityContextFactory.java
@@ -1,0 +1,30 @@
+package com.gamegoo.gamegoo_v2.controller;
+
+import com.gamegoo.gamegoo_v2.account.auth.domain.Role;
+import com.gamegoo.gamegoo_v2.account.auth.security.CustomUserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockAdminSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockAdmin> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockAdmin annotation) {
+        Long memberId = annotation.memberId;
+
+        UserDetails userDetails = new CustomUserDetails(memberId, Role.ADMIN);
+
+        // UserDetails, Password, Role -> 접근권한 인증 Token 생성
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        //현재 Request의 Security Context에 접근권한 설정
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(usernamePasswordAuthenticationToken);
+
+        return context;
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockMember.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockMember.java
@@ -1,0 +1,14 @@
+package com.gamegoo.gamegoo_v2.controller;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockMemberSecurityContextFactory.class)
+public @interface WithCustomMockMember {
+
+    Long memberId = 1L;
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockMemberSecurityContextFactory.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/WithCustomMockMemberSecurityContextFactory.java
@@ -1,0 +1,30 @@
+package com.gamegoo.gamegoo_v2.controller;
+
+import com.gamegoo.gamegoo_v2.account.auth.domain.Role;
+import com.gamegoo.gamegoo_v2.account.auth.security.CustomUserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockMemberSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockMember> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockMember annotation) {
+        Long memberId = annotation.memberId;
+
+        UserDetails userDetails = new CustomUserDetails(memberId, Role.MEMBER);
+
+        // UserDetails, Password, Role -> 접근권한 인증 Token 생성
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        //현재 Request의 Security Context에 접근권한 설정
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(usernamePasswordAuthenticationToken);
+        
+        return context;
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/block/BlockControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/block/BlockControllerTest.java
@@ -1,13 +1,14 @@
 package com.gamegoo.gamegoo_v2.controller.block;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.controller.WithCustomMockMember;
+import com.gamegoo.gamegoo_v2.core.exception.BlockException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.block.controller.BlockController;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockResponse;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockFacadeService;
-import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
-import com.gamegoo.gamegoo_v2.core.exception.BlockException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BlockController.class)
+@WithCustomMockMember
 class BlockControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/chat/ChatControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/chat/ChatControllerTest.java
@@ -10,6 +10,7 @@ import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse.SystemFlagResponse;
 import com.gamegoo.gamegoo_v2.chat.service.ChatFacadeService;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.controller.WithCustomMockMember;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ChatController.class)
+@WithCustomMockMember
 class ChatControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/friend/FriendControllerTest.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.controller.friend;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.controller.WithCustomMockMember;
 import com.gamegoo.gamegoo_v2.core.exception.FriendException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
@@ -34,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(FriendController.class)
+@WithCustomMockMember
 class FriendControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/internal/InternalControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/internal/InternalControllerTest.java
@@ -12,9 +12,12 @@ import com.gamegoo.gamegoo_v2.utils.DateTimeUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -29,7 +32,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({FriendInternalController.class, ChatInternalController.class})
+@AutoConfigureMockMvc(addFilters = false) // internal은 security filter 전부 무시하도록 설정
 public class InternalControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @MockitoBean
     private FriendFacadeService friendFacadeService;

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/manner/MannerControllerTest.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.controller.manner;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.controller.WithCustomMockMember;
 import com.gamegoo.gamegoo_v2.social.manner.controller.MannerController;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MannerController.class)
+@WithCustomMockMember
 public class MannerControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/notification/NotificationControllerTest.java
@@ -1,9 +1,10 @@
 package com.gamegoo.gamegoo_v2.controller.notification;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.controller.WithCustomMockMember;
 import com.gamegoo.gamegoo_v2.core.exception.NotificationException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.notification.controller.NotificationController;
 import com.gamegoo.gamegoo_v2.notification.domain.Notification;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationCursorListResponse;
@@ -31,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(NotificationController.class)
+@WithCustomMockMember
 class NotificationControllerTest extends ControllerTestSupport {
 
     @MockitoBean
@@ -111,7 +113,8 @@ class NotificationControllerTest extends ControllerTestSupport {
                     .isLast(true)
                     .build();
 
-            given(notificationFacadeService.getNotificationPageList(any(Member.class), any(Integer.class))).willReturn(response);
+            given(notificationFacadeService.getNotificationPageList(any(Member.class), any(Integer.class))).willReturn(
+                    response);
 
             // when // then
             int pageIdx = 1;

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/report/ReportControllerTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/report/ReportControllerTest.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportRequest;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportInsertResponse;
 import com.gamegoo.gamegoo_v2.content.report.service.ReportFacadeService;
 import com.gamegoo.gamegoo_v2.controller.ControllerTestSupport;
+import com.gamegoo.gamegoo_v2.controller.WithCustomMockMember;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,10 +20,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ReportController.class)
+@WithCustomMockMember
 public class ReportControllerTest extends ControllerTestSupport {
 
     @MockitoBean
@@ -60,6 +63,7 @@ public class ReportControllerTest extends ControllerTestSupport {
             mockMvc.perform(post(API_URL_PREFIX + "/{memberId}", TARGET_MEMBER_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value("VALID_ERROR"))
                     .andExpect(jsonPath("$.message").value("신고 코드 리스트는 비워둘 수 없습니다."));


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 여기에 작성해주세요.

## ⏳ 작업 상세 내용
- [x] 시큐리티 도입으로 인한 테스트코드 수정
- [x] 시큐리티 필터 체인 무시하는 커스텀 어노테이션 구현
- [x] SecurityConfig 리팩토링
- [x] JwtAuthFilter exclude path 로직 리팩토링

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] MEMBER, ADMIN role을 필요로 하는 api의 컨트롤러 테스트에서는 `@WithCustomMockMember`, `@WithCustomMockAdmin` 어노테이션을 붙여서 시큐리티 기본 필터 체인을 통과한 것으로 간주하고 mock UserDetails 객체를 생성하도록 했습니다.
- [ ] internal api와 같이 아예 role 구분이 필요 없는 api의 컨트롤러 테스트에서는 `@AutoConfigureMockMvc(addFilters = false)`을 붙여서 시큐리티 필터를 전부 무시하도록 했습니다.
- [ ] SecurityConfig에서 이렇게 불필요하게 bean을 생성하는 부분이 있어서 이런 코드 모두 삭제했습니다.
        ```
        private final CustomAccessDeniedHandler accessDeniedHandler = new CustomAccessDeniedHandler();
        ```

- [ ] 기존에는 jwt 검증 필터를 적용하지 않을 엔드포인트를 SecurityConfig에서 하드코딩으로 값을 넣어서 설정했었고, JwtAuthFilter에서 단순히 uri 문자열을 startsWith으로 비교해 필터 적용 여부를 판단했었습니다. 그래서 같은 엔드포인트라도  GET /api/v2/board 는 jwt 검증 제외, POST /api/v2/board는 jwt 검증 적용 << 이렇게 http 메소드별로 다르게 설정이 불가했습니다. 이런 문제들 해결을 위해서 excluded-paths.yml 설정 파일을 만들고 여기에 http 메소드 + 엔드포인트 패턴을 등록해두면 jwtAuthFilter가 RequestMatcher를 이용해 필터 적용 여부를 판단하도록 수정했습니다. 


## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] 앞으로 jwt 검증하지 않을 엔드포인트를 추가하려면 excluded-paths.yml 파일에 method와 pattern 추가 및 Security filterChain 설정에 .requestMatchers().permitAll() 추가가 필요합니다.
