### PR TITLE
[Feat/326] 라이엇 챔피언 db 기획 수정 사항 반영

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/response/RiotMatchResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/response/RiotMatchResponse.java
@@ -20,6 +20,7 @@ public class RiotMatchResponse {
 
         private List<ParticipantDTO> participants;
         private int gameDuration;
+        private int queueId;
 
     }
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordServiceTest.java
@@ -62,6 +62,7 @@ class RiotRecordServiceTest {
         RiotMatchResponse.InfoDTO info = RiotMatchResponse.InfoDTO.builder()
                 .participants(Arrays.asList(participant))
                 .gameDuration(1800) // 30분
+                .queueId(420)
                 .build();
 
         RiotMatchResponse matchResponse = RiotMatchResponse.builder()
@@ -110,6 +111,7 @@ class RiotRecordServiceTest {
         RiotMatchResponse.InfoDTO info = RiotMatchResponse.InfoDTO.builder()
                 .participants(Arrays.asList(participant))
                 .gameDuration(1800)
+                .queueId(420)
                 .build();
 
         RiotMatchResponse matchResponse = RiotMatchResponse.builder()
@@ -158,6 +160,7 @@ class RiotRecordServiceTest {
         RiotMatchResponse.InfoDTO info1 = RiotMatchResponse.InfoDTO.builder()
                 .participants(Arrays.asList(participant1))
                 .gameDuration(1800)
+                .queueId(420)
                 .build();
 
         RiotMatchResponse match1 = RiotMatchResponse.builder()
@@ -177,6 +180,7 @@ class RiotRecordServiceTest {
         RiotMatchResponse.InfoDTO info2 = RiotMatchResponse.InfoDTO.builder()
                 .participants(Arrays.asList(participant2))
                 .gameDuration(1800)
+                .queueId(420)
                 .build();
 
         RiotMatchResponse match2 = RiotMatchResponse.builder()


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 최근 전적 챔피언 4개까지 불러오기 && 챔피언 부족 시 추가 조회 x

## ⏳ 작업 상세 내용

- [x] 챔피언 4개까지 불러오기
- [x] 챔피언 부족 시 추가 조회 x
- [x] 일반, 칼바람, 이벤트 제외 솔랭, 자유랭만 받아오기

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
