### PR TITLE
[Feat/309] matching found 예외처리

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
     MATCHING_TARGET_UNAVAILABLE(BAD_REQUEST, "MATCH_404", "상대방이 다른 매칭 로직을 진행 중입니다."),
     MATCHING_FOUND_FAILED_TARGET_IS_BLOCKED(FORBIDDEN, "MATCH_405", "매칭 상대 회원을 차단한 상태입니다. 매칭 FOUND 처리가 불가능합니다."),
     MATCHING_FOUND_FAILED_BLOCKED_BY_TARGET(FORBIDDEN, "MATCH_406", "매칭 상대 회원이 나를 차단했습니다. 매칭 FOUND 처리가 불가능합니다."),
+    MATCHING_FOUND_FAILED_BY_CONFLICT_MATCHINGUUID(BAD_REQUEST, "MATCH_407", "sender와 receiver의 matchingUuid가 동일합니다."),
 
     /**
      * 차단 관련 에러

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingFacadeService.java
@@ -143,6 +143,9 @@ public class MatchingFacadeService {
      */
     @Transactional
     public MatchingFoundResponse matchingFound(String matchingUuid, String targetMatchingUuid) {
+        // matchingUuid 검증
+        matchingService.validateSenderAndReceiverMatchingUuid(matchingUuid, targetMatchingUuid);
+
         // 내 matching 조회
         MatchingRecord matchingRecord =
                 matchingService.getMatchingRecordByMatchingUuid(matchingUuid);

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/service/MatchingService.java
@@ -180,4 +180,10 @@ public class MatchingService {
         matchingRecord.updateMannerMessageSent(mannerMessageStatus);
     }
 
+    public void validateSenderAndReceiverMatchingUuid(String senderMatchingUuid, String receiverMatchingUuid) {
+        if (senderMatchingUuid.equals(receiverMatchingUuid)) {
+            throw new MatchingException(ErrorCode.MATCHING_FOUND_FAILED_BY_CONFLICT_MATCHINGUUID);
+        }
+    }
+
 }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> matching found API 호출 시, sender와 receiver의 matchingUuid가 같을 경우 예외처리

## ⏳ 작업 상세 내용

- [x] sender와 receiver의 matchingUuid가 같은지 검증
- [x] 검증이 제대로 실행되는지 테스트코드 작성

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
