### PR TITLE
[Fix/222] 매칭 리스트 조회 시 중복 Id 조회되는 문제 해결 + 프로필 조회 수정

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
@@ -27,8 +27,6 @@ public class MyProfileResponse {
     Tier freeTier;
     Integer freeRank;
     Double freeWinrate;
-    Double mannerRank;
-    Integer mannerLevel;
     String updatedAt;
     Position mainP;
     Position subP;
@@ -39,7 +37,7 @@ public class MyProfileResponse {
     List<GameStyleResponse> gameStyleResponseList;
     List<ChampionResponse> championResponseList;
 
-    public static MyProfileResponse of(Member member, Double mannerRank) {
+    public static MyProfileResponse of(Member member) {
         List<GameStyleResponse> gameStyleResponseList = member.getMemberGameStyleList().stream()
                 .map(memberGameStyle -> GameStyleResponse.of(memberGameStyle.getGameStyle()))
                 .toList();
@@ -61,8 +59,6 @@ public class MyProfileResponse {
                 .freeRank(member.getFreeRank())
                 .freeWinrate(member.getFreeWinRate())
                 .profileImg(member.getProfileImage())
-                .mannerLevel(member.getMannerLevel())
-                .mannerRank(mannerRank)
                 .mainP(member.getMainP())
                 .subP(member.getSubP())
                 .wantP(member.getWantP())

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
@@ -26,9 +26,6 @@ public class OtherProfileResponse {
     Tier freeTier;
     Integer freeRank;
     Double freeWinrate;
-    Integer mannerLevel;
-    Double mannerRank;
-    Long mannerRatingCount;  // 매너 평가를 한 사람의 수
     String updatedAt;
     Position mainP;
     Position subP;
@@ -42,8 +39,7 @@ public class OtherProfileResponse {
     List<GameStyleResponse> gameStyleResponseList;
     List<ChampionResponse> championResponseList;
 
-    public static OtherProfileResponse of(Member targetMember, Double managerRank,
-                                          Long mannerRatingCount, Boolean isFriend, Long friendRequestMemberId,
+    public static OtherProfileResponse of(Member targetMember, Boolean isFriend, Long friendRequestMemberId,
                                           Boolean isBlocked) {
         List<GameStyleResponse> gameStyleResponseList = targetMember.getMemberGameStyleList().stream()
                 .map(memberGameStyle -> GameStyleResponse.of(memberGameStyle.getGameStyle()))
@@ -65,9 +61,6 @@ public class OtherProfileResponse {
                 .freeRank(targetMember.getFreeRank())
                 .freeWinrate(targetMember.getFreeWinRate())
                 .profileImg(targetMember.getProfileImage())
-                .mannerLevel(targetMember.getMannerLevel())
-                .mannerRank(managerRank)
-                .mannerRatingCount(mannerRatingCount)
                 .mainP(targetMember.getMainP())
                 .wantP(targetMember.getWantP())
                 .subP(targetMember.getSubP())

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
@@ -30,11 +30,7 @@ public class MemberFacadeService {
      * @return 조회된 결과 DTO
      */
     public MyProfileResponse getMyProfile(Member member) {
-
-        // TODO: mannerRank 로직 추가
-        double mannerRank = 1.0;
-
-        return MyProfileResponse.of(member, mannerRank);
+        return MyProfileResponse.of(member);
     }
 
     /**
@@ -48,10 +44,6 @@ public class MemberFacadeService {
         // memberId로 targetMember 얻기
         Member targetMember = memberService.findMemberById(targetMemberId);
 
-        // TODO: mannerRank, mannerRatingCount 로직 추가
-        double mannerRank = 1.0;
-        long mannerRatingCount = 1L;
-
         // 친구 정보 얻기
         boolean isFriend = friendService.isFriend(member, targetMember);
         Long friendRequestMemberId = friendService.getFriendRequestMemberId(member, targetMember);
@@ -59,7 +51,7 @@ public class MemberFacadeService {
         // 차단된 사용자인지 확인
         boolean isBlocked = blockService.isBlocked(member, targetMember);
 
-        return OtherProfileResponse.of(targetMember, mannerRank, mannerRatingCount, isFriend, friendRequestMemberId,
+        return OtherProfileResponse.of(targetMember, isFriend, friendRequestMemberId,
                 isBlocked);
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/controller/MatchingController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/controller/MatchingController.java
@@ -50,7 +50,7 @@ public class MatchingController {
     @Operation(summary = "매칭 FOUND API", description = "API triggered when a match is found")
     @PostMapping("/matching/found")
     public ApiResponse<MatchingFoundResponse> FindMatching(@RequestBody @Valid MatchingFoundRequest request) {
-        return ApiResponse.ok(matchingFacadeService.modifyTargetMatchingRecordAndStatus(request));
+        return ApiResponse.ok(matchingFacadeService.matchingFound(request));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/repository/MatchingRecordRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/repository/MatchingRecordRepositoryCustom.java
@@ -15,9 +15,10 @@ public interface MatchingRecordRepositoryCustom {
      *
      * @param createdAt 생성 시간
      * @param gameMode  게임 모드
+     * @param memberId  사용자 id
      * @return 매칭 가능한 레코드 리스트
      */
-    List<MatchingRecord> findValidMatchingRecords(LocalDateTime createdAt, GameMode gameMode);
+    List<MatchingRecord> findValidMatchingRecords(LocalDateTime createdAt, GameMode gameMode, Long memberId);
 
     /**
      * 가장 최근 기록 불러오기 - member

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/repository/MatchingRecordRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/repository/MatchingRecordRepositoryCustomImpl.java
@@ -30,19 +30,22 @@ public class MatchingRecordRepositoryCustomImpl implements MatchingRecordReposit
      *
      * @param createdAt 생성 시간
      * @param gameMode  게임 모드
+     * @param memberId  사용자 id
      * @return 매칭 기록
      */
     @Override
-    public List<MatchingRecord> findValidMatchingRecords(LocalDateTime createdAt, GameMode gameMode) {
+    public List<MatchingRecord> findValidMatchingRecords(LocalDateTime createdAt, GameMode gameMode, Long memberId) {
         return queryFactory.selectFrom(matchingRecord)
                 .where(
                         matchingRecord.createdAt.gt(createdAt),
                         matchingRecord.status.eq(MatchingStatus.PENDING),
                         matchingRecord.gameMode.eq(gameMode),
+                        matchingRecord.member.id.ne(memberId),
                         existsValidMatchSubquery(),
                         applyGameModeFilter(gameMode)
                 )
                 .orderBy(matchingRecord.member.id.asc(), matchingRecord.createdAt.desc())
+                .distinct()
                 .fetch();
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
@@ -139,7 +139,7 @@ public class MatchingFacadeService {
      * @return 나와 상대방의 매칭 정보
      */
     @Transactional
-    public MatchingFoundResponse modifyTargetMatchingRecordAndStatus(MatchingFoundRequest request) {
+    public MatchingFoundResponse matchingFound(MatchingFoundRequest request) {
         // 내 matching 조회
         MatchingRecord matchingRecord =
                 matchingService.getMatchingRecordByMatchingUuid(request.getMatchingUuid());
@@ -161,11 +161,11 @@ public class MatchingFacadeService {
         // 서로의 차단 여부 검증
         validateBlockStatusWhenMatch(member, targetMember);
 
-        // 내 매칭 status가 올바른지 검증
+        // 두 매칭 status가 올바른지 검증
         validateMatchingStatus(MatchingStatus.PENDING, matchingRecord, targetMatchingRecord);
 
         // targetMatchingRecord 지정하기
-        matchingService.setTargetMatchingMember(matchingRecord, targetMatchingRecord);
+        matchingService.setTargetMatchingRecord(matchingRecord, targetMatchingRecord);
 
         // matchingStatus 변경
         matchingService.setMatchingStatus(MatchingStatus.FOUND, matchingRecord);

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
@@ -68,7 +68,8 @@ public class MatchingFacadeService {
                 request.getGameMode());
 
         // 현재 대기 중인 사용자 조회
-        List<MatchingRecord> pendingMatchingRecords = matchingService.getPendingMatchingRecords(request.getGameMode());
+        List<MatchingRecord> pendingMatchingRecords = matchingService.getPendingMatchingRecords(request.getGameMode()
+                , memberId);
 
         // 차단당한 사용자 제외
         List<Long> targetMemberIds = new ArrayList<>();

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingService.java
@@ -99,8 +99,9 @@ public class MatchingService {
      * @param gameMode 게임모드
      * @return 대기 중인 매칭 리스트
      */
-    public List<MatchingRecord> getPendingMatchingRecords(GameMode gameMode) {
-        return matchingRecordRepository.findValidMatchingRecords(LocalDateTime.now().minusMinutes(5), gameMode);
+    public List<MatchingRecord> getPendingMatchingRecords(GameMode gameMode, Long memberId) {
+        return matchingRecordRepository.findValidMatchingRecords(LocalDateTime.now().minusMinutes(5), gameMode,
+                memberId);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingService.java
@@ -162,7 +162,7 @@ public class MatchingService {
      * @param targetMatchingRecord 상대방 matchingRecord
      */
     @Transactional
-    public void setTargetMatchingMember(MatchingRecord matchingRecord, MatchingRecord targetMatchingRecord) {
+    public void setTargetMatchingRecord(MatchingRecord matchingRecord, MatchingRecord targetMatchingRecord) {
         matchingRecord.updateTargetMatchingRecord(targetMatchingRecord);
         targetMatchingRecord.updateTargetMatchingRecord(matchingRecord);
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/matching/MatchingFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/matching/MatchingFacadeServiceTest.java
@@ -313,7 +313,8 @@ public class MatchingFacadeServiceTest {
 
         // 3. Priority 검증
         List<MatchingRecord> recentValidMatchingRecords =
-                matchingRecordRepository.findValidMatchingRecords(LocalDateTime.now().minusMinutes(5), GameMode.SOLO);
+                matchingRecordRepository.findValidMatchingRecords(LocalDateTime.now().minusMinutes(5), GameMode.SOLO,
+                        member.getId());
         PriorityListResponse expectedPriorityList = matchingService.calculatePriorityList(matchingRecord,
                 recentValidMatchingRecords);
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/matching/MatchingFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/matching/MatchingFacadeServiceTest.java
@@ -431,7 +431,7 @@ public class MatchingFacadeServiceTest {
 
         @DisplayName("실패: 두 회원이 동일한 경우 예외가 발생한다.")
         @Test
-        void startChatroomByMatching_shouldThrownWhenTargetMemberIsSelf() {
+        void matchingFoundFailWhenMemberDuplicate() {
             // given
             MatchingRecord matchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC, member,
                     MatchingStatus.PENDING);
@@ -445,13 +445,13 @@ public class MatchingFacadeServiceTest {
 
 
             // when // then
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(GlobalException.class);
         }
 
         @DisplayName("실패: 회원이 탈퇴한 경우 예외가 발생한다.")
         @Test
-        void startChatroomByMatching_shouldThrownWhenMemberIsBlind() {
+        void matchingFoundFailWhenMemberIsBlind() {
             MatchingRecord matchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC, member,
                     MatchingStatus.PENDING);
             MatchingRecord targetMatchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC,
@@ -466,14 +466,14 @@ public class MatchingFacadeServiceTest {
             blindMember(targetMember);
 
             // when // then
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(MemberException.class)
                     .hasMessage(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage());
         }
 
         @DisplayName("실패: 상대 회원을 차단한 경우 예외가 발생한다.")
         @Test
-        void startChatroomByMatching_shouldThrownWhenTargetIsBlocked() {
+        void matchingFoundFailWhenTargetMemberBlocked() {
             MatchingRecord matchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC, member,
                     MatchingStatus.PENDING);
             MatchingRecord targetMatchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC,
@@ -488,14 +488,14 @@ public class MatchingFacadeServiceTest {
             blockMember(member, targetMember);
 
             // when // then
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(ChatException.class)
                     .hasMessage(ErrorCode.MATCHING_FOUND_FAILED_TARGET_IS_BLOCKED.getMessage());
         }
 
         @DisplayName("실패: 상대 회원에게 차단 당한 경우 예외가 발생한다.")
         @Test
-        void startChatroomByMatching_shouldThrownWhenBlockedByTarget() {
+        void matchingFoundFailWhenBlockedByTargetMember() {
             MatchingRecord matchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC, member,
                     MatchingStatus.PENDING);
             MatchingRecord targetMatchingRecord = createMatchingRecord(GameMode.SOLO, MatchingType.BASIC,
@@ -510,12 +510,12 @@ public class MatchingFacadeServiceTest {
             blockMember(targetMember, member);
 
             // when // then
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(ChatException.class)
                     .hasMessage(ErrorCode.MATCHING_FOUND_FAILED_BLOCKED_BY_TARGET.getMessage());
         }
 
-        @DisplayName("실패: 내 매칭 uuid없는 uuid일 경우")
+        @DisplayName("실패: 매칭 uuid에 해당하는 매칭 기록이 없는 경우")
         @Test
         void notFoundMatchingUuid() {
             // given
@@ -528,12 +528,12 @@ public class MatchingFacadeServiceTest {
                     .build();
 
             // when, then
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(MatchingException.class)
                     .hasMessage(ErrorCode.MATCHING_NOT_FOUND.getMessage());
         }
 
-        @DisplayName("실패: 상대 매칭 uuid없는 uuid일 경우")
+        @DisplayName("실패: 매칭 uuid에 해당하는 상대 매칭 기록이 없는 경우")
         @Test
         void notFoundTargetMatchingUuid() {
             // given
@@ -546,7 +546,7 @@ public class MatchingFacadeServiceTest {
                     .build();
 
             // when, then
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(MatchingException.class)
                     .hasMessage(ErrorCode.MATCHING_NOT_FOUND.getMessage());
         }
@@ -570,7 +570,7 @@ public class MatchingFacadeServiceTest {
             assertThat(targetMatchingRecord.getTargetMatchingRecord()).isNull();
             assertThat(matchingRecord.getStatus()).isEqualTo(MatchingStatus.FAIL);
             assertThat(targetMatchingRecord.getStatus()).isEqualTo(MatchingStatus.PENDING);
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(MatchingException.class)
                     .hasMessage(ErrorCode.MATCHING_STATUS_NOT_ALLOWED.getMessage());
         }
@@ -594,7 +594,7 @@ public class MatchingFacadeServiceTest {
             assertThat(targetMatchingRecord.getTargetMatchingRecord()).isNull();
             assertThat(matchingRecord.getStatus()).isEqualTo(MatchingStatus.PENDING);
             assertThat(targetMatchingRecord.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
-            assertThatThrownBy(() -> matchingFacadeService.modifyTargetMatchingRecordAndStatus(request))
+            assertThatThrownBy(() -> matchingFacadeService.matchingFound(request))
                     .isInstanceOf(MatchingException.class)
                     .hasMessage(ErrorCode.MATCHING_TARGET_UNAVAILABLE.getMessage());
         }
@@ -615,7 +615,7 @@ public class MatchingFacadeServiceTest {
 
             // when
             MatchingFoundResponse matchingFoundResponse =
-                    matchingFacadeService.modifyTargetMatchingRecordAndStatus(request);
+                    matchingFacadeService.matchingFound(request);
 
             // then
             assertThat(matchingRecord.getStatus()).isEqualTo(MatchingStatus.FOUND);

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -123,7 +123,6 @@ class MemberServiceFacadeTest {
         assertThat(response.getIsAgree()).isEqualTo(member.isAgree());
         assertThat(response.getIsBlind()).isEqualTo(member.isBlind());
         assertThat(response.getLoginType()).isEqualTo(member.getLoginType().name());
-        assertThat(response.getMannerLevel()).isEqualTo(member.getMannerLevel());
         assertThat(response.getChampionResponseList()).isNotNull();
 
         List<Champion> championList =
@@ -154,7 +153,6 @@ class MemberServiceFacadeTest {
         assertThat(response.getFreeTier()).isEqualTo(targetMember.getFreeTier());
         assertThat(response.getFreeRank()).isEqualTo(targetMember.getFreeRank());
         assertThat(response.getFreeWinrate()).isEqualTo(targetMember.getFreeWinRate());
-        assertThat(response.getMannerLevel()).isEqualTo(targetMember.getMannerLevel());
         assertThat(response.getMainP()).isEqualTo(targetMember.getMainP());
         assertThat(response.getSubP()).isEqualTo(targetMember.getSubP());
         assertThat(response.getWantP()).isEqualTo(targetMember.getWantP());

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingServiceTest.java
@@ -303,11 +303,12 @@ class MatchingServiceTest {
         }
 
         // when
-        List<MatchingRecord> matchingRecords = matchingService.getPendingMatchingRecords(gameMode);
+        List<MatchingRecord> matchingRecords = matchingService.getPendingMatchingRecords(gameMode, member.getId());
 
         // then
         List<MatchingRecord> expectedMatchingRecords =
-                matchingRecordRepository.findValidMatchingRecords(LocalDateTime.now().minusMinutes(5), gameMode);
+                matchingRecordRepository.findValidMatchingRecords(LocalDateTime.now().minusMinutes(5), gameMode,
+                        member.getId());
         assertThat(matchingRecords.size()).isEqualTo(expectedMatchingRecords.size());
     }
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 매칭 리스트 조회 시 중복 Id 조회되는 문제 해결 + 프로필 조회 수정

## ⏳ 작업 상세 내용

- [x] findValidMatchingRecords 수정
- [x] 프로필 조회에서 매너 부분 삭제
- [x] matchingFound로 네이밍 변경

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 나중에 PENDING 상태를 아예 남기지 않기위해서 처음 조회할 때, 본인 MatchingRecord 중 PENDING인 Record가 있다면, QUIT으로 변경하는게 좋을 것 같습니다. 아니면 오히려 PENDING을 남겨서 어떤 경우에 PENDING이 남는지 의도치않은 경우를 확인해보는 것도 좋을 것 같습니다.  

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
