### PR TITLE
[Feat/175] API 요청 LoggingFilter 구현

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
@@ -4,6 +4,7 @@ import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.account.auth.security.SecurityUtil;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.core.exception.AuthException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import lombok.NonNull;
@@ -37,8 +38,13 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
                                   @NonNull NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        return memberRepository.findById(currentMemberId)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        if (currentMemberId != null) {
+            return memberRepository.findById(currentMemberId)
+                    .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        } else {
+            throw new AuthException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+        }
+
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthenticationExceptionHandler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthenticationExceptionHandler.java
@@ -3,26 +3,37 @@ package com.gamegoo.gamegoo_v2.account.auth.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.exception.JwtAuthException;
+import com.gamegoo.gamegoo_v2.core.log.LogUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.UUID;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+    private final LogUtil logUtil;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
+        String requestId = UUID.randomUUID().toString();  // 고유한 requestId 생성
+        MDC.put("requestId", requestId);
+
         try {
             filterChain.doFilter(request, response);
         } catch (JwtAuthException authException) {
@@ -37,11 +48,15 @@ public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
                     .status(authException.getStatus())
                     .build();
 
-            ObjectMapper objectMapper = new ObjectMapper();
+            // jwt 검증 로그 출력
+            logUtil.apiJwtException(request, authException);
+
             String jsonResponse = objectMapper.writeValueAsString(apiResponse);
             writer.write(jsonResponse);
             writer.flush();
             writer.close();
+        } finally {
+            MDC.remove("requestId");
         }
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/SecurityUtil.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/SecurityUtil.java
@@ -1,7 +1,5 @@
 package com.gamegoo.gamegoo_v2.account.auth.security;
 
-import com.gamegoo.gamegoo_v2.core.exception.AuthException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -13,7 +11,7 @@ public class SecurityUtil {
         if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails customUserDetails) {
             return customUserDetails.getMemberId();
         } else {
-            throw new AuthException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+            return null;
         }
 
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.account.auth.security.CustomUserDetailsService;
 import com.gamegoo.gamegoo_v2.account.auth.security.EntryPointUnauthorizedHandler;
 import com.gamegoo.gamegoo_v2.account.auth.security.JwtAuthFilter;
 import com.gamegoo.gamegoo_v2.account.auth.security.JwtAuthenticationExceptionHandler;
+import com.gamegoo.gamegoo_v2.core.log.LoggingFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,7 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final EntryPointUnauthorizedHandler unauthorizedHandler;
     private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler;
+    private final LoggingFilter loggingFilter;
     private final SecurityJwtProperties securityJwtProperties;
 
     @Bean
