### PR TITLE
[Feat/275] RSO 로그인 닉네임, id, 프로필 이미지 번호 추가

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/OAuthRedirectBuilder.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/OAuthRedirectBuilder.java
@@ -1,0 +1,29 @@
+package com.gamegoo.gamegoo_v2.external.riot.service;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthRedirectBuilder {
+
+    public String buildRedirectUrl(Member member, String state, String frontUrl, String accessToken,
+                                   String refreshToken) {
+        String encodedState = URLEncoder.encode(state, StandardCharsets.UTF_8);
+        String encodedGameName = URLEncoder.encode(member.getGameName(), StandardCharsets.UTF_8);
+
+        return String.format("%s/riot/callback?accessToken=%s&refreshToken=%s&name=%s&profileImage=%s&id=%s&state=%s",
+                frontUrl,
+                accessToken,
+                refreshToken,
+                encodedGameName,
+                member.getProfileImage(),
+                member.getId(),
+                encodedState);
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
@@ -34,6 +34,7 @@ public class RiotFacadeService {
     private final MemberChampionService memberChampionService;
     private final AuthService authService;
     private final JwtProvider jwtProvider;
+    private final OAuthRedirectBuilder oAuthRedirectBuilder;
 
     @Value(value = "${spring.front_url}")
     private String frontUrl;
@@ -119,8 +120,7 @@ public class RiotFacadeService {
         // refresh token DB에 저장
         authService.addRefreshToken(member, refreshToken);
 
-        return String.format("%s/riot/callback?accessToken=%s&refreshToken=%s&state=%s", frontUrl, accessToken,
-                refreshToken, state);
+        return oAuthRedirectBuilder.buildRedirectUrl(member, state, frontUrl, accessToken, refreshToken);
     }
 
 }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
>RSO 로그인 시 닉네임(name), 프로필 이미지 번호(profileImage), 유저 ID(id)를 프론트로 전달하도록 리다이렉트 URL 개선

## ⏳ 작업 상세 내용
- [x] OAuthRedirectBuilder에서 accessToken, refreshToken만 받아 리다이렉트 URL 생성하도록 리팩토링
- [x] RiotFacadeService에서 JWT 토큰 생성 및 저장 책임 분리
- [x] URL 쿼리 파라

미터에 name, profileImage, id 포함되도록 변경

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
