### PR TITLE
[Fix/237] Riot, Champion, Auth 에러 해결

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
@@ -40,26 +40,29 @@ public class AuthFacadeService {
      */
     @Transactional
     public String join(JoinRequest request) {
-        // 1. [Member] 중복확인
+        // [Member] 이메일 중복확인
         memberService.checkDuplicateMemberByEmail(request.getEmail());
 
-        // 2. [Riot] 존재하는 소환사인지 검증 & puuid 얻기
+        // [Member] gameName 중복확인
+        memberService.checkDuplicateMemberByGameName(request.getGameName());
+
+        // [Riot] 존재하는 소환사인지 검증 & puuid 얻기
         String puuid = riotAccountService.getPuuid(request.getGameName(), request.getTag());
 
-        // 3. [Riot] summonerId 얻기
+        // [Riot] summonerId 얻기
         String summonerId = riotAccountService.getSummonerId(puuid);
 
-        // 3. [Riot] tier, rank, winrate 얻기
+        // [Riot] tier, rank, winrate 얻기
         List<TierDetails> tierWinrateRank = riotInfoService.getTierWinrateRank(summonerId);
 
-        // 4. [Member] member DB에 저장
+        // [Member] member DB에 저장
         Member member = memberService.createMember(request, tierWinrateRank);
 
-        // 5. [Riot] 최근 사용한 챔피언 3개 가져오기
+        // [Riot] 최근 사용한 챔피언 3개 가져오기
         List<Long> preferChampionfromMatch = riotRecordService.getPreferChampionfromMatch(request.getGameName(),
                 puuid);
 
-        // 6. [Member] Member Champion DB에서 매핑하기
+        // [Member] Member Champion DB에서 매핑하기
         memberChampionService.saveMemberChampions(member, preferChampionfromMatch);
 
         return "회원가입이 완료되었습니다.";

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
@@ -11,6 +11,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByGameName(String gameName);
+
     Optional<Member> findByEmail(String email);
 
     @Query("SELECT m.id FROM Member m WHERE m.mannerScore IS NOT NULL ORDER BY m.mannerScore desc")

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
@@ -1,8 +1,5 @@
 package com.gamegoo.gamegoo_v2.account.member.service;
 
-import com.gamegoo.gamegoo_v2.core.exception.RiotException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
-import com.gamegoo.gamegoo_v2.game.domain.Champion;
 import com.gamegoo.gamegoo_v2.game.repository.ChampionRepository;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.MemberChampion;
@@ -29,19 +26,14 @@ public class MemberChampionService {
      */
     @Transactional
     public void saveMemberChampions(Member member, List<Long> top3ChampionIds) {
-        if (top3ChampionIds == null || top3ChampionIds.isEmpty()) {
-            throw new RiotException(ErrorCode.CHAMPION_NOT_FOUND);
-        }
-
         top3ChampionIds.forEach(championId -> {
-            Champion champion = championRepository.findById(championId)
-                    .orElseThrow(() -> new RiotException(ErrorCode.CHAMPION_NOT_FOUND));
-
-            MemberChampion memberChampion = MemberChampion.create(champion, member);
-
-            memberChampionRepository.save(memberChampion);
+            // 챔피언이 존재하지 않으면 스킵
+            championRepository.findById(championId).ifPresent(champion -> {
+                MemberChampion memberChampion = MemberChampion.create(champion, member);
+                memberChampionRepository.save(memberChampion);
+            });
         });
-
     }
+
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberService.java
@@ -103,6 +103,18 @@ public class MemberService {
     }
 
     /**
+     * GameName 중복 확인하기
+     *
+     * @param gameName 소환사명
+     */
+    public void checkDuplicateMemberByGameName(String gameName) {
+        if (memberRepository.existsByGameName(gameName)) {
+            throw new MemberException(ErrorCode.RIOT_ACCOUNT_CONFLICT);
+        }
+    }
+
+
+    /**
      * DB에 없는 사용자일 경우 예외 발생
      *
      * @param email email

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/RiotException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/RiotException.java
@@ -9,4 +9,7 @@ public class RiotException extends GlobalException {
         super(errorCode);
     }
 
+    public RiotException(ErrorCode errorCode,String message) {
+        super(errorCode,message);
+    }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
@@ -4,11 +4,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
@@ -47,29 +49,30 @@ public enum ErrorCode {
     /**
      * 이메일 관련 에러
      */
-    EMAIL_CONTENT_LOAD_FAIL(NOT_FOUND, "EMAIL401", "이메일 본문을 읽어오는데 실패했습니다."),
-    EMAIL_SEND_FAIL(NOT_FOUND, "EMAIL402", "이메일 전송에 실패했습니다"),
+    EMAIL_CONTENT_LOAD_FAIL(NOT_FOUND, "EMAIL_401", "이메일 본문을 읽어오는데 실패했습니다."),
+    EMAIL_SEND_FAIL(NOT_FOUND, "EMAIL_402", "이메일 전송에 실패했습니다"),
     EMAIL_LIMIT_EXCEEDED(BAD_REQUEST, "EMAIL_403", "3분 이내 3개 이상 이메일을 보냈습니다."),
     EMAIL_RECORD_NOT_FOUND(NOT_FOUND, "EMAIL_404", "해당 이메일을 가진 기록이 없습니다."),
     INVALID_VERIFICATION_CODE(BAD_REQUEST, "EMAIL_405", "인증 코드가 틀렸습니다"),
     EMAIL_VERIFICATION_TIME_EXCEED(BAD_REQUEST, "EMAIL_406", "인증 코드 검증 시간을 초과했습니다."),
+
+    /**
+     * 게임스타일 관련 에러
+     */
     GAMESTYLE_NOT_FOUND(NOT_FOUND, "GAMESTYLE401", "해당 게임 스타일을 찾을 수 없습니다."),
 
     /**
      * Riot 관련 에러
      */
+    RIOT_UNKNOWN_ERROR(INTERNAL_SERVER_ERROR, "RIOT_501", "Riot API에서 알 수 없는 오류가 발생했습니다."),
+    RIOT_NETWORK_ERROR(SERVICE_UNAVAILABLE, "RIOT_502", "네트워크 오류로 Riot API 요청이 실패했습니다."),
+    RIOT_SERVER_ERROR(BAD_GATEWAY, "RIOT_503", "Riot API 서버에서 오류가 발생했습니다"),
+    RIOT_API_ERROR(INTERNAL_SERVER_ERROR, "RIOT_504", "Riot API 요청 중 에러가 발생했습니다."),
+    RIOT_INVALID_API_KEY(BAD_REQUEST, "RIOT_401", "잘못된 Riot API 키입니다."),
+    RIOT_API_BAD_REQUEST(BAD_REQUEST, "RIOT_402", "잘못된 Riot API 호출입니다."),
     RIOT_NOT_FOUND(NOT_FOUND, "RIOT_401", "해당 Riot 계정이 존재하지 않습니다."),
-    RIOT_MEMBER_CONFLICT(CONFLICT, "RIOT_402", "해당 이메일 계정은 이미 다른 RIOT 계정과 연동되었습니다."),
-    RIOT_ACCOUNT_CONFLICT(CONFLICT, "RIOT403", "해당 RIOT 계정은 이미 다른 이메일과 연동되어있습니다."),
-    RIOT_INSUFFICIENT_MATCHES(NOT_FOUND, "RIOT404",
-            "해당 RIOT 계정은 최근 100판 이내에 솔로랭크, 자유랭크, 일반게임, 칼바람을 플레이한 적이 없기 때문에 선호하는 챔피언 3명을 정할 수 없습니다."),
-    RIOT_ERROR(INTERNAL_SERVER_ERROR, "RIOT405", "RIOT API 연동 중 에러가 발생했습니다."),
-    RIOT_MATCH_NOT_FOUND(NOT_FOUND, "RIOTMATCH_401",
-            "해당 Riot 계정의 매칭을 불러오는 도중 에러가 발생했습니다. 최근 100판 이내 이벤트 매칭 제외, 일반 매칭(일반게임,랭크게임,칼바람)을 많이 한 계정으로 다시 시도하세요."),
-    RIOT_MATCH_IDS_NOT_FOUND(NOT_FOUND, "RIOTMATCH_402", "Riot 매칭 id 들을 불러오는 도중 에러가 발생했습니다."),
-    RIOT_PREFER_CHAMPION_ERROR(INTERNAL_SERVER_ERROR, "RIOTCHAMPION_401", "선호 챔피언을 연동하는 도중 에러가 발생했습니다"),
-    RIOT_MATCH_CHAMPION_NOT_FOUND(NOT_FOUND, "RIOTCHAMPION_402", "매칭 정보에서 챔피언 정보를 불러오는 도중 에러가 발생했습니다."),
-    CHAMPION_NOT_FOUND(NOT_FOUND, "CHAMPION_401", "해당 챔피언이 존재하지 않습니다."),
+    RIOT_MEMBER_CONFLICT(CONFLICT, "RIOT_402", "해당 이메일 계정은 이미 다른 Riot 계정과 연동되었습니다."),
+    RIOT_ACCOUNT_CONFLICT(CONFLICT, "RIOT403", "해당 Riot 계정은 이미 다른 이메일과 연동되어있습니다."),
 
     /**
      * 매칭 관련 에러

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
@@ -69,9 +69,7 @@ public enum ErrorCode {
     RIOT_SERVER_ERROR(BAD_GATEWAY, "RIOT_503", "Riot API 서버에서 오류가 발생했습니다"),
     RIOT_API_ERROR(INTERNAL_SERVER_ERROR, "RIOT_504", "Riot API 요청 중 에러가 발생했습니다."),
     RIOT_INVALID_API_KEY(BAD_REQUEST, "RIOT_401", "잘못된 Riot API 키입니다."),
-    RIOT_API_BAD_REQUEST(BAD_REQUEST, "RIOT_402", "잘못된 Riot API 호출입니다."),
     RIOT_NOT_FOUND(NOT_FOUND, "RIOT_401", "해당 Riot 계정이 존재하지 않습니다."),
-    RIOT_MEMBER_CONFLICT(CONFLICT, "RIOT_402", "해당 이메일 계정은 이미 다른 Riot 계정과 연동되었습니다."),
     RIOT_ACCOUNT_CONFLICT(CONFLICT, "RIOT403", "해당 Riot 계정은 이미 다른 이메일과 연동되어있습니다."),
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/GlobalException.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/GlobalException.java
@@ -16,4 +16,9 @@ public class GlobalException extends RuntimeException {
         this.message = errorCode.getMessage();
     }
 
+    public GlobalException(ErrorCode errorCode, String customMessage) {
+        this.status = errorCode.getStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage() + customMessage;
+    }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotAuthService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotAuthService.java
@@ -4,6 +4,7 @@ import com.gamegoo.gamegoo_v2.core.exception.RiotException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.external.riot.dto.RiotAuthResponse;
 import com.gamegoo.gamegoo_v2.external.riot.dto.RiotSummonerResponse;
+import com.gamegoo.gamegoo_v2.utils.RiotApiHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.web.client.RestTemplate;
 public class RiotAuthService {
 
     private final RestTemplate restTemplate;
+    private final RiotApiHelper riotApiHelper;
 
     @Value("${spring.riot.api.key}")
     private String riotAPIKey;
@@ -43,8 +45,8 @@ public class RiotAuthService {
 
             return response.getPuuid();
         } catch (Exception e) {
-            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
-        }
+            riotApiHelper.handleApiError(e);
+            return null;        }
     }
 
     /**
@@ -64,8 +66,8 @@ public class RiotAuthService {
 
             return summonerResponse.getId();
         } catch (Exception e) {
-            throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
-        }
+            riotApiHelper.handleApiError(e);
+            return null;        }
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotInfoService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotInfoService.java
@@ -1,11 +1,10 @@
 package com.gamegoo.gamegoo_v2.external.riot.service;
 
-import com.gamegoo.gamegoo_v2.core.exception.RiotException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.external.riot.dto.RiotInfoResponse;
 import com.gamegoo.gamegoo_v2.external.riot.dto.TierDetails;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import com.gamegoo.gamegoo_v2.utils.RiotApiHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +23,7 @@ import java.util.Map;
 public class RiotInfoService {
 
     private final RestTemplate restTemplate;
+    private final RiotApiHelper riotApiHelper;
 
     @Value("${spring.riot.api.key}")
     private String riotAPIKey;
@@ -61,8 +61,8 @@ public class RiotInfoService {
                 }
             }
         } catch (Exception e) {
-            log.error("RIOT API INTERNAL ERROR: ", e);
-            throw new RiotException(ErrorCode.RIOT_ERROR);
+            riotApiHelper.handleApiError(e);
+            return null;
         }
 
         return tierDetails;

--- a/src/main/java/com/gamegoo/gamegoo_v2/utils/ChampionIdStore.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/utils/ChampionIdStore.java
@@ -1,0 +1,22 @@
+package com.gamegoo.gamegoo_v2.utils;
+
+import java.util.Set;
+
+public class ChampionIdStore {
+    private static final Set<Long> CHAMPION_IDS = Set.of(
+            1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L,
+            22L, 23L, 24L, 25L, 26L, 27L, 28L, 29L, 30L, 31L, 32L, 33L, 34L, 35L, 36L, 37L, 38L, 39L, 40L, 41L,
+            42L, 43L, 44L, 45L, 48L, 50L, 51L, 53L, 54L, 55L, 56L, 57L, 58L, 59L, 60L, 61L, 62L, 63L, 64L, 67L,
+            68L, 69L, 72L, 74L, 75L, 76L, 77L, 78L, 79L, 80L, 81L, 82L, 83L, 84L, 85L, 86L, 89L, 90L, 91L, 92L,
+            96L, 98L, 99L, 101L, 102L, 103L, 104L, 105L, 106L, 107L, 110L, 111L, 112L, 113L, 114L, 115L, 117L,
+            119L, 120L, 121L, 122L, 126L, 127L, 131L, 133L, 134L, 136L, 141L, 142L, 143L, 145L, 147L, 150L, 154L,
+            157L, 161L, 163L, 164L, 166L, 200L, 201L, 202L, 203L, 221L, 222L, 223L, 233L, 234L, 235L, 236L, 238L,
+            240L, 245L, 246L, 254L, 266L, 267L, 268L, 350L, 360L, 412L, 420L, 421L, 427L, 429L, 432L, 497L, 498L,
+            516L, 517L, 518L, 523L, 526L, 555L, 711L, 777L, 875L, 876L, 887L, 888L, 895L, 897L, 901L, 902L, 910L,
+            950L
+    );
+
+    public static boolean contains(Long championId) {
+        return CHAMPION_IDS.contains(championId);
+    }
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/utils/EmailTemplateProcessor.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/utils/EmailTemplateProcessor.java
@@ -2,7 +2,6 @@ package com.gamegoo.gamegoo_v2.utils;
 
 import com.gamegoo.gamegoo_v2.core.exception.EmailException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.FileCopyUtils;
@@ -10,7 +9,6 @@ import org.springframework.util.FileCopyUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-@Slf4j
 @Component
 public class EmailTemplateProcessor {
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/utils/RiotApiHelper.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/utils/RiotApiHelper.java
@@ -1,0 +1,33 @@
+package com.gamegoo.gamegoo_v2.utils;
+
+import com.gamegoo.gamegoo_v2.core.exception.RiotException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.*;
+
+@Component
+public class RiotApiHelper {
+    /**
+     * Riot API 호출 실패 시 예외 처리
+     */
+    public void handleApiError(Exception e) {
+        if (e instanceof HttpClientErrorException httpEx) {
+            if (httpEx.getStatusCode() == HttpStatus.BAD_REQUEST) {
+                String responseBody = httpEx.getResponseBodyAsString();
+                if (responseBody.contains("Unknown apikey")) {
+                    throw new RiotException(ErrorCode.RIOT_INVALID_API_KEY);
+                }
+                throw new RiotException(ErrorCode.RIOT_API_BAD_REQUEST);
+            }
+
+            if (httpEx.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
+            }
+
+            throw new RiotException(ErrorCode.RIOT_API_ERROR, httpEx.getMessage());
+        }
+
+        throw new RiotException(ErrorCode.RIOT_UNKNOWN_ERROR, e.getMessage());
+    }
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/utils/RiotApiHelper.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/utils/RiotApiHelper.java
@@ -13,19 +13,23 @@ public class RiotApiHelper {
      */
     public void handleApiError(Exception e) {
         if (e instanceof HttpClientErrorException httpEx) {
-            if (httpEx.getStatusCode() == HttpStatus.BAD_REQUEST) {
-                String responseBody = httpEx.getResponseBodyAsString();
-                if (responseBody.contains("Unknown apikey")) {
-                    throw new RiotException(ErrorCode.RIOT_INVALID_API_KEY);
-                }
-                throw new RiotException(ErrorCode.RIOT_API_BAD_REQUEST);
+            if (httpEx.getStatusCode() == HttpStatus.BAD_REQUEST||httpEx.getStatusCode() == HttpStatus.UNAUTHORIZED||httpEx.getStatusCode() == HttpStatus.FORBIDDEN) {
+                throw new RiotException(ErrorCode.RIOT_INVALID_API_KEY);
             }
 
             if (httpEx.getStatusCode() == HttpStatus.NOT_FOUND) {
                 throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
             }
 
-            throw new RiotException(ErrorCode.RIOT_API_ERROR, httpEx.getMessage());
+            throw new RiotException(ErrorCode.RIOT_API_ERROR,httpEx.getMessage());
+        }
+
+        if (e instanceof HttpServerErrorException) {
+            throw new RiotException(ErrorCode.RIOT_SERVER_ERROR);
+        }
+
+        if (e instanceof ResourceAccessException) {
+            throw new RiotException(ErrorCode.RIOT_NETWORK_ERROR);
         }
 
         throw new RiotException(ErrorCode.RIOT_UNKNOWN_ERROR, e.getMessage());

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -345,8 +345,7 @@ class MemberServiceFacadeTest {
 
     private void initMemberChampion(Member member, List<Long> top3ChampionIds) {
         top3ChampionIds.forEach(championId -> {
-            Champion champion = championRepository.findById(championId)
-                    .orElseThrow(() -> new RiotException(ErrorCode.CHAMPION_NOT_FOUND));
+            Champion champion = championRepository.findById(championId).isPresent() ? championRepository.findById(championId).get() : null;
             MemberChampion memberChampion = MemberChampion.create(champion, member);
             memberChampionRepository.save(memberChampion);
         });


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> Riot : 예외처리 추가
> Champion : 모든 경우에도 다 챔피언이 오도록 변경
> Auth : 소환사명 검증 추가

## ⏳ 작업 상세 내용
### Riot
- [x] RiotApiHandler 추가 -> RIOT API의 오류일 경우, 유형 분석 후 예외 던지기
- [x] riot API 불러올 때 속도 상승 (불러올 때마다 이전 데이터까지 불러오지 않고 새로운 데이터 더 들고와서 추가로 계산하도록)

### Champion
- [x] 어떤 모드라도 다 가져오도록 변경
- [x] 판 수 모자라도 들고오도록 변경
- [x] champion이 3개 미만이어도 괜찮도록 변경
-> Champion 관련 에러응답 전부 삭제

### Auth
- [x] gameName 중복 검증 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->
- [ ] DEV DB 테스트 계정 Notion에 정리
- [ ] 에러 응답

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] RIOT API 환경 변수 변경 -> RGAPI-e26b899b-46de-410c-bff6-60e7d665d902
- [ ] DEV DB 초기화 후 데이터 삽입

