### PR TITLE
[Fix/214] 게시물 조회 시 티어 파라미터 통합

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -70,8 +70,7 @@ public class BoardController {
             @Parameter(name = "pageIdx", description = "조회할 페이지 번호를 입력해주세요. 페이지 당 20개의 게시물을 볼 수 있습니다."),
             @Parameter(name = "gameMode", description = "(선택) 게임 모드를 입력해주세요. < 빠른대전: FAST, 솔로랭크: SOLO, 자유랭크: FREE, " +
                     "칼바람 나락: ARAM >"),
-            @Parameter(name = "soloTier", description = "(선택) 솔로랭크 티어를 선택해주세요."),
-            @Parameter(name = "freeTier", description = "(선택) 자유랭크 티어를 선택해주세요."),
+            @Parameter(name = "tier", description = "(선택) 티어를 선택해주세요."),
             @Parameter(name = "mainP", description = "(선택) 포지션을 입력해주세요. < 전체: ANY, 탑: TOP, 정글: JUNGLE, 미드: " +
                     "MID, 원딜: ADC, " +
                     "서포터: SUP >"),
@@ -80,12 +79,11 @@ public class BoardController {
     public ApiResponse<BoardResponse> boardList(
             @ValidPage @RequestParam(name = "page") Integer page,
             @RequestParam(required = false) GameMode gameMode,
-            @RequestParam(required = false) Tier soloTier,
-            @RequestParam(required = false) Tier freeTier,
+            @RequestParam(required = false) Tier tier,
             @RequestParam(required = false) Position mainP,
             @RequestParam(required = false) Mike mike) {
 
-        return ApiResponse.ok(boardFacadeService.getBoardList(gameMode, soloTier, freeTier, mainP, mike, page));
+        return ApiResponse.ok(boardFacadeService.getBoardList(gameMode, tier, mainP, mike, page));
 
 
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
@@ -25,20 +25,16 @@ public class BoardByIdResponse {
     String gameName;
     String tag;
     Integer mannerLevel;
-    Tier soloTier;
-    Tier freeTier;
-    int soloRank;
-    int freeRank;
+    Tier tier;
+    int rank;
     Mike mike;
     List<ChampionResponse> championResponseList;
     GameMode gameMode;
     Position mainP;
     Position subP;
     Position wantP;
-    Integer soloRecentGameCount;
-    Integer freeRecentGameCount;
-    Double soloWinRate;
-    Double freeWinRate;
+    Integer recentGameCount;
+    Double winRate;
     List<Long> gameStyles;
     String contents;
 
@@ -54,6 +50,23 @@ public class BoardByIdResponse {
                 .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
 
+        Tier tier;
+        int rank;
+        Integer recentGameCount;
+        Double winRate;
+
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = poster.getFreeTier();
+            rank = poster.getFreeRank();
+            recentGameCount = poster.getFreeGameCount();
+            winRate = poster.getFreeWinRate();
+        } else {
+            tier = poster.getSoloTier();
+            rank = poster.getSoloRank();
+            recentGameCount = poster.getSoloGameCount();
+            winRate = poster.getSoloWinRate();
+        }
+
         return BoardByIdResponse.builder()
                 .boardId(board.getId())
                 .memberId(poster.getId())
@@ -62,20 +75,16 @@ public class BoardByIdResponse {
                 .gameName(poster.getGameName())
                 .tag(poster.getTag())
                 .mannerLevel(poster.getMannerLevel())
-                .soloTier(poster.getSoloTier())
-                .freeTier(poster.getFreeTier())
-                .soloRank(poster.getSoloRank())
-                .freeRank(poster.getFreeRank())
+                .tier(tier)
+                .rank(rank)
                 .mike(board.getMike())
                 .championResponseList(championResponseList)
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())
                 .wantP(board.getWantP())
-                .soloRecentGameCount(poster.getSoloGameCount())
-                .freeRecentGameCount(poster.getFreeGameCount())
-                .soloWinRate(poster.getSoloWinRate())
-                .freeWinRate(poster.getFreeWinRate())
+                .recentGameCount(recentGameCount)
+                .winRate(winRate)
                 .gameStyles(gameStyleIds)
                 .contents(board.getContent())
                 .build();

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
@@ -30,20 +30,16 @@ public class BoardByIdResponseForMember {
     String tag;
     Integer mannerLevel;
     List<MannerKeyword> mannerKeywords;
-    Tier soloTier;
-    Tier freeTier;
-    int soloRank;
-    int freeRank;
+    Tier tier;
+    int rank;
     Mike mike;
     List<ChampionResponse> championResponseDTOList;
     GameMode gameMode;
     Position mainP;
     Position subP;
     Position wantP;
-    Integer soloRecentGameCount;
-    Integer freeRecentGameCount;
-    Double soloWinRate;
-    Double freeWinRate;
+    Integer recentGameCount;
+    Double winRate;
     List<Long> gameStyles;
     String contents;
 
@@ -67,6 +63,23 @@ public class BoardByIdResponseForMember {
                 .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
 
+        Tier tier;
+        int rank;
+        Integer recentGameCount;
+        Double winRate;
+
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = poster.getFreeTier();
+            rank = poster.getFreeRank();
+            recentGameCount = poster.getFreeGameCount();
+            winRate = poster.getFreeWinRate();
+        } else {
+            tier = poster.getSoloTier();
+            rank = poster.getSoloRank();
+            recentGameCount = poster.getSoloGameCount();
+            winRate = poster.getSoloWinRate();
+        }
+
         return BoardByIdResponseForMember.builder()
                 .boardId(board.getId())
                 .memberId(poster.getId())
@@ -78,20 +91,16 @@ public class BoardByIdResponseForMember {
                 .gameName(poster.getGameName())
                 .tag(poster.getTag())
                 .mannerLevel(poster.getMannerLevel())
-                .soloTier(poster.getSoloTier())
-                .freeTier(poster.getFreeTier())
-                .soloRank(poster.getSoloRank())
-                .freeRank(poster.getFreeRank())
+                .tier(tier)
+                .rank(rank)
                 .mike(board.getMike())
                 .championResponseDTOList(championResponseList)
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())
                 .wantP(board.getWantP())
-                .soloRecentGameCount(poster.getSoloGameCount())
-                .freeRecentGameCount(poster.getFreeGameCount())
-                .soloWinRate(poster.getSoloWinRate())
-                .freeWinRate(poster.getFreeWinRate())
+                .recentGameCount(recentGameCount)
+                .winRate(winRate)
                 .gameStyles(gameStyleIds)
                 .contents(board.getContent())
                 .build();

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
@@ -20,10 +20,8 @@ public class BoardInsertResponse {
     private Integer profileImage;
     private String gameName;
     private String tag;
-    private Tier soloTier;
-    private Tier freeTier;
-    private int soloRank;
-    private int freeRank;
+    private Tier tier;
+    private int rank;
     private GameMode gameMode;
     private Position mainP;
     private Position subP;
@@ -33,16 +31,25 @@ public class BoardInsertResponse {
     private String contents;
 
     public static BoardInsertResponse of(Board board, Member member) {
+
+        Tier tier;
+        int rank;
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = member.getFreeTier();
+            rank = member.getFreeRank();
+        } else {
+            tier = member.getSoloTier();
+            rank = member.getSoloRank();
+        }
+
         return BoardInsertResponse.builder()
                 .boardId(board.getId())
                 .memberId(member.getId())
                 .profileImage(board.getBoardProfileImage())
                 .gameName(member.getGameName())
                 .tag(member.getTag())
-                .soloTier(member.getSoloTier())
-                .freeTier(member.getFreeTier())
-                .soloRank(member.getSoloRank())
-                .freeRank(member.getFreeRank())
+                .tier(tier)
+                .rank(rank)
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -24,17 +24,14 @@ public class BoardListResponse {
     String gameName;
     String tag;
     Integer mannerLevel;
-    Tier soloTier;
-    Tier freeTier;
-    int soloRank;
-    int freeRank;
+    Tier tier;
+    int rank;
     GameMode gameMode;
     Position mainP;
     Position subP;
     Position wantP;
     List<ChampionResponse> championResponseList;
-    Double soloWinRate;
-    Double freeWinRate;
+    Double winRate;
     LocalDateTime createdAt;
     LocalDateTime bumpTime;
     String contents;
@@ -48,6 +45,19 @@ public class BoardListResponse {
                         .collect(Collectors.toList())
                 : null;
 
+        Tier tier;
+        int rank;
+        Double winRate;
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = member.getFreeTier();
+            rank = member.getFreeRank();
+            winRate = member.getFreeWinRate();
+        } else {
+            tier = member.getSoloTier();
+            rank = member.getSoloRank();
+            winRate = member.getSoloWinRate();
+        }
+
         return BoardListResponse.builder()
                 .boardId(board.getId())
                 .memberId(member.getId())
@@ -55,17 +65,14 @@ public class BoardListResponse {
                 .gameName(member.getGameName())
                 .tag(member.getTag())
                 .mannerLevel(member.getMannerLevel())
-                .soloTier(member.getSoloTier())
-                .freeTier(member.getFreeTier())
-                .soloRank(member.getSoloRank())
-                .freeRank(member.getFreeRank())
+                .tier(tier)
+                .rank(rank)
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())
                 .wantP(board.getWantP())
                 .championResponseList(championResponseList)
-                .soloWinRate(member.getSoloWinRate())
-                .freeWinRate(member.getFreeWinRate())
+                .winRate(winRate)
                 .createdAt(board.getCreatedAt())
                 .bumpTime(board.getBumpTime())
                 .contents(board.getContent())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardUpdateResponse.java
@@ -21,10 +21,8 @@ public class BoardUpdateResponse {
     Integer profileImage;
     String gameName;
     String tag;
-    Tier soloTier;
-    Tier freeTier;
-    Integer soloRank;
-    Integer freeRank;
+    Tier tier;
+    Integer rank;
     GameMode gameMode;
     Position mainP;
     Position subP;
@@ -39,16 +37,24 @@ public class BoardUpdateResponse {
                 .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
 
+        Tier tier;
+        int rank;
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = member.getFreeTier();
+            rank = member.getFreeRank();
+        } else {
+            tier = member.getSoloTier();
+            rank = member.getSoloRank();
+        }
+
         return BoardUpdateResponse.builder()
                 .boardId(board.getId())
                 .memberId(member.getId())
                 .profileImage(board.getBoardProfileImage())
                 .gameName(member.getGameName())
                 .tag(member.getTag())
-                .soloTier(member.getSoloTier())
-                .freeTier(member.getFreeTier())
-                .soloRank(member.getSoloRank())
-                .freeRank(member.getFreeRank())
+                .tier(tier)
+                .rank(rank)
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardListResponse.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.content.board.dto.response;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,26 +18,33 @@ public class MyBoardListResponse {
     Integer profileImage;
     String gameName;
     String tag;
-    Tier soloTier;
-    Tier freeTier;
-    int soloRank;
-    int freeRank;
+    Tier tier;
+    int rank;
     String contents;
     LocalDateTime createdAt;
     LocalDateTime bumpTime;
 
     public static MyBoardListResponse of(Board board) {
         Member member = board.getMember();
+        Tier tier;
+        int rank;
+
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = member.getFreeTier();
+            rank = member.getFreeRank();
+        } else {
+            tier = member.getSoloTier();
+            rank = member.getSoloRank();
+        }
+
         return MyBoardListResponse.builder()
                 .boardId(board.getId())
                 .memberId(member.getId())
                 .profileImage(board.getBoardProfileImage())
                 .gameName(member.getGameName())
                 .tag(member.getTag())
-                .soloTier(member.getSoloTier())
-                .freeTier(member.getFreeTier())
-                .soloRank(member.getSoloRank())
-                .freeRank(member.getFreeRank())
+                .tier(tier)
+                .rank(rank)
                 .contents(board.getContent())
                 .createdAt(board.getCreatedAt())
                 .bumpTime(board.getBumpTime())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
@@ -18,15 +18,16 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT b FROM Board b JOIN b.member m WHERE " +
             "b.deleted = false AND " +
             "(:mode IS NULL OR b.gameMode = :mode) AND " +
-            "(COALESCE(:soloTier, :freeTier) IS NULL OR m.soloTier = :soloTier OR m.freeTier = :freeTier) AND " +
+            "(:tier IS NULL OR (CASE WHEN b.gameMode = com.gamegoo.gamegoo_v2.matching.domain.GameMode.FREE THEN m" +
+            ".freeTier ELSE m.soloTier END) = :tier) AND " +
             "(:mainP IS NULL OR :mainP = 'ANY' OR b.mainP = :mainP) AND " +
             "(:mike IS NULL OR b.mike = :mike)")
     Page<Board> findByFilters(@Param("mode") GameMode gameMode,
-                              @Param("soloTier") Tier soloTier,
-                              @Param("freeTier") Tier freeTier,
+                              @Param("tier") Tier tier,
                               @Param("mainP") Position mainP,
                               @Param("mike") Mike mike,
                               Pageable pageable);
+
 
     Optional<Board> findByIdAndDeleted(Long boardId, boolean b);
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
@@ -56,14 +56,14 @@ public class BoardFacadeService {
      * 게시판 글 목록 조회 (파사드)
      */
 
-    public BoardResponse getBoardList(GameMode gameMode, Tier soloTier, Tier freeTier, Position mainP, Mike mike,
+    public BoardResponse getBoardList(GameMode gameMode, Tier tier, Position mainP, Mike mike,
                                       @ValidPage int pageIdx) {
 
         if (mainP == null) {
             mainP = Position.ANY;
         }
 
-        Page<Board> boardPage = boardService.getBoardsWithPagination(gameMode, soloTier, freeTier, mainP, mike,
+        Page<Board> boardPage = boardService.getBoardsWithPagination(gameMode, tier, mainP, mike,
                 pageIdx);
 
         return BoardResponse.of(boardPage);

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -57,20 +57,20 @@ public class BoardService {
     /**
      * 게시글 목록 조회
      */
-    public Page<Board> findBoards(GameMode gameMode, Tier soloTier, Tier freeTier, Position mainP, Mike mike,
+    public Page<Board> findBoards(GameMode gameMode, Tier tier, Position mainP, Mike mike,
                                   Pageable pageable) {
-        return boardRepository.findByFilters(gameMode, soloTier, freeTier, mainP, mike, pageable);
+        return boardRepository.findByFilters(gameMode, tier, mainP, mike, pageable);
     }
 
     /**
      * 게시글 목록 조회 (페이징 처리)
      */
 
-    public Page<Board> getBoardsWithPagination(GameMode gameMode, Tier soloTier, Tier freeTier, Position mainP,
+    public Page<Board> getBoardsWithPagination(GameMode gameMode, Tier tier, Position mainP,
                                                Mike mike,
                                                int pageIdx) {
         Pageable pageable = PageRequest.of(pageIdx - 1, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "activityTime"));
-        return findBoards(gameMode, soloTier, freeTier, mainP, mike, pageable);
+        return findBoards(gameMode, tier, mainP, mike, pageable);
     }
 
     /**


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 게시물 조회 시 티어 파라미터를 2개를 요구해 혼동 야기

## ⏳ 작업 상세 내용

- [x] 게시물 필터링 로직에서 freeTier와 soloTier 둘 중 하나의 파라미터를 보내는 방식에서 Tier 하나만을 받아와서 조회하는 방식으로 통합
- [x] 게시물 조회 시 gameMode에 따라 Tier값 하나만 제공(현재 자유랭크 제외하곤 솔랭티어를 받아오는 형식)


## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
