### PR TITLE
[Feat/178] 로그 파일 일별 저장 설정

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -108,7 +108,7 @@ jobs:
 
       # 8. 기존 Docker 이미지 삭제
       - name: 기존 Docker 이미지 삭제
-        run: sudo docker system prune -f
+        run: docker image prune -a
 
       # 실패 시 디스코드에 알림 보내기
       - name: 배포 실패 시 디스코드 알림 전송

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -5,6 +5,9 @@ on:
     types: [ closed ]
     branches:
       - develop
+  push:
+    branches:
+      - feat/178
   workflow_dispatch: # 수동 실행 가능
 
 jobs:

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -5,9 +5,6 @@ on:
     types: [ closed ]
     branches:
       - develop
-  push:
-    branches:
-      - feat/178
   workflow_dispatch: # 수동 실행 가능
 
 jobs:

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -87,7 +87,10 @@ jobs:
 
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2:${{ github.sha }}
 
-            docker run -d -p 8080:8080 --name gamegoo-api-v2 \
+            docker run -d \
+            -p 8080:8080 \
+            --name gamegoo-api-v2 \
+            -v ${{ secrets.EC2_LOG_PATH }}:/app/logs \
             -e SPRING_PROFILES_ACTIVE=dev \
             -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
             -e RDS_PRIVATE_IP=${{ secrets.RDS_PRIVATE_IP }} \
@@ -99,6 +102,10 @@ jobs:
             -e RIOT_API=${{ secrets.RIOT_API }} \
             -e SOCKET_SERVER_URL=${{ secrets.SOCKET_SERVER_URL }} \
             ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2:${{ github.sha }}
+
+      # 8. 기존 Docker 이미지 삭제
+      - name: 기존 Docker 이미지 삭제
+        run: sudo docker system prune -f
 
       # 실패 시 디스코드에 알림 보내기
       - name: 배포 실패 시 디스코드 알림 전송

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,7 +9,7 @@
     <!-- Log파일에 기록되는 로그 패턴 -->
     <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
     <!-- 로그 파일 저장 경로 -->
-    <property name="LOG_PATH" value="app/logs"/>
+    <property name="LOG_PATH" value="/app/logs"/>
 
     <!-- 콘솔로그 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,9 +8,8 @@
               value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
     <!-- Log파일에 기록되는 로그 패턴 -->
     <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
-
     <!-- 로그 파일 저장 경로 -->
-    <property name="LOG_PATH" value="/Users/jennyeunjin/app/logs"/>
+    <property name="LOG_PATH" value="app/logs"/>
 
     <!-- 콘솔로그 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -19,8 +18,8 @@
         </encoder>
     </appender>
 
-    <!-- 파일로그 Appender -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!-- 파일 INFO 로그 Appender -->
+    <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
@@ -30,10 +29,28 @@
             <!-- 날짜별로 기록, maxFileSize를 넘기면 인덱스(i)를 증가시켜 새로운 파일로 저장 -->
             <fileNamePattern>${LOG_PATH}/api.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <!-- 로그파일 최대사이즈 -->
-            <maxFileSize>100MB</maxFileSize>
+            <maxFileSize>10MB</maxFileSize>
             <!-- 생성한 로그파일 관리 일수 -->
             <maxHistory>7</maxHistory>
         </rollingPolicy>
+    </appender>
+
+    <!-- 파일 ERROR 로그 Appender -->
+    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- error 전용 파일명 패턴 -->
+            <fileNamePattern>${LOG_PATH}/api.error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <!-- ERROR 이상만 수용하는 필터 추가 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
     </appender>
 
     <!-- local Profile에서의 로그 설정 -->
@@ -41,15 +58,15 @@
         <root level="INFO">
             <!-- CONSOLE 로그만 등록 -->
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
     </springProfile>
     <!-- dev Profile에서의 로그 설정 -->
     <springProfile name="dev">
         <root level="INFO">
-            <!-- CONSOLE, FILE 등록-->
+            <!-- CONSOLE, FILE_INFO, FILE_ERROR 등록-->
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="FILE_INFO"/>
+            <appender-ref ref="FILE_ERROR"/>
         </root>
     </springProfile>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <!-- base.xml default.xml 에 존재하는 Log 메시지의 Color 설정 -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- 콘솔에 출력되는 로그 패턴 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
+    <!-- Log파일에 기록되는 로그 패턴 -->
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+
+    <!-- 로그 파일 저장 경로 -->
+    <property name="LOG_PATH" value="/Users/jennyeunjin/app/logs"/>
+
+    <!-- 콘솔로그 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일로그 Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <!-- 로그파일을 크기, 시간 기반으로 관리하기 위한 SizeAndTimeBasedRollingPolicy -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- 로그파일명 패턴 -->
+            <!-- 날짜별로 기록, maxFileSize를 넘기면 인덱스(i)를 증가시켜 새로운 파일로 저장 -->
+            <fileNamePattern>${LOG_PATH}/api.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <!-- 로그파일 최대사이즈 -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- 생성한 로그파일 관리 일수 -->
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- local Profile에서의 로그 설정 -->
+    <springProfile name="local">
+        <root level="INFO">
+            <!-- CONSOLE 로그만 등록 -->
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+    <!-- dev Profile에서의 로그 설정 -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <!-- CONSOLE, FILE 등록-->
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 로그 파일 일별 저장 설정

## ⏳ 작업 상세 내용

- [x] Logback을 이용해 로그 파일 일별 저장 설정
- [x] 로그 파일별 최대 크기 10MB 제한 적용
- [x] ERROR 레벨 로그는 별도 파일로 저장하도록 설정
- [x] 도커 컨테이너의 로그 저장 디렉토리를 EC2 특정 경로에 마운트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 기존에는 도커 컨테이너에만 로그가 저장되어서 서버를 재배포했을 때 컨테이너가 내려가면서 로그가 전부 삭제되는 문제가 있었습니다. 이걸 EC2 인스턴스의 특정 경로에도 동시에 로그를 기록하도록 설정해서 도커 컨테이너가 내려가더라도 EC2에는 로그가 남아있도록 설정했습니다!
- [x] 배포할 때마다 도커 이미지가 계속 쌓여서
    ```
          # 8. 기존 Docker 이미지 삭제
      - name: 기존 Docker 이미지 삭제
        run: docker image prune -a
    ```
    이걸 github_actions.yml에 추가했는데 그래도 기존 이미지 삭제가  안되더라구요 ㅠㅠ 어떻게 해야하는지 아시는 분 계신가요..

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
