### PR TITLE
[Feat/249] 회원전용 게시글 상세 조회 API 응답에 챔피언 통계 정보 추가

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
@@ -7,6 +7,7 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
+import com.gamegoo.gamegoo_v2.content.board.dto.response.ChampionStatsResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -35,7 +36,7 @@ public class BoardByIdResponseForMember {
     Tier freeTier;
     int freeRank;
     Mike mike;
-    List<ChampionResponse> championResponseDTOList;
+    List<ChampionStatsResponse> championResponseDTOList;
     GameMode gameMode;
     Position mainP;
     Position subP;
@@ -54,10 +55,17 @@ public class BoardByIdResponseForMember {
     ) {
         Member poster = board.getMember();
 
-        List<ChampionResponse> championResponseList = poster.getMemberChampionList() == null
+        List<ChampionStatsResponse> championResponseList = poster.getMemberChampionList() == null
                 ? List.of()
                 : poster.getMemberChampionList().stream()
-                .map(mc -> ChampionResponse.of(mc.getChampion()))
+                .map(mc -> ChampionStatsResponse.builder()
+                        .championId(mc.getChampion().getId())
+                        .championName(mc.getChampion().getName())
+                        .wins(mc.getWins())
+                        .games(mc.getGames())
+                        .winRate(mc.getGames() > 0 ? (double) mc.getWins() / mc.getGames() : 0)
+                        .csPerMinute(mc.getCsPerMinute())
+                        .build())
                 .collect(Collectors.toList());
 
 
@@ -83,7 +91,7 @@ public class BoardByIdResponseForMember {
                 .isFriend(isFriend)
                 .friendRequestMemberId(friendRequestMemberId)
                 .createdAt(board.getCreatedAt())
-                .profileImage(board.getBoardProfileImage())
+                .profileImage(poster.getProfileImage())
                 .gameName(poster.getGameName())
                 .tag(poster.getTag())
                 .mannerLevel(poster.getMannerLevel())


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 게시글 상세 조회 API 응답에 챔피언 통계 정보를 추가하여 사용자의 챔피언 숙련도를 더 상세하게 표시합니다.

## ⏳ 작업 상세 내용

- [x] BoardByIdResponseForMember 클래스에서 ChampionResponse를 ChampionStatsResponse로 변경
- [x] 챔피언 통계 정보(승리 횟수, 게임 수, 승률, 분당 CS)를 포함하도록 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
