### PR TITLE
[Feat/220] 게시글 작성 쿨타임(5분) 적용

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
@@ -31,6 +31,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Optional<Board> findByIdAndDeleted(Long boardId, boolean b);
 
+    Optional<Board> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
+
 
     Page<Board> findByMemberIdAndDeletedFalse(Long memberId, Pageable pageable);
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
@@ -142,6 +142,8 @@ public enum ErrorCode {
     BOARD_FORBIDDEN_WORD_LOAD_FAILED(INTERNAL_SERVER_ERROR, "BOARD_409", "금지어 파일을 읽어오는데 실패했습니다."),
     BUMP_ACCESS_DENIED(FORBIDDEN, "BOARD_410", "게시글 끌어올리기 권한이 없습니다."),
     BUMP_TIME_LIMIT(BAD_REQUEST, "BOARD_411", "게시글 끌어올리기는 24시간에 1회만 가능합니다."),
+    BOARD_CREATE_COOL_DOWN(BAD_REQUEST, "BOARD_412", "게시글 작성 쿨타임이 적용되었습니다. 5분 후 다시 시도해주세요."),
+
 
     /**
      * 매너평가 관련 에러


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 게시글 작성 쿨타임(5분) 적용

## ⏳ 작업 상세 내용

- [ ] 게시글 생성 API 호출 시, 해당 회원의 마지막 게시글 생성 시간 조회
- [ ] 현재 시간과의 차이 5분 미만 시 예외 발생

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] 없을 경우 체크
