### PR TITLE
[Feat/192] 게시판 목록에서 메모, 끌올 시간 불러오기

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -33,6 +33,8 @@ public class BoardListResponse {
     List<ChampionResponse> championResponseList;
     Double winRate;
     LocalDateTime createdAt;
+    LocalDateTime bumpTime;
+    String contents;
     Mike mike;
 
     public static BoardListResponse of(Board board) {
@@ -59,6 +61,8 @@ public class BoardListResponse {
                 .championResponseList(championResponseList)
                 .winRate(member.getSoloWinRate())
                 .createdAt(board.getCreatedAt())
+                .bumpTime(board.getBumpTime())
+                .contents(board.getContent())
                 .mike(board.getMike())
                 .build();
     }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 게시판에서 게시물이 어떻게 보이는지에 대한 수정입니다.

## ⏳ 작업 상세 내용

- [ ] 메모기능을 위해 게시물에 있는 content를 게시판에서 조회 가능
- [ ] 끌올 시간 게시판에서 조회 가능

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] 없을 경우 체크
