### PR TITLE
[Fix/297] 신고 등록 시 관리자 메일 전송 버그 수정

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/email/service/EmailAsyncService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/email/service/EmailAsyncService.java
@@ -1,0 +1,26 @@
+package com.gamegoo.gamegoo_v2.account.email.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailAsyncService {
+
+    private final EmailService emailService;
+
+    @Async
+    public void sendEmailAsync(String to, String subject, String templatePath, Map<String, String> placeholders) {
+        try {
+            emailService.sendEmail(to, subject, templatePath, placeholders);
+        } catch (Exception e) {
+            log.error("비동기 이메일 전송 실패", e);
+        }
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 신고 등록 시 관리자 메일 전송 버그 수정

## ⏳ 작업 상세 내용

- [x] `EmailEventListener.handleSendReportEmailEvent` 이벤트 리스너를 TransactionalEventListener로 변경
- [x] EmailAsyncService 구현
- [x] `EmailEventListener.handleSendReportEmailEvent` 이벤트 리스너에서 이메일 전송을 비동기적으로 실행하도록 변경

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
