### PR TITLE
[Feat/304] 커서 기반 페이지네이션 구현

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -146,6 +147,18 @@ public class BoardController {
     public ApiResponse<BoardBumpResponse> bumpBoard(@PathVariable Long boardId,
                                                     @AuthMember Member member) {
         return ApiResponse.ok(boardFacadeService.bumpBoard(boardId, member));
+    }
+
+    @GetMapping("/cursor")
+    public ResponseEntity<ApiResponse<BoardCursorResponse>> getBoardsWithCursor(
+            @RequestParam(required = false) LocalDateTime cursor,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) GameMode gameMode,
+            @RequestParam(required = false) Tier tier,
+            @RequestParam(required = false) Position position1,
+            @RequestParam(required = false) Position position2) {
+        BoardCursorResponse response = boardFacadeService.getAllBoardsWithCursor(cursor, cursorId, gameMode, tier, position1, position2);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -7,15 +7,10 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardInsertRequest;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardUpdateRequest;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardBumpResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardByIdResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardByIdResponseForMember;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardInsertResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardUpdateResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.MyBoardResponse;
+import com.gamegoo.gamegoo_v2.content.board.dto.response.*;
 import com.gamegoo.gamegoo_v2.content.board.service.BoardFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -129,6 +124,15 @@ public class BoardController {
                                                        @AuthMember Member member) {
         return ApiResponse.ok(boardFacadeService.getMyBoardList(member, page));
     }
+
+    @GetMapping("/my/cursor")
+    @Operation(summary = "내가 작성한 게시판 글 목록 조회 API/모바일", description = "모바일에서 내가 작성한 게시판 글을 조회하는 API 입니다.")
+    @Parameter(name = "cursor", description = "페이징을 위한 커서, Long 타입 boardId를 보내주세요. " + "보내지 않으면 가장 최근 게시물 10개를 조회합니다.")
+    public ApiResponse<MyBoardCursorResponse> getMyBoardCursorList(@ValidCursor @RequestParam(name = "cursor", required = false) Long cursor,
+                                                                   @AuthMember Member member) {
+        return ApiResponse.ok(boardFacadeService.getMyBoardCursorList(member, cursor));
+    }
+
 
     /**
      * 게시글 끌올(bump) API

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -127,9 +128,10 @@ public class BoardController {
 
     @GetMapping("/my/cursor")
     @Operation(summary = "내가 작성한 게시판 글 목록 조회 API/모바일", description = "모바일에서 내가 작성한 게시판 글을 조회하는 API 입니다.")
-    @Parameter(name = "cursor", description = "페이징을 위한 커서, Long 타입 boardId를 보내주세요. " + "보내지 않으면 가장 최근 게시물 10개를 조회합니다.")
-    public ApiResponse<MyBoardCursorResponse> getMyBoardCursorList(@ValidCursor @RequestParam(name = "cursor", required = false) Long cursor,
-                                                                   @AuthMember Member member) {
+    @Parameter(name = "cursor", description = "페이징을 위한 커서, ISO 8601 형식의 LocalDateTime을 보내주세요. " + "보내지 않으면 가장 최근 게시물 10개를 조회합니다.")
+    public ApiResponse<MyBoardCursorResponse> getMyBoardCursorList(
+            @ValidCursor @RequestParam(name = "cursor", required = false) LocalDateTime cursor,
+            @AuthMember Member member) {
         return ApiResponse.ok(boardFacadeService.getMyBoardCursorList(member, cursor));
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardCursorResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardCursorResponse.java
@@ -1,0 +1,35 @@
+package com.gamegoo.gamegoo_v2.content.board.dto.response;
+
+import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class BoardCursorResponse {
+    private final List<BoardResponse> boards;
+    private final boolean hasNext;
+    private final LocalDateTime nextCursor;
+    private Long cursorId;
+
+    public static BoardCursorResponse of(Slice<Board> boardSlice) {
+        List<BoardResponse> boards = boardSlice.getContent().stream()
+                .map(BoardResponse::of)
+                .collect(Collectors.toList());
+        Long cursorId = null;
+        if (!boardSlice.isEmpty()) {
+            Board lastBoard = boardSlice.getContent().get(boardSlice.getContent().size() - 1);
+            cursorId = lastBoard.getId();
+        }
+        return BoardCursorResponse.builder()
+                .boards(boards)
+                .hasNext(boardSlice.hasNext())
+                .cursorId(cursorId)
+                .build();
+    }
+} 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardResponse.java
@@ -1,16 +1,31 @@
 package com.gamegoo.gamegoo_v2.content.board.dto.response;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
+import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class BoardResponse {
+    private Long id;
+    private Long memberId;
+    private String nickname;
+    private Tier tier;
+    private GameMode gameMode;
+    private Position position1;
+    private Position position2;
+    private Mike mike;
+    private LocalDateTime createdAt;
+    private LocalDateTime bumpTime;
     private List<BoardListResponse> boards;
     private int totalPages;
     private long totalElements;
@@ -32,6 +47,21 @@ public class BoardResponse {
                 .totalElements(totalCount)
                 .boards(boardList)
                 .currentPage(boardPage.getNumber())
+                .build();
+    }
+
+    public static BoardResponse of(Board board) {
+        return BoardResponse.builder()
+                .id(board.getId())
+                .memberId(board.getMember().getId())
+                .nickname(board.getMember().getGameName())
+                .tier(board.getMember().getSoloTier())
+                .gameMode(board.getGameMode())
+                .position1(board.getMainP())
+                .position2(board.getSubP())
+                .mike(board.getMike())
+                .createdAt(board.getCreatedAt())
+                .bumpTime(board.getBumpTime())
                 .build();
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardCursorResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardCursorResponse.java
@@ -1,0 +1,42 @@
+package com.gamegoo.gamegoo_v2.content.board.dto.response;
+
+import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MyBoardCursorResponse {
+
+    List<MyBoardListResponse> myBoards;
+    int size;
+    boolean hasNext;
+    Long nextCursor;
+
+
+    public static MyBoardCursorResponse of(Slice<Board> boardSlice) {
+
+        // Board -> MyBoardListResponse 변환
+        List<MyBoardListResponse> boardList = boardSlice.getContent().stream()
+                .map(MyBoardListResponse::of)
+                .collect(Collectors.toList());
+
+        Long nextCursor = boardSlice.hasNext() && !boardList.isEmpty()
+                ? boardList.get(boardList.size() - 1).getBoardId()
+                :null;
+
+        // DTO 생성
+        return MyBoardCursorResponse.builder()
+                .myBoards(boardList)
+                .size(boardList.size())
+                .hasNext(boardSlice.hasNext())
+                .nextCursor(nextCursor)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardCursorResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardCursorResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,19 +16,17 @@ public class MyBoardCursorResponse {
     List<MyBoardListResponse> myBoards;
     int size;
     boolean hasNext;
-    Long nextCursor;
-
+    LocalDateTime nextCursor;
 
     public static MyBoardCursorResponse of(Slice<Board> boardSlice) {
-
         // Board -> MyBoardListResponse 변환
         List<MyBoardListResponse> boardList = boardSlice.getContent().stream()
                 .map(MyBoardListResponse::of)
                 .collect(Collectors.toList());
 
-        Long nextCursor = boardSlice.hasNext() && !boardList.isEmpty()
-                ? boardList.get(boardList.size() - 1).getBoardId()
-                :null;
+        LocalDateTime nextCursor = boardSlice.hasNext() && !boardList.isEmpty()
+                ? boardSlice.getContent().get(boardSlice.getContent().size() - 1).getActivityTime()
+                : null;
 
         // DTO 생성
         return MyBoardCursorResponse.builder()
@@ -37,5 +36,4 @@ public class MyBoardCursorResponse {
                 .nextCursor(nextCursor)
                 .build();
     }
-
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardCursorResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardCursorResponse.java
@@ -3,7 +3,6 @@ package com.gamegoo.gamegoo_v2.content.board.dto.response;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
@@ -8,6 +8,7 @@ import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -41,6 +42,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
 
     Page<Board> findByMemberIdAndDeletedFalse(Long memberId, Pageable pageable);
+    Slice<Board> findByMemberIdAndDeletedFalseAndIdLessThan(Long memberId, Long cursor, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Board b SET b.deleted = true where b.member = :member")

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
@@ -54,6 +54,27 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("activityTime") LocalDateTime activityTime,
             Pageable pageable);
 
+    @Query("SELECT b FROM Board b JOIN b.member m " +
+           "WHERE b.deleted = false " +
+           "AND (" +
+           "  :activityTime IS NULL " +
+           "  OR GREATEST(COALESCE(b.bumpTime, b.createdAt), b.createdAt) < :activityTime " +
+           "  OR (GREATEST(COALESCE(b.bumpTime, b.createdAt), b.createdAt) = :activityTime AND b.id < :cursorId)" +
+           ") " +
+           "AND (:gameMode IS NULL OR b.gameMode = :gameMode) " +
+           "AND (:tier IS NULL OR (CASE WHEN b.gameMode = com.gamegoo.gamegoo_v2.matching.domain.GameMode.FREE THEN m.freeTier ELSE m.soloTier END) = :tier) " +
+           "AND (:mainPList IS NULL OR b.mainP IN :mainPList) " +
+           "AND (:subPList IS NULL OR b.subP IN :subPList) " +
+           "ORDER BY GREATEST(COALESCE(b.bumpTime, b.createdAt), b.createdAt) DESC, b.id DESC")
+    Slice<Board> findAllBoardsWithCursor(
+            @Param("activityTime") LocalDateTime activityTime,
+            @Param("cursorId") Long cursorId,
+            @Param("gameMode") GameMode gameMode,
+            @Param("tier") Tier tier,
+            @Param("mainPList") List<Position> mainPList,
+            @Param("subPList") List<Position> subPList,
+            Pageable pageable);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Board b SET b.deleted = true where b.member = :member")
     void deleteAllByMember(@Param("member") Member member);

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
@@ -4,12 +4,10 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
-import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardInsertRequest;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardUpdateRequest;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.*;
-import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockService;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendService;
@@ -21,8 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +27,6 @@ public class BoardFacadeService {
 
     private final BoardService boardService;
     private final BoardGameStyleService boardGameStyleService;
-    private final MemberService memberService;
     private final FriendService friendService;
     private final BlockService blockService;
     private final ProfanityCheckService profanityCheckService;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
@@ -8,13 +8,7 @@ import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardInsertRequest;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardUpdateRequest;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardBumpResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardByIdResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardByIdResponseForMember;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardInsertResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardUpdateResponse;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.MyBoardResponse;
+import com.gamegoo.gamegoo_v2.content.board.dto.response.*;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockService;
@@ -22,6 +16,7 @@ import com.gamegoo.gamegoo_v2.social.friend.service.FriendService;
 import com.gamegoo.gamegoo_v2.social.manner.service.MannerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -134,6 +129,14 @@ public class BoardFacadeService {
     public MyBoardResponse getMyBoardList(Member member, int pageIdx) {
         Page<Board> boardPage = boardService.getMyBoards(member.getId(), pageIdx);
         return MyBoardResponse.of(boardPage);
+    }
+
+    /**
+     * 내가 작성한 게시글 목록 조회(커서)
+     */
+    public MyBoardCursorResponse getMyBoardCursorList(Member member, Long cursor) {
+        Slice<Board> boardSlice = boardService.getMyBoards(member.getId(), cursor);
+        return MyBoardCursorResponse.of(boardSlice);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
@@ -152,4 +152,18 @@ public class BoardFacadeService {
         return BoardBumpResponse.of(board.getId(), board.getBumpTime());
     }
 
+    /**
+     * 전체 게시글 커서 기반 조회 (Secondary Cursor)
+     */
+    public BoardCursorResponse getAllBoardsWithCursor(
+            LocalDateTime cursor,
+            Long cursorId,
+            GameMode gameMode,
+            Tier tier,
+            Position position1,
+            Position position2) {
+        Slice<Board> boardSlice = boardService.getAllBoardsWithCursor(cursor, cursorId, gameMode, tier, position1, position2);
+        return BoardCursorResponse.of(boardSlice);
+    }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardFacadeService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -134,7 +135,7 @@ public class BoardFacadeService {
     /**
      * 내가 작성한 게시글 목록 조회(커서)
      */
-    public MyBoardCursorResponse getMyBoardCursorList(Member member, Long cursor) {
+    public MyBoardCursorResponse getMyBoardCursorList(Member member, LocalDateTime cursor) {
         Slice<Board> boardSlice = boardService.getMyBoards(member.getId(), cursor);
         return MyBoardCursorResponse.of(boardSlice);
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 public class BoardService {
 
     private final BoardRepository boardRepository;
-    public static final int PAGE_SIZE = 20;
+    public static final int PAGE_SIZE = 10;
     public static final int MY_PAGE_SIZE = 10;
     private static final Duration BUMP_INTERVAL = Duration.ofMinutes(5);
 
@@ -227,6 +227,38 @@ public class BoardService {
     @Transactional
     public void deleteAllBoardByMember(Member member) {
         boardRepository.deleteAllByMember(member);
+    }
+
+    /**
+     * 전체 게시글 커서 기반 조회 (Secondary Cursor)
+     */
+    public Slice<Board> getAllBoardsWithCursor(
+            LocalDateTime cursor,
+            Long cursorId,
+            GameMode gameMode,
+            Tier tier,
+            Position mainP,
+            Position subP) {
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+
+        // 페이지 기반과 동일하게 null이면 ANY로 대체
+        if (mainP == null) mainP = Position.ANY;
+        if (subP == null) subP = Position.ANY;
+
+        List<Position> mainPList = new ArrayList<>();
+        List<Position> subPList = new ArrayList<>();
+        if (mainP == Position.ANY) {
+            mainPList = Arrays.asList(Position.values());
+        } else {
+            mainPList.add(mainP);
+        }
+        if (subP == Position.ANY) {
+            subPList = Arrays.asList(Position.values());
+        } else {
+            subPList.add(subP);
+        }
+
+        return boardRepository.findAllBoardsWithCursor(cursor, cursorId, gameMode, tier, mainPList, subPList, pageable);
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -12,10 +12,7 @@ import com.gamegoo.gamegoo_v2.core.exception.BoardException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -180,6 +177,17 @@ public class BoardService {
         // PageRequest.of의 첫 번째 인자(pageIdx - 1)는 0-based index
         Pageable pageable = PageRequest.of(pageIdx - 1, MY_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "activityTime"));
         return boardRepository.findByMemberIdAndDeletedFalse(memberId, pageable);
+    }
+
+    /**
+     * 내가 작성한 게시글(cursor) 조회
+     */
+    public Slice<Board> getMyBoards(Long memberId, Long cursor) {
+        if (cursor == null) {
+            throw new IllegalArgumentException("cursor는 null이 아닙니다.");
+        }
+        Pageable pageable = PageRequest.of(0, MY_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "activityTime"));
+        return boardRepository.findByMemberIdAndDeletedFalseAndIdLessThan(memberId, cursor, pageable);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -183,10 +183,10 @@ public class BoardService {
      * 내가 작성한 게시글(cursor) 조회
      */
     public Slice<Board> getMyBoards(Long memberId, Long cursor) {
-        if (cursor == null) {
-            throw new IllegalArgumentException("cursor는 null이 아닙니다.");
-        }
         Pageable pageable = PageRequest.of(0, MY_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "activityTime"));
+        if (cursor == null) {
+            return boardRepository.findByMemberIdAndDeletedFalse(memberId, pageable);
+        }
         return boardRepository.findByMemberIdAndDeletedFalseAndIdLessThan(memberId, cursor, pageable);
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -182,12 +182,9 @@ public class BoardService {
     /**
      * 내가 작성한 게시글(cursor) 조회
      */
-    public Slice<Board> getMyBoards(Long memberId, Long cursor) {
-        Pageable pageable = PageRequest.of(0, MY_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "activityTime"));
-        if (cursor == null) {
-            return boardRepository.findByMemberIdAndDeletedFalse(memberId, pageable);
-        }
-        return boardRepository.findByMemberIdAndDeletedFalseAndIdLessThan(memberId, cursor, pageable);
+    public Slice<Board> getMyBoards(Long memberId, LocalDateTime cursor) {
+        Pageable pageable = PageRequest.of(0, MY_PAGE_SIZE);
+        return boardRepository.findByMemberIdAndActivityTimeLessThan(memberId, cursor, pageable);
     }
 
     /**

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/board/BoardRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/board/BoardRepositoryTest.java
@@ -1,0 +1,508 @@
+package com.gamegoo.gamegoo_v2.repository.board;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
+import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import com.gamegoo.gamegoo_v2.content.board.repository.BoardRepository;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import com.gamegoo.gamegoo_v2.repository.RepositoryTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoardRepositoryTest extends RepositoryTestSupport {
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    private Board createBoard(Member member, GameMode gameMode, Position mainP, Position subP, Mike mike) {
+        return em.persist(Board.builder()
+                .member(member)
+                .gameMode(gameMode)
+                .mainP(mainP)
+                .subP(subP)
+                .mike(mike)
+                .content("Test content")
+                .wantP(new ArrayList<>())
+                .boardProfileImage(1)
+                .build());
+    }
+
+    @Nested
+    @DisplayName("기본 CRUD 테스트")
+    class CrudTest {
+        
+        @Test
+        @DisplayName("게시글 저장 및 조회")
+        void saveAndFind() {
+            // given
+            Board board = createBoard(member, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+
+            // when
+            Optional<Board> found = boardRepository.findById(board.getId());
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getMember()).isEqualTo(member);
+            assertThat(found.get().getGameMode()).isEqualTo(GameMode.SOLO);
+        }
+
+        @Test
+        @DisplayName("게시글 삭제 플래그 설정")
+        void softDelete() {
+            // given
+            Board board = createBoard(member, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+
+            // when
+            board.setDeleted(true);
+            em.flush();
+            em.clear();
+
+            // then
+            Optional<Board> found = boardRepository.findByIdAndDeleted(board.getId(), false);
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 필터링 테스트")
+    class FilteringTest {
+
+        private Member ironMember;
+        private Member goldMember;
+        private Member platinumMember;
+
+        @BeforeEach
+        void setUp() {
+            // 다양한 티어의 멤버 생성
+            ironMember = createMember("iron@test.com", "iron");
+            goldMember = createMember("gold@test.com", "gold");
+            platinumMember = createMember("platinum@test.com", "platinum");
+            
+            // 티어 설정
+            ReflectionTestUtils.setField(goldMember, "soloTier", Tier.GOLD);
+            ReflectionTestUtils.setField(platinumMember, "soloTier", Tier.PLATINUM);
+            
+            // 포지션과 마이크 설정
+            goldMember.updateMemberByMatchingRecord(Mike.AVAILABLE, Position.TOP, Position.MID, new ArrayList<>());
+            platinumMember.updateMemberByMatchingRecord(Mike.AVAILABLE, Position.ADC, Position.SUP, new ArrayList<>());
+            
+            // 매너 점수 설정
+            goldMember.updateMannerScore(100);
+            platinumMember.updateMannerScore(150);
+
+            // 23개의 게시물 생성
+            createTestPosts();
+        }
+
+        private void createTestPosts() {
+            LocalDateTime baseTime = LocalDateTime.now();
+            Position[] positions = {Position.TOP, Position.JUNGLE, Position.MID, Position.ADC, Position.SUP};
+            
+            // IRON 멤버의 게시물 (7개)
+            for (int i = 0; i < 7; i++) {
+                Board board = createBoard(ironMember, 
+                    i % 2 == 0 ? GameMode.SOLO : GameMode.FREE,
+                    positions[i % positions.length],
+                    positions[(i + 1) % positions.length],
+                    i % 3 == 0 ? Mike.AVAILABLE : Mike.UNAVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i));
+            }
+
+            // GOLD 멤버의 게시물 (8개)
+            for (int i = 0; i < 8; i++) {
+                Board board = createBoard(goldMember,
+                    i % 2 == 0 ? GameMode.SOLO : GameMode.ARAM,
+                    positions[i % positions.length],
+                    positions[(i + 2) % positions.length],
+                    i % 2 == 0 ? Mike.AVAILABLE : Mike.UNAVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i + 7));
+            }
+
+            // PLATINUM 멤버의 게시물 (8개)
+            for (int i = 0; i < 8; i++) {
+                Board board = createBoard(platinumMember,
+                    i % 3 == 0 ? GameMode.SOLO : (i % 3 == 1 ? GameMode.FREE : GameMode.ARAM),
+                    positions[i % positions.length],
+                    positions[(i + 3) % positions.length],
+                    i % 2 == 0 ? Mike.AVAILABLE : Mike.UNAVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i + 15));
+            }
+
+            em.flush();
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("게임 모드와 티어로 필터링")
+        void filterByGameModeAndTier() {
+            // when
+            Page<Board> result = boardRepository.findByGameModeAndTierAndMainPInAndSubPInAndMikeAndDeletedFalse(
+                    GameMode.SOLO,
+                    Tier.GOLD,
+                    Arrays.asList(Position.TOP),
+                    Arrays.asList(Position.MID),
+                    Mike.AVAILABLE,
+                    PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(result.getContent())
+                .isNotEmpty()
+                .allSatisfy(board -> {
+                    assertThat(board.getGameMode()).isEqualTo(GameMode.SOLO);
+                    assertThat(board.getMember().getSoloTier()).isEqualTo(Tier.GOLD);
+                    assertThat(board.getMainP()).isEqualTo(Position.TOP);
+                    assertThat(board.getSubP()).isEqualTo(Position.MID);
+                    assertThat(board.getMike()).isEqualTo(Mike.AVAILABLE);
+                });
+        }
+
+        @Test
+        @DisplayName("여러 페이지에 걸친 게시글 조회")
+        void findMultiplePages() {
+            Position[] positions = {Position.TOP, Position.JUNGLE, Position.MID, Position.ADC, Position.SUP};
+            
+            // when
+            Page<Board> firstPage = boardRepository.findByGameModeAndTierAndMainPInAndSubPInAndMikeAndDeletedFalse(
+                    GameMode.SOLO,
+                    null,
+                    Arrays.asList(positions),
+                    Arrays.asList(positions),
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            Page<Board> secondPage = boardRepository.findByGameModeAndTierAndMainPInAndSubPInAndMikeAndDeletedFalse(
+                    GameMode.SOLO,
+                    null,
+                    Arrays.asList(positions),
+                    Arrays.asList(positions),
+                    null,
+                    PageRequest.of(1, 10)
+            );
+
+            // then
+            assertThat(firstPage.getContent()).hasSize(10);
+            assertThat(secondPage.getContent()).isNotEmpty();
+            assertThat(firstPage.getContent())
+                .extracting(Board::getCreatedAt)
+                .isSortedAccordingTo((d1, d2) -> d2.compareTo(d1));
+        }
+    }
+
+    @Nested
+    @DisplayName("활동 시간 기반 정렬 테스트")
+    class ActivityTimeTest {
+
+        @Test
+        @DisplayName("끌올 시간이 있는 경우 활동 시간 기준으로 정렬")
+        void sortByActivityTimeWithBump() {
+            // given
+            Board oldBoard = createBoard(member, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+            Board newBoard = createBoard(member, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+            
+            // 오래된 게시글을 끌올
+            LocalDateTime bumpTime = LocalDateTime.now().plusHours(1);
+            oldBoard.bump(bumpTime);
+            
+            em.flush();
+            em.clear();
+
+            // when
+            Page<Board> result = boardRepository.findByMemberIdAndDeletedFalse(
+                    member.getId(),
+                    PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent().get(0).getId()).isEqualTo(oldBoard.getId());
+            assertThat(result.getContent().get(1).getId()).isEqualTo(newBoard.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("커서 기반 페이지네이션 테스트")
+    class CursorPaginationTest {
+
+        @Test
+        @DisplayName("내 게시물 커서 기반 조회 - 첫 페이지")
+        void getMyBoardsFirstPage() {
+            // given
+            Member testMember = createMember("test2@test.com", "tester");
+            LocalDateTime baseTime = LocalDateTime.now();
+            
+            // 15개의 게시물 생성
+            for (int i = 0; i < 15; i++) {
+                Board board = createBoard(testMember, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i));
+                
+                // 일부 게시물은 끌올 처리
+                if (i % 3 == 0) {
+                    board.bump(baseTime.plusMinutes(i));
+                }
+            }
+            
+            em.flush();
+            em.clear();
+
+            // when
+            Slice<Board> result = boardRepository.findByMemberIdAndActivityTimeLessThan(
+                    testMember.getId(),
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(result.getContent()).hasSize(10); // 첫 페이지는 10개
+            assertThat(result.hasNext()).isTrue(); // 다음 페이지 존재
+            assertThat(result.getContent())
+                .extracting(Board::getActivityTime)
+                .isSortedAccordingTo((t1, t2) -> t2.compareTo(t1)); // 활동 시간 내림차순 정렬
+        }
+
+        @Test
+        @DisplayName("내 게시물 커서 기반 조회 - 두 번째 페이지")
+        void getMyBoardsSecondPage() {
+            // given
+            Member testMember = createMember("test2@test.com", "tester");
+            LocalDateTime baseTime = LocalDateTime.now();
+            List<Board> boards = new ArrayList<>();
+            
+            // 15개의 게시물 생성
+            for (int i = 0; i < 15; i++) {
+                Board board = createBoard(testMember, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i));
+                
+                // 일부 게시물은 끌올 처리
+                if (i % 3 == 0) {
+                    board.bump(baseTime.plusMinutes(i));
+                }
+                boards.add(board);
+            }
+            
+            em.flush();
+            em.clear();
+
+            // 첫 페이지 조회
+            Slice<Board> firstPage = boardRepository.findByMemberIdAndActivityTimeLessThan(
+                    testMember.getId(),
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // when - 두 번째 페이지 조회
+            LocalDateTime cursor = firstPage.getContent().get(firstPage.getContent().size() - 1).getActivityTime();
+            Slice<Board> secondPage = boardRepository.findByMemberIdAndActivityTimeLessThan(
+                    testMember.getId(),
+                    cursor,
+                    PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(secondPage.getContent()).hasSize(5); // 남은 5개
+            assertThat(secondPage.hasNext()).isFalse(); // 다음 페이지 없음
+            
+            // 페이지 간 연속성 검증
+            assertThat(firstPage.getContent().get(firstPage.getContent().size() - 1).getActivityTime())
+                .isAfterOrEqualTo(secondPage.getContent().get(0).getActivityTime());
+            
+            // 두 번째 페이지 정렬 검증
+            assertThat(secondPage.getContent())
+                .extracting(Board::getActivityTime)
+                .isSortedAccordingTo((t1, t2) -> t2.compareTo(t1));
+        }
+
+        @Test
+        @DisplayName("내 게시물 커서 기반 조회 - 끌올이 섞인 경우")
+        void getMyBoardsWithBumpMixed() {
+            // given
+            Member testMember = createMember("test2@test.com", "tester");
+            LocalDateTime baseTime = LocalDateTime.now();
+            List<Board> boards = new ArrayList<>();
+            
+            // 12개의 게시물 생성
+            for (int i = 0; i < 12; i++) {
+                Board board = createBoard(testMember, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i));
+                boards.add(board);
+            }
+            
+            // 중간 게시물 3개를 끌올
+            boards.get(5).bump(baseTime.plusMinutes(30)); // 5번째 게시물
+            boards.get(8).bump(baseTime.plusMinutes(20)); // 8번째 게시물
+            boards.get(10).bump(baseTime.plusMinutes(10)); // 10번째 게시물
+            
+            em.flush();
+            em.clear();
+
+            // when
+            Slice<Board> result = boardRepository.findByMemberIdAndActivityTimeLessThan(
+                    testMember.getId(),
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(result.getContent()).hasSize(10);
+            
+            // 끌올된 게시물이 상단에 위치하는지 확인
+            List<LocalDateTime> activityTimes = result.getContent().stream()
+                .map(Board::getActivityTime)
+                .collect(Collectors.toList());
+            
+            assertThat(activityTimes.get(0)).isAfter(baseTime); // 첫 번째는 끌올된 게시물
+            assertThat(activityTimes)
+                .isSortedAccordingTo((t1, t2) -> t2.compareTo(t1)); // 활동 시간 내림차순 정렬
+        }
+
+        @Test
+        @DisplayName("내 게시물 커서 기반 조회 - 삭제된 게시물 제외")
+        void getMyBoardsExcludeDeleted() {
+            // given
+            Member testMember = createMember("test2@test.com", "tester");
+            LocalDateTime baseTime = LocalDateTime.now();
+            
+            // 10개의 게시물 생성
+            for (int i = 0; i < 10; i++) {
+                Board board = createBoard(testMember, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+                ReflectionTestUtils.setField(board, "createdAt", baseTime.minusHours(i));
+                
+                // 3의 배수 인덱스의 게시물은 삭제 처리 (0, 3, 6, 9)
+                if (i % 3 == 0) {
+                    board.setDeleted(true);
+                }
+                em.persist(board);
+            }
+            
+            em.flush();
+            em.clear();
+
+            // when
+            Slice<Board> result = boardRepository.findByMemberIdAndActivityTimeLessThan(
+                    testMember.getId(),
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // then
+            assertThat(result.getContent()).hasSize(6); // 삭제되지 않은 6개만 조회 (인덱스: 1, 2, 4, 5, 7, 8)
+            assertThat(result.getContent())
+                .allSatisfy(board -> assertThat(board.isDeleted()).isFalse());
+            assertThat(result.getContent())
+                .extracting(Board::getActivityTime)
+                .isSortedAccordingTo((t1, t2) -> t2.compareTo(t1));
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 게시물 커서 기반 조회 테스트")
+    class AllBoardsCursorTest {
+
+        @BeforeEach
+        void cleanUp() {
+            boardRepository.deleteAll();
+        }
+
+        @Test
+        @DisplayName("첫 페이지 조회 - 필터 없음")
+        void getAllBoardsFirstPage() {
+            // given
+            Member testMember = createMember("test@test.com", "tester");
+            LocalDateTime baseTime = LocalDateTime.now();
+            List<Board> boards = new ArrayList<>();
+            // 15개의 게시물 생성 (SOLO, TOP, MID)
+            for (int i = 0; i < 15; i++) {
+                Board board = createBoard(testMember, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+                LocalDateTime createdAt = baseTime.minusHours(i).minusMinutes(i).minusSeconds(i);
+                ReflectionTestUtils.setField(board, "createdAt", createdAt);
+                ReflectionTestUtils.setField(board, "activityTime", createdAt);
+                if (i % 3 == 0) {
+                    LocalDateTime bumpTime = baseTime.plusMinutes(i).plusSeconds(i);
+                    board.bump(bumpTime);
+                    ReflectionTestUtils.setField(board, "activityTime", bumpTime);
+                }
+                em.persist(board);
+                boards.add(board);
+            }
+            em.flush();
+            em.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Position> mainPList = List.of(Position.TOP);
+            List<Position> subPList = List.of(Position.MID);
+            Slice<Board> firstPage = boardRepository.findAllBoardsWithCursor(null, null, GameMode.SOLO, null, mainPList, subPList, pageable);
+
+            // then
+            assertThat(firstPage.getContent()).hasSize(10);
+            assertThat(firstPage.hasNext()).isTrue();
+            assertThat(firstPage.getContent())
+                .extracting(Board::getActivityTime)
+                .isSortedAccordingTo((t1, t2) -> t2.compareTo(t1));
+        }
+
+        @Test
+        @DisplayName("두 번째 페이지 조회 - 필터 적용")
+        void getAllBoardsSecondPage() {
+            // given
+            Member testMember = createMember("test@test.com", "tester");
+            LocalDateTime baseTime = LocalDateTime.now();
+            List<Board> boards = new ArrayList<>();
+            // 15개의 게시물 생성 (SOLO, TOP, MID)
+            for (int i = 0; i < 15; i++) {
+                Board board = createBoard(testMember, GameMode.SOLO, Position.TOP, Position.MID, Mike.AVAILABLE);
+                LocalDateTime createdAt = baseTime.minusHours(i).minusMinutes(i).minusSeconds(i);
+                ReflectionTestUtils.setField(board, "createdAt", createdAt);
+                ReflectionTestUtils.setField(board, "activityTime", createdAt);
+                if (i % 3 == 0) {
+                    LocalDateTime bumpTime = baseTime.plusMinutes(i).plusSeconds(i);
+                    board.bump(bumpTime);
+                    ReflectionTestUtils.setField(board, "activityTime", bumpTime);
+                }
+                em.persist(board);
+                boards.add(board);
+            }
+            em.flush();
+            em.clear();
+
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Position> mainPList = List.of(Position.TOP);
+            List<Position> subPList = List.of(Position.MID);
+            // 첫 페이지 조회
+            Slice<Board> firstPage = boardRepository.findAllBoardsWithCursor(null, null, GameMode.SOLO, null, mainPList, subPList, pageable);
+            assertThat(firstPage.getContent()).hasSize(10);
+            assertThat(firstPage.hasNext()).isTrue();
+            // 두 번째 페이지 조회
+            Board lastBoard = firstPage.getContent().get(firstPage.getContent().size() - 1);
+            LocalDateTime cursorTime = lastBoard.getActivityTime();
+            Long cursorId = lastBoard.getId();
+            Slice<Board> result = boardRepository.findAllBoardsWithCursor(cursorTime, cursorId, GameMode.SOLO, null, mainPList, subPList, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(5);  // SOLO 게시물 중 남은 5개
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.getContent())
+                .extracting(Board::getActivityTime)
+                .isSortedAccordingTo((t1, t2) -> t2.compareTo(t1));
+        }
+    }
+} 

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/board/BoardFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/board/BoardFacadeServiceTest.java
@@ -5,17 +5,13 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
-import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardByIdResponseForMember;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardCursorResponse;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardListResponse;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.BoardResponse;
-import com.gamegoo.gamegoo_v2.content.board.repository.BoardRepository;
 import com.gamegoo.gamegoo_v2.content.board.service.BoardFacadeService;
-import com.gamegoo.gamegoo_v2.content.board.service.BoardGameStyleService;
 import com.gamegoo.gamegoo_v2.content.board.service.BoardService;
-import com.gamegoo.gamegoo_v2.content.board.service.ProfanityCheckService;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockService;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendService;
@@ -31,7 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -41,7 +36,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -56,15 +50,6 @@ class BoardFacadeServiceTest {
     private BoardService boardService;
 
     @Mock
-    private BoardGameStyleService boardGameStyleService;
-
-    @Mock
-    private ProfanityCheckService profanityCheckService;
-
-    @Mock
-    private MemberService memberService;
-
-    @Mock
     private FriendService friendService;
 
     @Mock
@@ -72,9 +57,6 @@ class BoardFacadeServiceTest {
 
     @Mock
     private MannerService mannerService;
-
-    @Mock
-    private BoardRepository boardRepository;
 
     @InjectMocks
     private BoardFacadeService boardFacadeService;
@@ -84,9 +66,6 @@ class BoardFacadeServiceTest {
 
     @BeforeEach
     void cleanUp() {
-        if (boardRepository != null) {
-            boardRepository.deleteAll();
-        }
         if (em != null) {
             em.flush();
             em.clear();

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/board/BoardFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/board/BoardFacadeServiceTest.java
@@ -26,13 +26,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -583,6 +588,79 @@ class BoardFacadeServiceTest {
         assertThat(response.getBoards()).hasSize(2);
         assertThat(response.getBoards().stream().map(BoardListResponse::getMainP))
                 .containsExactlyInAnyOrder(Position.TOP, Position.ADC);
+    }
+
+    @Test
+    @DisplayName("내가 작성한 게시글 커서 기반 조회가 정상 동작하는지 테스트")
+    void getMyBoardCursorList() {
+        // given
+        Member member = Member.builder()
+                .email("test@test.com")
+                .password("password")
+                .loginType(LoginType.GENERAL)
+                .gameName("testGameName")
+                .tag("testTag")
+                .soloTier(Tier.GOLD)
+                .soloRank(1)
+                .soloWinRate(60.0)
+                .freeTier(Tier.PLATINUM)
+                .freeRank(2)
+                .freeWinRate(55.0)
+                .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        List<Board> boards = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            Board board = Board.builder()
+                    .gameMode(GameMode.SOLO)
+                    .mainP(Position.TOP)
+                    .subP(Position.JUNGLE)
+                    .wantP(List.of(Position.TOP))
+                    .mike(Mike.AVAILABLE)
+                    .member(member)
+                    .content("test content " + i)
+                    .boardProfileImage(1)
+                    .deleted(false)
+                    .build();
+            ReflectionTestUtils.setField(board, "id", (long)(i + 1));
+            ReflectionTestUtils.setField(board, "createdAt", LocalDateTime.now().minusMinutes(i));
+            boards.add(board);
+        }
+
+        // 첫 페이지 설정
+        Slice<Board> firstPageSlice = new SliceImpl<>(boards.subList(0, 10), PageRequest.of(0, 10), true);
+        when(boardService.getMyBoards(eq(member.getId()), eq(null)))
+                .thenReturn(firstPageSlice);
+
+        // 두 번째 페이지 설정
+        Slice<Board> secondPageSlice = new SliceImpl<>(boards.subList(10, 15), PageRequest.of(0, 10), false);
+        when(boardService.getMyBoards(eq(member.getId()), eq(10L)))
+                .thenReturn(secondPageSlice);
+
+        // when
+        // 첫 페이지 조회
+        var firstPage = boardFacadeService.getMyBoardCursorList(member, null);
+        // 두 번째 페이지 조회
+        var secondPage = boardFacadeService.getMyBoardCursorList(member, 10L);
+
+        // then
+        // 첫 페이지 검증
+        assertThat(firstPage.getMyBoards()).hasSize(10);
+        assertThat(firstPage.isHasNext()).isTrue();
+        assertThat(firstPage.getNextCursor()).isEqualTo(10L);
+
+        // 두 번째 페이지 검증
+        assertThat(secondPage.getMyBoards()).hasSize(5);
+        assertThat(secondPage.isHasNext()).isFalse();
+        assertThat(secondPage.getNextCursor()).isNull();
+
+        // 정렬 순서 검증 (최신순)
+        assertThat(firstPage.getMyBoards()).isSortedAccordingTo(
+            (b1, b2) -> b2.getCreatedAt().compareTo(b1.getCreatedAt())
+        );
+        assertThat(secondPage.getMyBoards()).isSortedAccordingTo(
+            (b1, b2) -> b2.getCreatedAt().compareTo(b1.getCreatedAt())
+        );
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/board/BoardServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/board/BoardServiceTest.java
@@ -23,8 +23,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,14 +43,9 @@ public class BoardServiceTest {
     @Autowired
     BoardService boardService;
 
-    @PersistenceContext
-    EntityManager em;
-
     @BeforeEach
     void cleanUp() {
         boardRepository.deleteAll();
-        // em.flush();
-        // em.clear();
     }
 
     @AfterEach
@@ -189,7 +182,6 @@ public class BoardServiceTest {
                 }
                 boards.add(boardRepository.save(board));
             }
-            // boardRepository.flush(); // Ensure all boards are persisted
 
             // when
             var result = boardService.getMyBoards(member.getId(), null);
@@ -216,7 +208,7 @@ public class BoardServiceTest {
             List<Board> boards = new ArrayList<>();
             LocalDateTime baseTime = LocalDateTime.now();
 
-            // 게시글 15개 생성 (시간차를 두고)
+            // 게시글 15개 생성
             for (int i = 0; i < 15; i++) {
                 Board board = Board.create(member, GameMode.ARAM, Position.ANY, Position.ANY, new ArrayList<>(),
                         Mike.AVAILABLE, "contents " + i, 1);
@@ -226,7 +218,7 @@ public class BoardServiceTest {
                 }
                 boards.add(boardRepository.save(board));
             }
-            // boardRepository.flush(); // Ensure all boards are persisted
+
 
             // when - 첫 페이지 조회
             var firstPage = boardService.getMyBoards(member.getId(), null);
@@ -274,14 +266,13 @@ public class BoardServiceTest {
                 }
                 boards.add(boardRepository.save(board));
             }
-            // boardRepository.flush(); // Ensure all boards are persisted
 
             // when
             var result = boardService.getMyBoards(member.getId(), null);
 
             // then
-            assertThat(result.getContent()).hasSize(2); // Only non-deleted boards
-            assertThat(result.getContent()).allSatisfy(board -> 
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent()).allSatisfy(board ->
                 assertThat(board.isDeleted()).isFalse()
             );
         }
@@ -310,7 +301,6 @@ public class BoardServiceTest {
                 }
                 boards.add(boardRepository.save(board));
             }
-            // boardRepository.flush();
 
             // when
             var result = boardService.getAllBoardsWithCursor(null, null, null, null, null, null);
@@ -348,7 +338,6 @@ public class BoardServiceTest {
                 }
                 boards.add(boardRepository.save(board));
             }
-            // boardRepository.flush();
 
             // 첫 페이지 조회
             Slice<Board> firstPage = boardService.getAllBoardsWithCursor(null, null, GameMode.SOLO, Tier.GOLD, Position.TOP, Position.JUNGLE);
@@ -394,8 +383,6 @@ public class BoardServiceTest {
                 .build());
     }
 
-    private Board createBoard(Member member, GameMode gameMode, Position position1, Position position2, Mike mike) {
-        return Board.create(member, gameMode, position1, position2, new ArrayList<>(), mike, "contents", 1);
-    }
+
 
 }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 게시물 조회 로직, 나의 게시물 조회 로직에 커서 페이지네이션 api 도입

## ⏳ 작업 상세 내용

- [ ] 게시물 조회 로직 커서 기반 페이지네이션 도입
- [ ] 나의 게시물 조회 로직 커서 기반 페이지네이션 도입
- [ ] 각 구현 테스트코드 작성

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->
게시물 조회 같은 경우는 저희가 boardId 기준으로 정렬하는게 아니라 activityTime(createdAt이 기본, 끌올 시 bumpTime)으로 정렬하기 때문에 복합 커서 조건으로 정렬하였습니다. 
나의 게시물 조회는 본인이 게시물을 작성하거나 끌올을 동시에 진행하는 것이 물리적으로 불가능하기 때문에 단일 커서 조건으로 작성하였습니다.

- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] 없을 경우 체크
