### PR TITLE
[Feat/251] 게시글 목록 조회 API 응답에 챔피언 통계 정보 추가

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
@@ -30,7 +30,7 @@ public class BoardByIdResponse {
     Tier freeTier;
     int freeRank;
     Mike mike;
-    List<ChampionResponse> championResponseList;
+    List<ChampionStatsResponse> championResponseList;
     GameMode gameMode;
     Position mainP;
     Position subP;
@@ -42,10 +42,17 @@ public class BoardByIdResponse {
 
     public static BoardByIdResponse of(Board board) {
         Member poster = board.getMember();
-        List<ChampionResponse> championResponseList = poster.getMemberChampionList() == null
+        List<ChampionStatsResponse> championResponseList = poster.getMemberChampionList() == null
                 ? List.of()
                 : poster.getMemberChampionList().stream()
-                .map(mc -> ChampionResponse.of(mc.getChampion()))
+                .map(mc -> ChampionStatsResponse.builder()
+                        .championId(mc.getChampion().getId())
+                        .championName(mc.getChampion().getName())
+                        .wins(mc.getWins())
+                        .games(mc.getGames())
+                        .winRate(mc.getGames() > 0 ? (double) mc.getWins() / mc.getGames() : 0)
+                        .csPerMinute(mc.getCsPerMinute())
+                        .build())
                 .collect(Collectors.toList());
 
         List<Long> gameStyleIds = board.getBoardGameStyles().stream()


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 여기에 작성해주세요.

## ⏳ 작업 상세 내용

- [x] BoardByIdResponse 클래스의 championResponseList 필드 타입을 List<ChampionResponse>에서 List<ChampionStatsResponse>로 변경
- [x] 챔피언 통계 정보(승리 횟수, 게임 수, 승률, 분당 CS)를 포함하도록 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
