### PR TITLE
:bug: [Fix] 정밀 매칭 점수 변경

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingStrategyProcessor.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingStrategyProcessor.java
@@ -16,8 +16,25 @@ public class MatchingStrategyProcessor {
      * @return 우선순위 점수
      */
     public int calculatePrecisePriority(MatchingRecord myRecord, MatchingRecord otherRecord) {
-        return MatchingScoreCalculator.getMannerPriority(
-                otherRecord.getMannerLevel(), myRecord.getMannerLevel(), 16, 4);
+        switch (myRecord.getGameMode()) {
+            case FAST -> {
+                return MatchingScoreCalculator.getMannerPriority(
+                        otherRecord.getMannerLevel(), myRecord.getMannerLevel(), 25, 4);
+            }
+            case SOLO -> {
+                return MatchingScoreCalculator.getMannerPriority(
+                        otherRecord.getMannerLevel(), myRecord.getMannerLevel(), 67, 4);
+            }
+            case FREE -> {
+                return MatchingScoreCalculator.getMannerPriority(
+                        otherRecord.getMannerLevel(), myRecord.getMannerLevel(), 65, 4);
+            }
+            case ARAM -> {
+                return MatchingScoreCalculator.getMannerPriority(
+                        otherRecord.getMannerLevel(), myRecord.getMannerLevel(), 19, 4);
+            }
+        }
+        return 0;
     }
 
     /**

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingStrategyProcessorTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingStrategyProcessorTest.java
@@ -37,14 +37,13 @@ class MatchingStrategyProcessorTest {
     }
 
     @Test
-    @DisplayName("정밀 매칭 우선순위 계산")
+    @DisplayName("정밀 매칭 우선순위 계산(SOLO)")
     void testCalculatePrecisePriority() {
         // given
-        // 랭크 점수 차이 : 0 점
         Member member1 = createMember("user1@gmail.com", Tier.GOLD, true);
         Member member2 = createMember("user2@gmail.com", Tier.GOLD, false);
 
-        // 매너 점수 차이 : 8점
+        // 매너 점수 차이: 4*2점
         member1.updateMannerLevel(4);
         member2.updateMannerLevel(2);
 
@@ -55,9 +54,77 @@ class MatchingStrategyProcessorTest {
         int result = matchingStrategyProcessor.calculatePrecisePriority(record1, record2);
 
         // then
-        int expectedPriority = 16 - (Math.abs(record1.getMannerLevel() - record2.getMannerLevel()) * 4);
+        int expectedPriority = 67 - (Math.abs(record1.getMannerLevel() - record2.getMannerLevel()) * 4);
         assertThat(result).isEqualTo(expectedPriority);
     }
+
+    @Test
+    @DisplayName("정밀 매칭 우선순위 계산(FAST)")
+    void testCalculatePrecisePriority_FAST() {
+        // given
+        // Tier 같음(가정)
+        Member member1 = createMember("user1@gmail.com", Tier.GOLD, true);
+        Member member2 = createMember("user2@gmail.com", Tier.GOLD, false);
+
+        // 매너 점수 차이: 3*4점
+        member1.updateMannerLevel(3);
+        member2.updateMannerLevel(0);
+
+        MatchingRecord record1 = createMatchingRecord(GameMode.FAST, MatchingType.PRECISE, member1);
+        MatchingRecord record2 = createMatchingRecord(GameMode.FAST, MatchingType.BASIC, member2);
+
+        // when
+        int result = matchingStrategyProcessor.calculatePrecisePriority(record1, record2);
+
+        // then
+        int expectedPriority = 25 - (Math.abs(record1.getMannerLevel() - record2.getMannerLevel()) * 4);
+        assertThat(result).isEqualTo(expectedPriority);
+    }
+
+    @Test
+    @DisplayName("정밀 매칭 우선순위 계산(FREE)")
+    void testCalculatePrecisePriority_FREE() {
+        // given
+        Member member1 = createMember("user1@gmail.com", Tier.GOLD, true);
+        Member member2 = createMember("user2@gmail.com", Tier.GOLD, false);
+
+        // 매너 점수 차이: 3*4점
+        member1.updateMannerLevel(3);
+        member2.updateMannerLevel(0);
+
+        MatchingRecord record1 = createMatchingRecord(GameMode.FREE, MatchingType.PRECISE, member1);
+        MatchingRecord record2 = createMatchingRecord(GameMode.FREE, MatchingType.BASIC, member2);
+
+        // when
+        int result = matchingStrategyProcessor.calculatePrecisePriority(record1, record2);
+
+        // then
+        int expectedPriority = 65 - (Math.abs(record1.getMannerLevel() - record2.getMannerLevel()) * 4);
+        assertThat(result).isEqualTo(expectedPriority);
+    }
+
+    @Test
+    @DisplayName("정밀 매칭 우선순위 계산(ARAM)")
+    void testCalculatePrecisePriority_ARAM() {
+        // given
+        Member member1 = createMember("user1@gmail.com", Tier.GOLD, true);
+        Member member2 = createMember("user2@gmail.com", Tier.GOLD, false);
+
+        // 매너 점수 차이: 3*4점
+        member1.updateMannerLevel(3);
+        member2.updateMannerLevel(0);
+
+        MatchingRecord record1 = createMatchingRecord(GameMode.ARAM, MatchingType.PRECISE, member1);
+        MatchingRecord record2 = createMatchingRecord(GameMode.ARAM, MatchingType.BASIC, member2);
+
+        // when
+        int result = matchingStrategyProcessor.calculatePrecisePriority(record1, record2);
+
+        // then
+        int expectedPriority = 19 - (Math.abs(record1.getMannerLevel() - record2.getMannerLevel()) * 4);
+        assertThat(result).isEqualTo(expectedPriority);
+    }
+
 
     @Test
     @DisplayName("개인랭크 우선순위 계산")


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 정밀 매칭 점수 변경

## ⏳ 작업 상세 내용

- [x] 정밀 매칭 점수 로직 변경
- 빠른 대전 : 25 - 매너점수 차이
매너레벨(16점) + 포지션(6점) + 마이크 (3점)
- 개인 랭크 : 67 - 매너점수 차이
매너레벨(16점) + 티어(40점) + 포지션(6점) + 마이크 (5점)
- 자유 랭크 : 65점 - 매너점수 차이
매너레벨(16점) + 티어(40점) + 포지션(6점) + 마이크 (3점)
- 칼바람 : 19 - 매너점수 차이
매너레벨(16점) + 마이크 (3점)


## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
