### PR TITLE
[Feat/211] 매칭 빠른대전 티어 기획 수정 반영

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/domain/MatchingRecord.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/domain/MatchingRecord.java
@@ -82,7 +82,6 @@ public class MatchingRecord extends BaseDateTimeEntity {
     @JoinColumn(name = "target_id")
     private MatchingRecord targetMatchingRecord;
 
-    // MatchingRecord 생성 메서드
     public static MatchingRecord create(GameMode gameMode, MatchingType matchingType, Member member) {
         return MatchingRecord.builder()
                 .gameMode(gameMode)
@@ -90,13 +89,34 @@ public class MatchingRecord extends BaseDateTimeEntity {
                 .subP(member.getSubP())
                 .wantP(member.getWantP())
                 .mike(member.getMike())
-                .tier(member.getSoloTier()) // TODO:
-                .gameRank(member.getSoloRank()) // TODO:
-                .winrate(member.getSoloWinRate()) // TODO:
+                .tier(getTierByGameMode(gameMode, member))
+                .gameRank(getGameRankByGameMode(gameMode, member))
+                .winrate(getWinRateByGameMode(gameMode, member))
                 .matchingType(matchingType)
                 .mannerLevel(member.getMannerLevel())
                 .member(member)
                 .build();
+    }
+
+    private static Tier getTierByGameMode(GameMode gameMode, Member member) {
+        if (gameMode == GameMode.FREE) {
+            return member.getFreeTier();
+        }
+        return member.getSoloTier();
+    }
+
+    private static int getGameRankByGameMode(GameMode gameMode, Member member) {
+        if (gameMode == GameMode.FREE) {
+            return member.getFreeRank();
+        }
+        return member.getSoloRank();
+    }
+
+    private static double getWinRateByGameMode(GameMode gameMode, Member member) {
+        if (gameMode == GameMode.FREE) {
+            return member.getFreeWinRate();
+        }
+        return member.getSoloWinRate();
     }
 
     // MatchingRecord Builder

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingStrategyProcessor.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingStrategyProcessor.java
@@ -34,10 +34,6 @@ public class MatchingStrategyProcessor {
         priority += MatchingScoreCalculator.getMannerPriority(
                 otherRecord.getMannerLevel(), myRecord.getMannerLevel(), 16, 4);
 
-        // TODO: 티어 및 랭킹 점수 계산
-        priority += MatchingScoreCalculator.getTierRankPriority(myRecord.getTier(), myRecord.getGameRank(),
-                otherRecord.getTier(), otherRecord.getGameRank(), 40, 4);
-
         // 포지션 우선순위
         priority += MatchingScoreCalculator.getPositionPriority(
                 myRecord.getWantP(), otherRecord.getMainP(), otherRecord.getSubP(), 3, 2, 1);

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -142,7 +142,6 @@ class MemberServiceFacadeTest {
         OtherProfileResponse response = memberFacadeService.getOtherProfile(member, targetMember.getId());
 
         // then
-        // TODO: GameStyle 로직 추가 후 수정 필요
         assertThat(response).isNotNull();
         assertThat(response.getId()).isEqualTo(targetMember.getId());
         assertThat(response.getProfileImg()).isEqualTo(targetMember.getProfileImage());

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingStrategyProcessorTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingStrategyProcessorTest.java
@@ -154,8 +154,6 @@ class MatchingStrategyProcessorTest {
 
         // then
         int expectedPriority = 16 - (Math.abs(record1.getMannerLevel() - record2.getMannerLevel()) * 4) +
-                (40 - Math.abs(record1.getTier().ordinal() * 4 + record1.getGameRank() -
-                        record2.getTier().ordinal() * 4 - record2.getGameRank())) +
                 (record1.getMike().equals(record2.getMike()) ? 3 : 0) + getPositionExpectedPriority(member1, member2);
 
         assertThat(result).isEqualTo(expectedPriority);


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 빠른대전 우선순위 계산할 때 티어 반영 안하도록 수정

## ⏳ 작업 상세 내용

- [x] 빠른대전 우선순위 계산할 때 티어 점수 제거
- [x] 자유랭크 이외의 다른 매칭의 경우, 개인랭크 점수로 기록하도록 변경

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
