### PR TITLE
[Feat/314] matching free/solo tier,rank 전부 보이도록 수정

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/dto/response/MatchingMemberInfoResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/dto/response/MatchingMemberInfoResponse.java
@@ -21,8 +21,10 @@ public class MatchingMemberInfoResponse {
     String matchingUuid;
     String gameName;
     String tag;
-    Tier tier;
-    Integer rank;
+    Tier soloTier;
+    Integer soloRank;
+    Tier freeTier;
+    Integer freeRank;
     Integer mannerLevel;
     Integer profileImg;
     GameMode gameMode;
@@ -43,8 +45,10 @@ public class MatchingMemberInfoResponse {
                 .mike(member.getMike())
                 .gameName(member.getGameName())
                 .tag(member.getTag())
-                .tier(member.getSoloTier())
-                .rank(member.getSoloRank())
+                .soloTier(member.getSoloTier())
+                .soloRank(member.getSoloRank())
+                .freeTier(member.getFreeTier())
+                .freeRank(member.getFreeRank())
                 .profileImg(member.getProfileImage())
                 .mannerLevel(member.getMannerLevel())
                 .mainP(member.getMainP())


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> matching free/solo tier,rank 전부 보이도록 수정

## ⏳ 작업 상세 내용

- [x] dto에서 solo/free tier,rank 둘 다 보이도록 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
