### PR TITLE
[Feat/239] 최근 선호 챔피언의 승률, 게임 수 제공

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
@@ -9,6 +9,7 @@ import com.gamegoo.gamegoo_v2.account.auth.jwt.JwtProvider;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.service.MemberChampionService;
 import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
+import com.gamegoo.gamegoo_v2.external.riot.domain.ChampionStats;
 import com.gamegoo.gamegoo_v2.external.riot.dto.TierDetails;
 import com.gamegoo.gamegoo_v2.external.riot.service.RiotAuthService;
 import com.gamegoo.gamegoo_v2.external.riot.service.RiotInfoService;
@@ -56,11 +57,11 @@ public class AuthFacadeService {
         Member member = memberService.createMember(request, tierWinrateRank);
 
         // 5. [Riot] 최근 사용한 챔피언 3개 가져오기
-        List<Long> preferChampionfromMatch = riotRecordService.getPreferChampionfromMatch(request.getGameName(),
+        List<ChampionStats> preferChampionStats = riotRecordService.getPreferChampionfromMatch(request.getGameName(),
                 puuid);
 
         // 6. [Member] Member Champion DB에서 매핑하기
-        memberChampionService.saveMemberChampions(member, preferChampionfromMatch);
+        memberChampionService.saveMemberChampions(member, preferChampionStats);
 
         return "회원가입이 완료되었습니다.";
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberChampion.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberChampion.java
@@ -33,18 +33,28 @@ public class MemberChampion extends BaseDateTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    public static MemberChampion create(Champion champion, Member member) {
+    @Column(nullable = false)
+    private int wins;
+
+    @Column(nullable = false)
+    private int games;
+
+    public static MemberChampion create(Champion champion, Member member, int wins, int games) {
         MemberChampion memberChampion = MemberChampion.builder()
                 .champion(champion)
+                .wins(wins)
+                .games(games)
                 .build();
         memberChampion.setMember(member);
         return memberChampion;
     }
 
     @Builder
-    private MemberChampion(Champion champion, Member member) {
+    private MemberChampion(Champion champion, Member member, int wins, int games) {
         this.champion = champion;
         this.member = member;
+        this.wins = wins;
+        this.games = games;
     }
 
     public void setMember(Member member) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
@@ -1,11 +1,11 @@
 package com.gamegoo.gamegoo_v2.account.member.dto.response;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.game.dto.response.ChampionResponse;
 import com.gamegoo.gamegoo_v2.game.dto.response.GameStyleResponse;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
-import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -43,7 +43,10 @@ public class MyProfileResponse {
                 .toList();
 
         List<ChampionResponse> championResponseList = member.getMemberChampionList().stream()
-                .map(memberChampion -> ChampionResponse.of(memberChampion.getChampion()))
+                .map(memberChampion -> ChampionResponse.of(
+                        memberChampion.getChampion(),
+                        memberChampion.getWins(),
+                        memberChampion.getGames()))
                 .toList();
 
         return MyProfileResponse.builder()

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
@@ -46,7 +46,10 @@ public class OtherProfileResponse {
                 .toList();
 
         List<ChampionResponse> championResponseList = targetMember.getMemberChampionList().stream()
-                .map(memberChampion -> ChampionResponse.of(memberChampion.getChampion()))
+                .map(memberChampion -> ChampionResponse.of(
+                        memberChampion.getChampion(),
+                        memberChampion.getWins(),
+                        memberChampion.getGames()))
                 .toList();
 
         return OtherProfileResponse.builder()

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberChampionRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberChampionRepository.java
@@ -1,8 +1,12 @@
 package com.gamegoo.gamegoo_v2.account.member.repository;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.MemberChampion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 public interface MemberChampionRepository extends JpaRepository<MemberChampion, Long> {
+
+    void deleteByMember(Member member);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
@@ -1,9 +1,10 @@
 package com.gamegoo.gamegoo_v2.account.member.service;
 
-import com.gamegoo.gamegoo_v2.game.repository.ChampionRepository;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.MemberChampion;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberChampionRepository;
+import com.gamegoo.gamegoo_v2.external.riot.domain.ChampionStats;
+import com.gamegoo.gamegoo_v2.game.repository.ChampionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,15 +22,17 @@ public class MemberChampionService {
     /**
      * 멤버와 챔피언 ID 목록을 기반으로 MemberChampion 엔티티를 생성 및 저장하는 메서드
      *
-     * @param member          대상 멤버
-     * @param top3ChampionIds 챔피언 ID 목록
+     * @param member        대상 멤버
+     * @param championStats 챔피언 ID 목록
      */
     @Transactional
-    public void saveMemberChampions(Member member, List<Long> top3ChampionIds) {
-        top3ChampionIds.forEach(championId -> {
+    public void saveMemberChampions(Member member, List<ChampionStats> championStats) {
+        championStats.forEach(stats -> {
+            Long championId = stats.getChampionId();
             // 챔피언이 존재하지 않으면 스킵
             championRepository.findById(championId).ifPresent(champion -> {
-                MemberChampion memberChampion = MemberChampion.create(champion, member);
+                MemberChampion memberChampion = MemberChampion.create(champion, member, stats.getGames(),
+                        stats.getWins());
                 memberChampionRepository.save(memberChampion);
             });
         });

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -67,7 +67,6 @@ public class BoardController {
     @Operation(summary = "게시판 글 목록 조회 API",
             description = "게시판 글 목록을 조회하는 API 입니다. 필터링을 원하면 각 파라미터를 입력하세요.")
     @Parameters({
-            @Parameter(name = "pageIdx", description = "조회할 페이지 번호를 입력해주세요. 페이지 당 20개의 게시물을 볼 수 있습니다."),
             @Parameter(name = "gameMode", description = "(선택) 게임 모드를 입력해주세요. < 빠른대전: FAST, 솔로랭크: SOLO, 자유랭크: FREE, " +
                     "칼바람 나락: ARAM >"),
             @Parameter(name = "tier", description = "(선택) 티어를 선택해주세요."),

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -41,7 +41,7 @@ public class BoardListResponse {
         Member member = board.getMember();
         List<ChampionResponse> championResponseList = (member.getMemberChampionList() != null) ?
                 member.getMemberChampionList().stream()
-                        .map(mc -> ChampionResponse.of(mc.getChampion()))
+                        .map(mc -> ChampionResponse.of(mc.getChampion(), mc.getWins(), mc.getGames()))
                         .collect(Collectors.toList())
                 : null;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/domain/ChampionStats.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/domain/ChampionStats.java
@@ -1,0 +1,69 @@
+package com.gamegoo.gamegoo_v2.external.riot.domain;
+
+/**
+ * 챔피언별 승/패 통계를 저장하는 클래스
+ */
+public class ChampionStats {
+
+    private final long championId;
+    private int wins;
+    private int games;
+
+    /**
+     * 한 경기의 결과로 객체를 생성
+     *
+     * @param championId 챔피언 ID
+     * @param win        해당 경기 승리 여부
+     */
+    public ChampionStats(long championId, boolean win) {
+        this.championId = championId;
+        this.games = 1;
+        this.wins = win ? 1 : 0;
+    }
+
+    /**
+     * 경기 결과를 추가하여 통계 갱신
+     *
+     * @param win 승리 여부
+     */
+    public void addGame(boolean win) {
+        this.games++;
+        if (win) {
+            this.wins++;
+        }
+    }
+
+    /**
+     * 다른 ChampionStats의 통계를 병합
+     *
+     * @param other 다른 통계 객체
+     */
+    public void merge(ChampionStats other) {
+        this.games += other.games;
+        this.wins += other.wins;
+    }
+
+    /**
+     * 승률 계산 (승리 수 / 경기 수)
+     *
+     * @return 승률
+     */
+    public double getWinRate() {
+        return games > 0 ? (double) wins / games : 0;
+    }
+
+    public long getChampionId() {
+        return championId;
+    }
+
+    public int getWins() {
+        return wins;
+    }
+
+    public int getGames() {
+        return games;
+    }
+
+}
+
+

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/RiotMatchResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/RiotMatchResponse.java
@@ -22,6 +22,8 @@ public class RiotMatchResponse {
         private String riotIdGameName;
         private String gameMode;
         private Long championId;
+        private boolean win;
+
 
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.external.riot.service;
 
 import com.gamegoo.gamegoo_v2.core.exception.RiotException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.external.riot.domain.ChampionStats;
 import com.gamegoo.gamegoo_v2.external.riot.dto.RiotMatchResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,53 +43,61 @@ public class RiotRecordService {
     /**
      * Riot API: 최근 선호 챔피언 3개 리스트 조회
      *
-     * @param gameName  게임 이름
-     * @param puuid     Riot PUUID
-     * @return          선호 챔피언 ID 리스트
+     * @param gameName 게임 이름
+     * @param puuid    Riot PUUID
+     * @return 선호 챔피언 ID 리스트
      */
-    public List<Long> getPreferChampionfromMatch(String gameName, String puuid) {
+    public List<ChampionStats> getPreferChampionfromMatch(String gameName, String puuid) {
         // 1. 최근 플레이한 챔피언 ID 리스트 가져오기
-        List<Long> recentChampionIds = fetchRecentChampionIds(gameName, puuid);
+        Map<Long, ChampionStats> championStatsMap = fetchRecentChampionStats(gameName, puuid);
 
         // 2. 최소 요구 챔피언 수 확인
-        if (recentChampionIds.size() < MINIMUM_CHAMPIONS_REQUIRED) {
+        if (championStatsMap.size() < MINIMUM_CHAMPIONS_REQUIRED) {
             throw new RiotException(ErrorCode.RIOT_INSUFFICIENT_MATCHES);
         }
 
         // 3. 많이 사용한 챔피언 상위 3개 계산
-        return findTopChampions(recentChampionIds, MINIMUM_CHAMPIONS_REQUIRED);
+        return findTopChampions(championStatsMap, MINIMUM_CHAMPIONS_REQUIRED);
     }
 
     /**
-     * 최근 플레이한 챔피언 ID 리스트를 Riot API에서 가져오는 메서드
+     * 최근 플레이한 챔피언의 승/패 통계 정보를 Riot API에서 가져오는 메서드
      *
-     * @param gameName  게임 이름
-     * @param puuid     Riot PUUID
-     * @return          챔피언 ID 리스트
+     * @param gameName 게임 이름
+     * @param puuid    Riot PUUID
+     * @return 챔피언별 통계 정보 맵
      */
-    private List<Long> fetchRecentChampionIds(String gameName, String puuid) {
-        List<Long> championIds = new ArrayList<>();
+    private Map<Long, ChampionStats> fetchRecentChampionStats(String gameName, String puuid) {
+        Map<Long, ChampionStats> championStatsMap = new HashMap<>();
         int count = INITIAL_MATCH_COUNT;
 
-        // 최소 3개 이상의 챔피언 데이터를 가져올 때까지 반복
-        while (championIds.size() < MINIMUM_CHAMPIONS_REQUIRED && count <= MAX_MATCH_COUNT) {
+        // 최소 요구 챔피언 수 이상일 때까지 반복
+        while (championStatsMap.size() < MINIMUM_CHAMPIONS_REQUIRED && count <= MAX_MATCH_COUNT) {
             List<String> matchIds = fetchMatchIds(puuid, count);
-            championIds = extractChampionIdsFromMatches(matchIds, gameName);
+            Map<Long, ChampionStats> matchStats = extractChampionStatsFromMatches(matchIds, gameName);
 
-            // 챔피언 수가 부족하면 더 많은 매칭 데이터를 가져옴
-            if (championIds.size() < MINIMUM_CHAMPIONS_REQUIRED) {
+            // 각 매치에서 얻은 통계 정보를 병합
+            for (Map.Entry<Long, ChampionStats> entry : matchStats.entrySet()) {
+                championStatsMap.merge(entry.getKey(), entry.getValue(), (oldStats, newStats) -> {
+                    oldStats.merge(newStats);
+                    return oldStats;
+                });
+            }
+
+            if (championStatsMap.size() < MINIMUM_CHAMPIONS_REQUIRED) {
                 count += MATCH_INCREMENT;
             }
         }
-        return championIds;
+        return championStatsMap;
     }
+
 
     /**
      * Riot API를 호출하여 puuid에 해당하는 최근 매칭 ID를 가져오는 메서드
      *
      * @param puuid Riot PUUID
      * @param count 가져올 매칭 개수
-     * @return      매칭 ID 리스트
+     * @return 매칭 ID 리스트
      */
     private List<String> fetchMatchIds(String puuid, int count) {
         String url = String.format(MATCH_IDS_URL_TEMPLATE, puuid, count, riotAPIKey);
@@ -103,66 +112,78 @@ public class RiotRecordService {
     }
 
     /**
-     * 매칭 ID 리스트를 기반으로 특정 게임 이름에 해당하는 챔피언 ID를 추출
+     * Riot API를 호출하여 매치 정보에서 사용자의 챔피언 ID와 승리 여부를 추출하는 메서드
      *
-     * @param matchIds  매칭 ID 리스트
-     * @param gameName  게임 이름
-     * @return          챔피언 ID 리스트
+     * @param matchId  매칭 ID
+     * @param gameName 사용자 게임 이름
+     * @return 챔피언 통계 정보 (1경기 기준)
      */
-    private List<Long> extractChampionIdsFromMatches(List<String> matchIds, String gameName) {
-        return matchIds.stream()
-                .map(matchId -> fetchChampionIdFromMatch(matchId, gameName))
-                .filter(Objects::nonNull)
-                .filter(championId -> championId < 1000)
-                .toList();
-    }
-
-    /**
-     * Riot API를 호출하여 매칭 ID로부터 특정 사용자의 챔피언 ID를 가져오는 메서드
-     *
-     * @param matchId   매칭 ID
-     * @param gameName  소환사명
-     * @return          챔피언 ID
-     */
-    private Long fetchChampionIdFromMatch(String matchId, String gameName) {
+    private ChampionStats fetchChampionStatsFromMatch(String matchId, String gameName) {
         String url = String.format(MATCH_INFO_URL_TEMPLATE, matchId, riotAPIKey);
-
         try {
-            // Riot API로부터 매칭 정보를 가져오기
             RiotMatchResponse response = restTemplate.getForObject(url, RiotMatchResponse.class);
 
-            // 매칭 정보에서 사용자의 챔피언 ID 찾기
             if (response == null || response.getInfo() == null || response.getInfo().getParticipants() == null) {
                 throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
             }
 
-            return response.getInfo().getParticipants().stream()
-                    .filter(participant -> gameName.equals(participant.getRiotIdGameName()))
-                    .map(RiotMatchResponse.ParticipantDTO::getChampionId)
+            // 매치 정보에서 사용자의 챔피언과 승리 여부 추출
+            RiotMatchResponse.ParticipantDTO participant = response.getInfo().getParticipants().stream()
+                    .filter(p -> gameName.equals(p.getRiotIdGameName()))
                     .findFirst()
                     .orElseThrow(() -> new RiotException(ErrorCode.CHAMPION_NOT_FOUND));
 
+            long championId = participant.getChampionId();
+            boolean win = participant.isWin(); // 승리 여부 (RiotMatchResponse.ParticipantDTO에 isWin() 메서드가 있다고 가정)
+
+            return new ChampionStats(championId, win);
         } catch (Exception e) {
-            log.error("Failed to fetch champion ID for match ID: {}", matchId, e);
+            log.error("Failed to fetch champion stats for match ID: {}", matchId, e);
             throw new RiotException(ErrorCode.RIOT_MATCH_CHAMPION_NOT_FOUND);
         }
     }
 
     /**
-     * 주어진 챔피언 ID 리스트에서 가장 많이 사용된 챔피언 상위 N개를 계산
+     * 매칭 ID 리스트에서 각 매치별 챔피언 통계 정보를 추출하여 병합한 맵 반환
      *
-     * @param championIds   챔피언 ID 리스트
-     * @param topN          가져올 상위 챔피언 개수
-     * @return              많이 사용된 상위 챔피언 ID 리스트
+     * @param matchIds 매칭 ID 리스트
+     * @param gameName 게임 이름
+     * @return 챔피언별 통계 정보 맵
      */
-    private List<Long> findTopChampions(List<Long> championIds, int topN) {
-        return championIds.stream()
-                .collect(Collectors.groupingBy(championId -> championId, Collectors.counting()))
-                .entrySet().stream()
-                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
-                .limit(topN)
-                .map(Map.Entry::getKey)
-                .toList();
+    private Map<Long, ChampionStats> extractChampionStatsFromMatches(List<String> matchIds, String gameName) {
+        Map<Long, ChampionStats> statsMap = new HashMap<>();
+        for (String matchId : matchIds) {
+            try {
+                ChampionStats stats = fetchChampionStatsFromMatch(matchId, gameName);
+                if (stats != null && stats.getChampionId() < 1000) {
+                    statsMap.merge(stats.getChampionId(), stats, (oldStats, newStats) -> {
+                        oldStats.merge(newStats);
+                        return oldStats;
+                    });
+                }
+            } catch (Exception e) {
+                log.error("Failed to fetch champion stats for match ID: {}", matchId, e);
+            }
+        }
+        return statsMap;
     }
+
+
+    /**
+     * 챔피언별 통계 정보를 기반으로 승률(및 경기 수)을 고려하여 상위 N개 챔피언 ID를 계산
+     *
+     * @param championStatsMap 챔피언별 통계 정보 맵
+     * @param topN             가져올 상위 챔피언 개수
+     * @return 상위 챔피언 ID 리스트
+     */
+    private List<ChampionStats> findTopChampions(Map<Long, ChampionStats> championStatsMap, int topN) {
+        return championStatsMap.values().stream()
+                .filter(stats -> stats.getGames() > 0)
+                .sorted(Comparator.comparingDouble(ChampionStats::getWinRate).reversed()
+                        .thenComparing(ChampionStats::getGames).reversed())
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/game/dto/response/ChampionResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/game/dto/response/ChampionResponse.java
@@ -10,11 +10,16 @@ public class ChampionResponse {
 
     Long championId;
     String championName;
+    Double winRate;
+    Integer games;
 
-    public static ChampionResponse of(Champion champion) {
+    public static ChampionResponse of(Champion champion, int wins, int games) {
+        double winRate = games > 0 ? (double) wins / games : 0.0;
         return ChampionResponse.builder()
                 .championId(champion.getId())
                 .championName(champion.getName())
+                .winRate(winRate)
+                .games(games)
                 .build();
     }
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -16,8 +16,6 @@ import com.gamegoo.gamegoo_v2.account.member.repository.MemberChampionRepository
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberGameStyleRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.account.member.service.MemberFacadeService;
-import com.gamegoo.gamegoo_v2.core.exception.RiotException;
-import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.game.domain.Champion;
 import com.gamegoo.gamegoo_v2.game.domain.GameStyle;
 import com.gamegoo.gamegoo_v2.game.repository.ChampionRepository;
@@ -345,8 +343,9 @@ class MemberServiceFacadeTest {
 
     private void initMemberChampion(Member member, List<Long> top3ChampionIds) {
         top3ChampionIds.forEach(championId -> {
-            Champion champion = championRepository.findById(championId).isPresent() ? championRepository.findById(championId).get() : null;
-            MemberChampion memberChampion = MemberChampion.create(champion, member);
+            Champion champion = championRepository.findById(championId).isPresent() ?
+                    championRepository.findById(championId).get() : null;
+            MemberChampion memberChampion = MemberChampion.create(champion, member, 1, 10);
             memberChampionRepository.save(memberChampion);
         });
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -347,7 +347,7 @@ class MemberServiceFacadeTest {
         top3ChampionIds.forEach(championId -> {
             Champion champion = championRepository.findById(championId)
                     .orElseThrow(() -> new RiotException(ErrorCode.CHAMPION_NOT_FOUND));
-            MemberChampion memberChampion = MemberChampion.create(champion, member);
+            MemberChampion memberChampion = MemberChampion.create(champion, member, 1, 10);
             memberChampionRepository.save(memberChampion);
         });
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 최근 선호 챔피언 승률, 게임 수 제공 추가

## ⏳ 작업 상세 내용

- [x] MemberChampion 엔티티에 승/패 필드, 게임  추가
- [x] RiotRecordService에서 챔피언 ID와 승리 여부를 받아 ChampionStats 계산
- [x] BoardListResponse에서 챔피언 승률과 경기 수를 확인 가능하도록 DTO 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] MemberChampionService에서 기존 데이터 삭제 후 새로 저장하는 방식이 적절한지

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] DB 스키마가 바뀌므로 마이그레이션이 필요합니다
