### PR TITLE
[Fix/303] Refresh Token 에러 해결

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/domain/RefreshToken.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/domain/RefreshToken.java
@@ -32,6 +32,10 @@ public class RefreshToken extends BaseDateTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    public void updateToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+    
     public static RefreshToken create(String refreshToken, Member member) {
         return RefreshToken.builder()
                 .refreshToken(refreshToken)

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
@@ -91,6 +91,7 @@ public class AuthFacadeService {
         String refreshToken = jwtProvider.createRefreshToken(member.getId());
 
         // DB에 저장
+        authService.deleteRefreshToken(member);
         authService.addRefreshToken(member, refreshToken);
 
         return LoginResponse.of(member, accessToken, refreshToken);
@@ -128,6 +129,7 @@ public class AuthFacadeService {
         Member member = memberService.findMemberById(memberId);
 
         // refreshToken 저장
+        authService.deleteRefreshToken(member);
         authService.addRefreshToken(member, refreshToken);
 
         return RefreshTokenResponse.of(memberId, accessToken, refreshToken);

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
@@ -91,8 +91,7 @@ public class AuthFacadeService {
         String refreshToken = jwtProvider.createRefreshToken(member.getId());
 
         // DB에 저장
-        authService.deleteRefreshToken(member);
-        authService.addRefreshToken(member, refreshToken);
+        authService.updateRefreshToken(member, refreshToken);
 
         return LoginResponse.of(member, accessToken, refreshToken);
     }
@@ -129,8 +128,7 @@ public class AuthFacadeService {
         Member member = memberService.findMemberById(memberId);
 
         // refreshToken 저장
-        authService.deleteRefreshToken(member);
-        authService.addRefreshToken(member, refreshToken);
+        authService.updateRefreshToken(member, refreshToken);
 
         return RefreshTokenResponse.of(memberId, accessToken, refreshToken);
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthService.java
@@ -36,9 +36,6 @@ public class AuthService {
      */
     @Transactional
     public void addRefreshToken(Member member, String refreshToken) {
-        // 이전에 있던 refreshToken 전부 지우기
-        refreshTokenRepository.findByMember(member).ifPresent(refreshTokenRepository::delete);
-
         // refresh token DB에 저장하기
         refreshTokenRepository.save(RefreshToken.create(refreshToken, member));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthService.java
@@ -29,15 +29,26 @@ public class AuthService {
     }
 
     /**
-     * 리프레시 토큰 생성
+     * 리프레시 토큰 수정
      *
      * @param member       로그인한 회원
      * @param refreshToken 리프레시토큰 정보
      */
     @Transactional
-    public void addRefreshToken(Member member, String refreshToken) {
-        // refresh token DB에 저장하기
-        refreshTokenRepository.save(RefreshToken.create(refreshToken, member));
+    public void updateRefreshToken(Member member, String refreshToken) {
+        refreshTokenRepository.findByMember(member)
+                .ifPresentOrElse(
+                        existingToken -> {
+                            // 업데이트
+                            existingToken.updateToken(refreshToken);
+                            refreshTokenRepository.save(existingToken);
+                        },
+                        () -> {
+                            // 없으면 새로 저장
+                            RefreshToken newToken = RefreshToken.create(refreshToken, member);
+                            refreshTokenRepository.save(newToken);
+                        }
+                );
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
@@ -118,6 +118,7 @@ public class RiotFacadeService {
         String refreshToken = jwtProvider.createRefreshToken(member.getId());
 
         // refresh token DB에 저장
+        authService.deleteRefreshToken(member);
         authService.addRefreshToken(member, refreshToken);
 
         return oAuthRedirectBuilder.buildRedirectUrl(member, state, frontUrl, accessToken, refreshToken);

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
@@ -118,8 +118,7 @@ public class RiotFacadeService {
         String refreshToken = jwtProvider.createRefreshToken(member.getId());
 
         // refresh token DB에 저장
-        authService.deleteRefreshToken(member);
-        authService.addRefreshToken(member, refreshToken);
+        authService.updateRefreshToken(member, refreshToken);
 
         return oAuthRedirectBuilder.buildRedirectUrl(member, state, frontUrl, accessToken, refreshToken);
     }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> refreshToken 동시성 에러 해결

## ⏳ 작업 상세 내용

- [x] authService refreshToken delete, add 트랜잭션 나누기

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] delete와 add가 하나의 transaction에 있어서 여러 요청이 들어왔을 경우, 동시성 에러가 발생한 것이었습니다. 그 이유는 ifPresent는 그 순간만 보고, JPA delete()는 나중에 적용됩니다. 그래서 ifPresent로 있는 줄 알고 없앴는데, 알고보니까 지워지고 없어져서 서버에 해당 에러가 발생했던 것으로 보입니다. 그런데. delete와 save를 하나의 트랜잭션 안에 넣지않고 다 빼놓는 것이 과연 맞는 것일지 의문이 듭니다. 너무 촘촘하게 트랜잭션을 나눈건 아닐까요..? 그리고 과연 이 오류가 동시에 여러 요청이 발생해서 꼬여서 일어난게 맞을까요? 제가 로그를 분석한 것이 맞는지 조금 헷갈립니다. 
로그 : https://www.notion.so/2145d32b00ae805691ece2b97b45f2ea?source=copy_link

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