@@ -96,6 +98,7 @@ public class SecurityConfig {
         // 커스텀 필터 추가
         http
                 .addFilterBefore(jwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(loggingFilter, JwtAuthFilter.class)
                 .addFilterBefore(jwtAuthenticationExceptionHandler, jwtAuthFilter.getClass());
 
         // 예외처리

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/log/LogUtil.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/log/LogUtil.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.core.log;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gamegoo.gamegoo_v2.account.auth.security.SecurityUtil;
+import com.gamegoo.gamegoo_v2.core.exception.JwtAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -56,9 +57,27 @@ public class LogUtil {
         String httpMethod = request.getMethod();
         String clientIp = getClientIp(request);
         int statusCode = response.getStatus();
-        
+
         log.info("[{}] [{}] {} | IP: {} | Status: {} | Execution Time: {}ms", requestId, httpMethod, requestUrl,
                 clientIp, statusCode, executionTime);
+    }
+
+    /**
+     * jwt 검증 에러 응답 로그 출력
+     *
+     * @param request request 객체
+     * @param e       exception
+     */
+    public void apiJwtException(HttpServletRequest request, JwtAuthException e) {
+        String requestId = MDC.get("requestId");
+        String requestUrl = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        String clientIp = getClientIp(request);
+        int statusCode = e.getStatus().value();
+        String errorCode = e.getCode();
+
+        log.info("[{}] [{}] {} | IP: {} | Status: {} {}", requestId, httpMethod, requestUrl, clientIp, statusCode,
+                errorCode);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/log/LogUtil.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/log/LogUtil.java
@@ -1,0 +1,92 @@
+package com.gamegoo.gamegoo_v2.core.log;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamegoo.gamegoo_v2.account.auth.security.SecurityUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogUtil {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * api request 로그 출력
+     *
+     * @param request request 객체
+     */
+    public void apiRequest(HttpServletRequest request) {
+        String requestId = MDC.get("requestId");
+        String requestUrl = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        String clientIp = getClientIp(request);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        String params = getParamsAsString(request);
+        String memberIdString = "Unauthenticated";
+
+        if (memberId != null) {
+            memberIdString = String.valueOf(memberId);
+        }
+
+        if (request.getParameterMap().isEmpty()) {
+            log.info("[{}] [{}] {} | IP: {} | Member: {}", requestId, httpMethod, requestUrl, clientIp, memberIdString);
+        } else {
+            log.info("[{}] [{}] {} | IP: {} | Member: {} | Params: {}", requestId, httpMethod, requestUrl, clientIp,
+                    memberIdString, params);
+        }
+    }
+
+    /**
+     * api response 로그 출력
+     *
+     * @param request       request 객체
+     * @param response      response 객체
+     * @param executionTime 실행 시간
+     */
+    public void apiResponse(HttpServletRequest request, HttpServletResponse response, long executionTime) {
+        String requestId = MDC.get("requestId");
+        String requestUrl = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        String clientIp = getClientIp(request);
+        int statusCode = response.getStatus();
+        
+        log.info("[{}] [{}] {} | IP: {} | Status: {} | Execution Time: {}ms", requestId, httpMethod, requestUrl,
+                clientIp, statusCode, executionTime);
+    }
+
+    /**
+     * 클라이언트 ip 추출 메소드
+     *
+     * @param request request 객체
+     * @return ip
+     */
+    private String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+            return ip.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * request param을 JSON 형태 String으로 변환
+     *
+     * @param request request 객체
+     * @return string
+     */
+    private String getParamsAsString(HttpServletRequest request) {
+        try {
+            return objectMapper.writeValueAsString(request.getParameterMap());
+        } catch (JsonProcessingException e) {
+            return "Unable to parse parameters";
+        }
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/log/LoggingFilter.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/log/LoggingFilter.java
@@ -5,12 +5,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.jboss.logging.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -21,9 +19,6 @@ public class LoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String requestId = UUID.randomUUID().toString();  // 고유한 requestId 생성
-        MDC.put("requestId", requestId);
-
         // 요청 로그 출력
         logUtil.apiRequest(request);
         long startTime = System.currentTimeMillis();
@@ -35,8 +30,6 @@ public class LoggingFilter extends OncePerRequestFilter {
 
         // 응답 로그 출력
         logUtil.apiResponse(request, response, executionTime);
-
-        MDC.remove("requestId");
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/log/LoggingFilter.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/log/LoggingFilter.java
@@ -1,0 +1,42 @@
+package com.gamegoo.gamegoo_v2.core.log;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jboss.logging.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class LoggingFilter extends OncePerRequestFilter {
+
+    private final LogUtil logUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestId = UUID.randomUUID().toString();  // 고유한 requestId 생성
+        MDC.put("requestId", requestId);
+
+        // 요청 로그 출력
+        logUtil.apiRequest(request);
+        long startTime = System.currentTimeMillis();
+
+        // 다음 로직 실행
+        filterChain.doFilter(request, response);
+
+        long executionTime = System.currentTimeMillis() - startTime;
+
+        // 응답 로그 출력
+        logUtil.apiResponse(request, response, executionTime);
+
+        MDC.remove("requestId");
+    }
+
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/controller/ControllerTestSupport.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/controller/ControllerTestSupport.java
@@ -7,6 +7,8 @@ import com.gamegoo.gamegoo_v2.account.auth.security.CustomUserDetailsService;
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.core.log.LogUtil;
+import com.gamegoo.gamegoo_v2.core.log.LoggingFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -44,6 +46,12 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    protected LoggingFilter loggingFilter;
+
+    @MockitoBean
+    protected LogUtil logUtil;
 
     @Autowired
     protected ObjectMapper objectMapper;


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> API 요청 LoggingFilter 구현

## ⏳ 작업 상세 내용

- [x] JwtAuthFilter를 통과한 요청에 대한 로그 출력하는 LoggingFilter 구현
- [x] JwtAuthFilter에서 검증 실패한 경우, JwtAuthenticationExceptionHandler에서 검증 실패 로그 출력

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 일단 이런식으로 출력되도록 구현했습니다. jwt 검증 과정 중 에러난 경우에는 그냥 한줄로 출력, 그 외 정상 API 요청은 request 한 줄, resposne 한 줄 총 2줄 출력되도록 했습니다..!
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/34f689bf-ffbf-4dd3-8a92-1fa023df2c3f" />


## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
