### PR TITLE
[Feat/330] 신고 목록 고급 필터링(다중 조건) 기능 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Building and Running
+```bash
+# Build the project
+./gradlew build
+
+# Run the application (local profile)
+./gradlew bootRun
+
+# Run tests
+./gradlew test
+
+# Clean build artifacts
+./gradlew clean
+
+# Generate QueryDSL Q-classes
+./gradlew compileJava
+```
+
+### Testing
+```bash
+# Run all tests
+./gradlew test
+
+# Run specific test class
+./gradlew test --tests "com.gamegoo.gamegoo_v2.service.matching.MatchingServiceTest"
+
+# Run tests with specific profile
+./gradlew test -Dspring.profiles.active=test
+```
+
+## Architecture Overview
+
+This is a Spring Boot application for a League of Legends player matching platform. The architecture follows Domain-Driven Design (DDD) principles with a clear separation of concerns.
+
+### Core Domains
+
+1. **Account** - User management, authentication (JWT), email verification
+2. **Matching** - Complex matchmaking algorithm based on game statistics and preferences
+3. **Chat** - Real-time messaging between matched players
+4. **Social** - Friend system, blocking, manner rating system
+5. **Game** - League of Legends champions and game styles
+6. **Content** - User-generated boards and reporting system
+
+### Key Architectural Patterns
+
+#### Facade Service Pattern
+Complex business operations are orchestrated through FacadeServices that coordinate multiple domain services:
+- `MatchingFacadeService` - Handles matching workflow and chatroom creation
+- `AuthFacadeService` - Coordinates authentication and member management
+- `ChatFacadeService` - Manages chat operations and validations
+
+#### Domain Service Layer
+Each domain has dedicated services:
+- **CommandService** - Write operations
+- **QueryService** - Read operations  
+- **FacadeService** - Cross-domain orchestration
+
+#### Validation Architecture
+Centralized validators handle cross-domain business rules:
+- `MemberValidator` - User existence and status checks
+- `BlockValidator` - User blocking verification
+- `MatchingValidator` - Matching state validation
+
+### Security Architecture
+
+- **JWT-based authentication** with refresh tokens
+- **JwtAuthFilter** for request authentication
+- **Role-based authorization** (member/admin roles)
+- **SecurityUtil** for accessing current user context
+
+### Database and Persistence
+
+- **JPA + QueryDSL** for complex queries
+- **Custom repository implementations** in `*RepositoryCustomImpl` classes
+- **BaseDateTimeEntity** for automatic timestamp tracking
+- **MySQL** for production, **H2** for testing
+
+### External Integrations
+
+- **Riot Games API** - OAuth2 integration and real-time game data
+- **Socket Server** - Real-time communication support
+- **Email Service** - Gmail SMTP integration
+- **Discord Logging** - Error monitoring and notifications
+
+### Event-Driven Components
+
+Spring Events are used for decoupled communication:
+- Friend request notifications
+- Manner rating calculations
+- Email sending operations
+- Socket join events
+
+## Development Guidelines
+
+### Working with the Codebase
+
+1. **Start with Controllers** - API endpoints define the application boundaries
+2. **Use FacadeServices** - For operations spanning multiple domains
+3. **Leverage Validators** - Ensure business rules are consistently applied
+4. **Custom Repositories** - Use QueryDSL for complex database queries
+
+### Environment Profiles
+
+- **local** - Local development with MySQL
+- **dev** - Development environment
+- **prod** - Production environment  
+- **test** - Testing with H2 in-memory database
+
+### Required Environment Variables
+
+For local development, ensure these environment variables are set:
+- `DB_URL`, `DB_USERNAME`, `DB_PASSWORD` - Database connection
+- `JWT_SECRET` - JWT token signing
+- `RIOT_API` - Riot Games API key
+- `CLIENT_ID`, `CLIENT_SECRET` - Riot OAuth credentials
+- `GMAIL_PWD` - Email service password
+
+### Testing Approach
+
+- **Integration tests** for FacadeServices (test cross-domain workflows)
+- **Unit tests** for business logic components
+- **Repository tests** for data access layer with `@DataJpaTest`
+- **Controller tests** with security context using custom annotations
+
+### Code Conventions
+
+- Use **@RequiredArgsConstructor** for dependency injection
+- **@Transactional(readOnly = true)** on query services
+- **ApiResponse** wrapper for all REST responses
+- **ErrorCode** enumeration for consistent error handling
+- **Q-classes** are auto-generated in `src/main/generated/`
+
+### Key Files to Understand
+
+- `SecurityConfig.java` - Security configuration and JWT setup
+- `*FacadeService.java` - Complex business workflows
+- `*Validator.java` - Cross-domain business rules
+- `application.yml` - Multi-profile configuration
+- `ExceptionAdvice.java` - Global error handling

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -128,6 +128,12 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberGameStyle> memberGameStyleList = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
+    private BanType banType = BanType.NONE;
+
+    private java.time.LocalDateTime banExpireAt;
+
     // puuid 전용
     public static Member createForGeneral(String email, String password, LoginType loginType, String gameName,
                                           String tag,

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
@@ -5,6 +5,7 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportRequest;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportInsertResponse;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportListResponse;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
 import com.gamegoo.gamegoo_v2.content.report.service.ReportFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,10 +41,10 @@ public class ReportController {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "신고 목록 조회 (관리자 전용)", description = "관리자만 접근 가능한 신고 목록 전체 조회 API입니다.")
+    @Operation(summary = "신고 목록 조회 (관리자 전용)", description = "관리자만 접근 가능한 신고 목록 고급 필터링 조회 API입니다.")
     @GetMapping("/list")
-    public ApiResponse<List<ReportListResponse>> getReportList() {
-        return ApiResponse.ok(reportFacadeService.getAllReports());
+    public ApiResponse<List<ReportListResponse>> getReportList(ReportSearchRequest request) {
+        return ApiResponse.ok(reportFacadeService.searchReports(request));
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportRequest.java
@@ -23,7 +23,7 @@ public class ReportRequest {
     @EachMax(value = 6, message = "report code는 6 이하의 값이어야 합니다.")
     List<Integer> reportCodeList;
 
-    @Length(max = 1000, message = "contents는 1000자 이내여야 합니다.")
+    @Length(max = 500, message = "contents는 500자 이내여야 합니다.")
     String contents;
 
     @Min(value = 1, message = "path code는 1 이상의 값이어야 합니다.")

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportSearchRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportSearchRequest.java
@@ -1,0 +1,32 @@
+package com.gamegoo.gamegoo_v2.content.report.dto.request;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportPath;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportSearchRequest {
+    private String reportedMemberKeyword;
+    private String reporterKeyword;
+    private String contentKeyword;
+    private List<ReportPath> reportPaths;
+    private List<Integer> reportTypes;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Integer reportCountMin;
+    private Integer reportCountMax;
+    private Integer reportCountExact;
+    private Boolean isDeleted;
+    private Pageable pageable;
+    private List<BanType> banTypes;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/repository/ReportRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/repository/ReportRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
 
     boolean existsByFromMemberIdAndToMemberIdAndCreatedAtBetween(Long fromMemberId, Long toMemberId,
                                                                  LocalDateTime startOfDay, LocalDateTime endOfDay);

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/repository/ReportRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.gamegoo.gamegoo_v2.content.report.repository;
+
+import com.gamegoo.gamegoo_v2.content.report.domain.Report;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
+import java.util.List;
+
+public interface ReportRepositoryCustom {
+    List<Report> searchReports(ReportSearchRequest request);
+} 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/repository/ReportRepositoryImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/repository/ReportRepositoryImpl.java
@@ -1,0 +1,116 @@
+package com.gamegoo.gamegoo_v2.content.report.repository;
+
+import com.gamegoo.gamegoo_v2.content.report.domain.Report;
+import com.gamegoo.gamegoo_v2.content.report.domain.QReport;
+import com.gamegoo.gamegoo_v2.content.report.domain.QReportTypeMapping;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
+import com.gamegoo.gamegoo_v2.content.board.domain.QBoard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.core.BooleanBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportRepositoryImpl implements ReportRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Report> searchReports(ReportSearchRequest request) {
+        QReport report = QReport.report;
+        QReportTypeMapping reportTypeMapping = QReportTypeMapping.reportTypeMapping;
+        QBoard board = QBoard.board;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 1. 신고자 키워드 검색
+        if (request.getReporterKeyword() != null && !request.getReporterKeyword().isEmpty()) {
+            builder.and(report.fromMember.gameName.contains(request.getReporterKeyword()));
+        }
+
+        // 2. 피신고자 키워드 검색
+        if (request.getReportedMemberKeyword() != null && !request.getReportedMemberKeyword().isEmpty()) {
+            builder.and(report.toMember.gameName.contains(request.getReportedMemberKeyword()));
+        }
+
+        // 3. 상세 내용 키워드 검색
+        if (request.getContentKeyword() != null && !request.getContentKeyword().isEmpty()) {
+            builder.and(report.content.contains(request.getContentKeyword()));
+        }
+
+        // 4. 신고된 페이지 유형 다중선택
+        if (request.getReportPaths() != null && !request.getReportPaths().isEmpty()) {
+            builder.and(report.path.in(request.getReportPaths()));
+        }
+
+        // 5. 신고 사유 다중선택 (ReportTypeMapping과 join 필요)
+        if (request.getReportTypes() != null && !request.getReportTypes().isEmpty()) {
+            builder.and(reportTypeMapping.code.in(request.getReportTypes()));
+        }
+
+        // 6. 날짜 범위 필터
+        if (request.getStartDate() != null && request.getEndDate() != null) {
+            builder.and(report.createdAt.between(request.getStartDate(), request.getEndDate()));
+        } else if (request.getStartDate() != null) {
+            builder.and(report.createdAt.goe(request.getStartDate()));
+        } else if (request.getEndDate() != null) {
+            builder.and(report.createdAt.loe(request.getEndDate()));
+        }
+
+        // 7. 신고 누적 횟수 구간 검색
+        if (request.getReportCountMin() != null && request.getReportCountMax() != null) {
+            // 서브쿼리로 신고 대상별 신고 횟수 집계 후 조건 추가
+            builder.and(report.toMember.id.in(
+                queryFactory.select(report.toMember.id)
+                    .from(report)
+                    .groupBy(report.toMember.id)
+                    .having(report.count().between(request.getReportCountMin(), request.getReportCountMax()))
+            ));
+        } else if (request.getReportCountMin() != null) {
+            builder.and(report.toMember.id.in(
+                queryFactory.select(report.toMember.id)
+                    .from(report)
+                    .groupBy(report.toMember.id)
+                    .having(report.count().goe(request.getReportCountMin()))
+            ));
+        } else if (request.getReportCountMax() != null) {
+            builder.and(report.toMember.id.in(
+                queryFactory.select(report.toMember.id)
+                    .from(report)
+                    .groupBy(report.toMember.id)
+                    .having(report.count().loe(request.getReportCountMax()))
+            ));
+        } else if (request.getReportCountExact() != null) {
+            builder.and(report.toMember.id.in(
+                queryFactory.select(report.toMember.id)
+                    .from(report)
+                    .groupBy(report.toMember.id)
+                    .having(report.count().eq(request.getReportCountExact().longValue()))
+            ));
+        }
+
+        // 8. 삭제된 게시글 필터
+        if (request.getIsDeleted() != null) {
+            if (request.getIsDeleted()) {
+                // 삭제된 게시글만 조회
+                builder.and(report.sourceBoard.isNotNull().and(report.sourceBoard.deleted.eq(true)));
+            } else {
+                // 삭제되지 않은 게시글만 조회
+                builder.and(report.sourceBoard.isNull().or(report.sourceBoard.deleted.eq(false)));
+            }
+        }
+
+        // 9. 계정 제재 상태 필터 (Member 엔티티에 banType 필드가 있다고 가정)
+        if (request.getBanTypes() != null && !request.getBanTypes().isEmpty()) {
+            builder.and(report.toMember.banType.in(request.getBanTypes()));
+        }
+
+        return queryFactory.selectFrom(report)
+                .leftJoin(reportTypeMapping).on(reportTypeMapping.report.eq(report))
+                .leftJoin(report.sourceBoard, board)
+                .where(builder)
+                .distinct()
+                .fetch();
+    }
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/service/ReportFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/service/ReportFacadeService.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.content.board.service.BoardService;
 import com.gamegoo.gamegoo_v2.content.report.domain.Report;
 import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportRequest;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportInsertResponse;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportListResponse;
 import com.gamegoo.gamegoo_v2.core.exception.ReportException;
@@ -54,11 +55,12 @@ public class ReportFacadeService {
         return ReportInsertResponse.of(report);
     }
 
+
     /**
-     * 전체 신고 목록 조회 (관리자용)
+     * 신고 목록 고급 필터링 조회 (관리자용)
      */
-    public List<ReportListResponse> getAllReports() {
-        return reportService.getAllReports().stream()
+    public List<ReportListResponse> searchReports(ReportSearchRequest request) {
+        return reportService.searchReports(request).stream()
                 .map(report -> ReportListResponse.builder()
                         .reportId(report.getId())
                         .fromMemberName(report.getFromMember().getGameName())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/service/ReportService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/service/ReportService.java
@@ -12,6 +12,7 @@ import com.gamegoo.gamegoo_v2.core.common.validator.MemberValidator;
 import com.gamegoo.gamegoo_v2.core.event.SendReportEmailEvent;
 import com.gamegoo.gamegoo_v2.core.exception.ReportException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -121,6 +122,10 @@ public class ReportService {
      */
     public List<Report> getAllReports() {
         return reportRepository.findAll();
+    }
+
+    public List<Report> searchReports(ReportSearchRequest request) {
+        return reportRepository.searchReports(request);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/repository/report/ReportRepositoryTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/repository/report/ReportRepositoryTest.java
@@ -1,0 +1,474 @@
+package com.gamegoo.gamegoo_v2.repository.report;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
+import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import com.gamegoo.gamegoo_v2.content.board.repository.BoardRepository;
+import com.gamegoo.gamegoo_v2.content.report.domain.Report;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportPath;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportTypeMapping;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
+import com.gamegoo.gamegoo_v2.content.report.repository.ReportRepository;
+import com.gamegoo.gamegoo_v2.content.report.repository.ReportTypeMappingRepository;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class ReportRepositoryTest {
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private ReportTypeMappingRepository reportTypeMappingRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    private Member fromMember;
+    private Member toMember;
+    private Member bannedMember;
+    private Board board;
+    private Board deletedBoard;
+
+    @BeforeEach
+    void setUp() {
+        fromMember = createMember("from@gmail.com", "fromMember");
+        toMember = createMember("to@gmail.com", "toMember");
+        bannedMember = createMember("banned@gmail.com", "bannedMember");
+        
+        board = createBoard(toMember, false);
+        deletedBoard = createBoard(fromMember, true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reportTypeMappingRepository.deleteAllInBatch();
+        reportRepository.deleteAllInBatch();
+        boardRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("신고 존재 여부 확인")
+    class ExistsByFromMemberIdAndToMemberIdAndCreatedAtBetweenTest {
+
+        @DisplayName("오늘 날짜에 신고가 존재하는 경우 true 반환")
+        @Test
+        void existsByFromMemberIdAndToMemberIdAndCreatedAtBetweenReturnsTrueWhenExists() {
+            // given
+            reportRepository.save(Report.create(fromMember, toMember, "content", ReportPath.CHAT, null));
+            
+            LocalDate today = LocalDate.now();
+            LocalDateTime startOfDay = today.atStartOfDay();
+            LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+            // when
+            boolean exists = reportRepository.existsByFromMemberIdAndToMemberIdAndCreatedAtBetween(
+                    fromMember.getId(), toMember.getId(), startOfDay, endOfDay);
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @DisplayName("오늘 날짜에 신고가 존재하지 않는 경우 false 반환")
+        @Test
+        void existsByFromMemberIdAndToMemberIdAndCreatedAtBetweenReturnsFalseWhenNotExists() {
+            // given
+            LocalDate today = LocalDate.now();
+            LocalDateTime startOfDay = today.atStartOfDay();
+            LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+            // when
+            boolean exists = reportRepository.existsByFromMemberIdAndToMemberIdAndCreatedAtBetween(
+                    fromMember.getId(), toMember.getId(), startOfDay, endOfDay);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @DisplayName("다른 회원 조합의 신고가 존재하는 경우 false 반환")
+        @Test
+        void existsByFromMemberIdAndToMemberIdAndCreatedAtBetweenReturnsFalseWhenDifferentMembers() {
+            // given
+            reportRepository.save(Report.create(fromMember, bannedMember, "content", ReportPath.CHAT, null));
+            
+            LocalDate today = LocalDate.now();
+            LocalDateTime startOfDay = today.atStartOfDay();
+            LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+            // when
+            boolean exists = reportRepository.existsByFromMemberIdAndToMemberIdAndCreatedAtBetween(
+                    fromMember.getId(), toMember.getId(), startOfDay, endOfDay);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("신고 검색")
+    class SearchReportsTest {
+
+        private Report report1;
+        private Report report2;
+        private Report report3;
+
+        @BeforeEach
+        void setUpReports() {
+            report1 = reportRepository.save(Report.create(fromMember, toMember, "욕설 신고", ReportPath.CHAT, null));
+            report2 = reportRepository.save(Report.create(toMember, bannedMember, "스팸 신고", ReportPath.BOARD, board));
+            report3 = reportRepository.save(Report.create(fromMember, bannedMember, "부정행위 신고", ReportPath.PROFILE, deletedBoard));
+
+            reportTypeMappingRepository.save(ReportTypeMapping.create(report1, 4)); // 욕설/ 혐오/ 차별적 표현
+            reportTypeMappingRepository.save(ReportTypeMapping.create(report2, 6)); // 불쾌한 표현
+            reportTypeMappingRepository.save(ReportTypeMapping.create(report3, 1)); // 스팸
+        }
+
+        @DisplayName("검색 조건이 없는 경우 모든 신고 반환")
+        @Test
+        void searchReportsWithoutConditions() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder().build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(3);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report1.getId(), report2.getId(), report3.getId());
+        }
+
+        @DisplayName("신고자 키워드로 검색")
+        @Test
+        void searchReportsByReporterKeyword() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reporterKeyword("fromMember")
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report1.getId(), report3.getId());
+        }
+
+        @DisplayName("피신고자 키워드로 검색")
+        @Test
+        void searchReportsByReportedMemberKeyword() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportedMemberKeyword("bannedMember")
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report2.getId(), report3.getId());
+        }
+
+        @DisplayName("내용 키워드로 검색")
+        @Test
+        void searchReportsByContentKeyword() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .contentKeyword("욕설")
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getId()).isEqualTo(report1.getId());
+        }
+
+        @DisplayName("신고 경로로 검색")
+        @Test
+        void searchReportsByReportPaths() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportPaths(List.of(ReportPath.CHAT, ReportPath.BOARD))
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report1.getId(), report2.getId());
+        }
+
+        @DisplayName("신고 유형으로 검색")
+        @Test
+        void searchReportsByReportTypes() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportTypes(List.of(4, 6)) // 욕설/ 혐오/ 차별적 표현, 불쾌한 표현
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report1.getId(), report2.getId());
+        }
+
+        @DisplayName("날짜 범위로 검색")
+        @Test
+        void searchReportsByDateRange() {
+            // given
+            LocalDateTime startDate = LocalDateTime.now().minusDays(1);
+            LocalDateTime endDate = LocalDateTime.now().plusDays(1);
+            
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(3);
+        }
+
+        @DisplayName("시작 날짜만으로 검색")
+        @Test
+        void searchReportsByStartDateOnly() {
+            // given
+            LocalDateTime startDate = LocalDateTime.now().minusHours(1);
+            
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .startDate(startDate)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(3);
+        }
+
+        @DisplayName("종료 날짜만으로 검색")
+        @Test
+        void searchReportsByEndDateOnly() {
+            // given
+            LocalDateTime endDate = LocalDateTime.now().plusHours(1);
+            
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .endDate(endDate)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(3);
+        }
+
+        @DisplayName("정확한 신고 횟수로 검색")
+        @Test
+        void searchReportsByExactReportCount() {
+            // given
+            // bannedMember는 2번 신고당함
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportCountExact(2)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report2.getId(), report3.getId());
+        }
+
+        @DisplayName("최소 신고 횟수로 검색")
+        @Test
+        void searchReportsByMinReportCount() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportCountMin(2)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report2.getId(), report3.getId());
+        }
+
+        @DisplayName("최대 신고 횟수로 검색")
+        @Test
+        void searchReportsByMaxReportCount() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportCountMax(1)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getId()).isEqualTo(report1.getId());
+        }
+
+        @DisplayName("신고 횟수 범위로 검색")
+        @Test
+        void searchReportsByReportCountRange() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reportCountMin(1)
+                    .reportCountMax(2)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(3);
+        }
+
+        @DisplayName("삭제된 게시글 필터 - 삭제된 게시글만")
+        @Test
+        void searchReportsWithDeletedBoardsOnly() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .isDeleted(true)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getId()).isEqualTo(report3.getId());
+        }
+
+        @DisplayName("삭제된 게시글 필터 - 삭제되지 않은 게시글만")
+        @Test
+        void searchReportsWithNonDeletedBoardsOnly() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .isDeleted(false)
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report1.getId(), report2.getId());
+        }
+
+
+        @DisplayName("복합 조건으로 검색")
+        @Test
+        void searchReportsByMultipleConditions() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .reporterKeyword("fromMember")
+                    .reportPaths(List.of(ReportPath.CHAT))
+                    .contentKeyword("욕설")
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getId()).isEqualTo(report1.getId());
+        }
+
+        @DisplayName("조건에 맞는 결과가 없는 경우 빈 리스트 반환")
+        @Test
+        void searchReportsReturnsEmptyListWhenNoMatch() {
+            // given
+            ReportSearchRequest request = ReportSearchRequest.builder()
+                    .contentKeyword("존재하지않는키워드")
+                    .build();
+
+            // when
+            List<Report> results = reportRepository.searchReports(request);
+
+            // then
+            assertThat(results).isEmpty();
+        }
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .soloTier(Tier.IRON)
+                .soloRank(0)
+                .soloWinRate(0.0)
+                .soloGameCount(0)
+                .freeTier(Tier.IRON)
+                .freeRank(0)
+                .freeWinRate(0.0)
+                .freeGameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private Board createBoard(Member member, boolean deleted) {
+        Board board = Board.builder()
+                .member(member)
+                .gameMode(GameMode.SOLO)
+                .mainP(Position.ADC)
+                .subP(Position.JUNGLE)
+                .wantP(List.of(Position.ADC))
+                .mike(Mike.AVAILABLE)
+                .content("content")
+                .boardProfileImage(1)
+                .deleted(deleted)
+                .build();
+        
+        return boardRepository.save(board);
+    }
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/report/ReportServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/report/ReportServiceTest.java
@@ -1,0 +1,372 @@
+package com.gamegoo.gamegoo_v2.service.report;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
+import com.gamegoo.gamegoo_v2.content.board.domain.Board;
+import com.gamegoo.gamegoo_v2.content.board.repository.BoardRepository;
+import com.gamegoo.gamegoo_v2.content.report.domain.Report;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportPath;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportTypeMapping;
+import com.gamegoo.gamegoo_v2.content.report.repository.ReportRepository;
+import com.gamegoo.gamegoo_v2.content.report.repository.ReportTypeMappingRepository;
+import com.gamegoo.gamegoo_v2.content.report.service.ReportService;
+import com.gamegoo.gamegoo_v2.core.event.SendReportEmailEvent;
+import com.gamegoo.gamegoo_v2.core.event.listener.EmailEventListener;
+import com.gamegoo.gamegoo_v2.core.exception.ReportException;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ReportServiceTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private ReportTypeMappingRepository reportTypeMappingRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @MockitoSpyBean
+    private EmailEventListener emailEventListener;
+
+    private Member fromMember;
+    private Member toMember;
+    private Board board;
+
+    @BeforeEach
+    void setUp() {
+        fromMember = createMember("from@gmail.com", "fromMember");
+        toMember = createMember("to@gmail.com", "toMember");
+        board = createBoard(toMember);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reportTypeMappingRepository.deleteAllInBatch();
+        reportRepository.deleteAllInBatch();
+        boardRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("신고 등록")
+    class InsertReportTest {
+
+        @DisplayName("실패: 자기 자신을 신고하는 경우")
+        @Test
+        void insertReportFailedWhenSelfReport() {
+            // given
+            List<Integer> reportCodes = List.of(1, 2, 3);
+            String content = "신고 내용";
+            Integer pathCode = 1;
+
+            // when // then
+            assertThatThrownBy(() -> reportService.insertReport(fromMember, fromMember, reportCodes, content, pathCode, null))
+                    .hasMessage(ErrorCode._BAD_REQUEST.getMessage());
+        }
+
+        @DisplayName("실패: 탈퇴한 회원을 신고하는 경우")
+        @Test
+        void insertReportFailedWhenTargetIsBlind() {
+            // given
+            toMember.updateBlind(true);
+            memberRepository.save(toMember);
+
+            List<Integer> reportCodes = List.of(1, 2, 3);
+            String content = "신고 내용";
+            Integer pathCode = 1;
+
+            // when // then
+            assertThatThrownBy(() -> reportService.insertReport(fromMember, toMember, reportCodes, content, pathCode, null))
+                    .hasMessage(ErrorCode.TARGET_MEMBER_DEACTIVATED.getMessage());
+        }
+
+        @DisplayName("성공: 신고 등록 (게시글 없음)")
+        @Test
+        void insertReportSucceeds() {
+            // given
+            List<Integer> reportCodes = List.of(1, 2, 3);
+            String content = "신고 내용";
+            Integer pathCode = 1;
+
+            // when
+            Report result = reportService.insertReport(fromMember, toMember, reportCodes, content, pathCode, null);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getFromMember().getId()).isEqualTo(fromMember.getId());
+            assertThat(result.getToMember().getId()).isEqualTo(toMember.getId());
+            assertThat(result.getContent()).isEqualTo(content);
+            assertThat(result.getPath()).isEqualTo(ReportPath.of(pathCode));
+            assertThat(result.getSourceBoard()).isNull();
+
+            List<ReportTypeMapping> mappings = reportTypeMappingRepository.findAllByReportId(result.getId());
+            assertThat(mappings).hasSize(3);
+            mappings.forEach(mapping -> assertThat(mapping.getCode()).isIn(reportCodes));
+
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(emailEventListener, times(1)).handleSendReportEmailEvent(any(SendReportEmailEvent.class));
+            });
+        }
+
+        @DisplayName("성공: 신고 등록 (게시글 포함)")
+        @Test
+        void insertReportSucceedsWithBoard() {
+            // given
+            List<Integer> reportCodes = List.of(1, 2);
+            String content = "신고 내용";
+            Integer pathCode = 2;
+
+            // when
+            Report result = reportService.insertReport(fromMember, toMember, reportCodes, content, pathCode, board);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getFromMember().getId()).isEqualTo(fromMember.getId());
+            assertThat(result.getToMember().getId()).isEqualTo(toMember.getId());
+            assertThat(result.getContent()).isEqualTo(content);
+            assertThat(result.getPath()).isEqualTo(ReportPath.of(pathCode));
+            assertThat(result.getSourceBoard().getId()).isEqualTo(board.getId());
+
+            List<ReportTypeMapping> mappings = reportTypeMappingRepository.findAllByReportId(result.getId());
+            assertThat(mappings).hasSize(2);
+            mappings.forEach(mapping -> assertThat(mapping.getCode()).isIn(reportCodes));
+
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                verify(emailEventListener, times(1)).handleSendReportEmailEvent(any(SendReportEmailEvent.class));
+            });
+        }
+
+        @DisplayName("성공: 신고 등록 (내용 없음)")
+        @Test
+        void insertReportSucceedsWithoutContent() {
+            // given
+            List<Integer> reportCodes = List.of(4, 5);
+            Integer pathCode = 3;
+
+            // when
+            Report result = reportService.insertReport(fromMember, toMember, reportCodes, null, pathCode, null);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getFromMember().getId()).isEqualTo(fromMember.getId());
+            assertThat(result.getToMember().getId()).isEqualTo(toMember.getId());
+            assertThat(result.getContent()).isNull();
+            assertThat(result.getPath()).isEqualTo(ReportPath.of(pathCode));
+            assertThat(result.getSourceBoard()).isNull();
+
+            List<ReportTypeMapping> mappings = reportTypeMappingRepository.findAllByReportId(result.getId());
+            assertThat(mappings).hasSize(2);
+            mappings.forEach(mapping -> assertThat(mapping.getCode()).isIn(reportCodes));
+        }
+    }
+
+    @Nested
+    @DisplayName("신고 존재 여부 확인")
+    class ExistsByMemberAndCreatedAtTest {
+
+        @DisplayName("오늘 날짜에 신고가 존재하는 경우 true 반환")
+        @Test
+        void existsByMemberAndCreatedAtReturnsTrueWhenExists() {
+            // given
+            reportRepository.save(Report.create(fromMember, toMember, "content", ReportPath.CHAT, null));
+            LocalDate today = LocalDate.now();
+
+            // when
+            boolean exists = reportService.existsByMemberAndCreatedAt(fromMember, toMember, today);
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @DisplayName("오늘 날짜에 신고가 존재하지 않는 경우 false 반환")
+        @Test
+        void existsByMemberAndCreatedAtReturnsFalseWhenNotExists() {
+            // given
+            LocalDate today = LocalDate.now();
+
+            // when
+            boolean exists = reportService.existsByMemberAndCreatedAt(fromMember, toMember, today);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @DisplayName("다른 날짜에 신고가 존재하는 경우 false 반환")
+        @Test
+        void existsByMemberAndCreatedAtReturnsFalseWhenDifferentDate() {
+            // given
+            reportRepository.save(Report.create(fromMember, toMember, "content", ReportPath.CHAT, null));
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+
+            // when
+            boolean exists = reportService.existsByMemberAndCreatedAt(fromMember, toMember, yesterday);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("신고 조회")
+    class FindByIdTest {
+
+        @DisplayName("성공: ID로 신고 조회")
+        @Test
+        void findByIdSucceeds() {
+            // given
+            Report savedReport = reportRepository.save(Report.create(fromMember, toMember, "content", ReportPath.CHAT, null));
+
+            // when
+            Report result = reportService.findById(savedReport.getId());
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(savedReport.getId());
+            assertThat(result.getFromMember().getId()).isEqualTo(fromMember.getId());
+            assertThat(result.getToMember().getId()).isEqualTo(toMember.getId());
+        }
+
+        @DisplayName("실패: 존재하지 않는 ID로 조회")
+        @Test
+        void findByIdFailedWhenNotFound() {
+            // when // then
+            assertThatThrownBy(() -> reportService.findById(999L))
+                    .isInstanceOf(ReportException.class)
+                    .hasMessage(ErrorCode.REPORT_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("신고 유형 문자열 조회")
+    class GetReportTypeStringTest {
+
+        @DisplayName("성공: 신고 유형 문자열 조회")
+        @Test
+        void getReportTypeStringSucceeds() {
+            // given
+            Report savedReport = reportRepository.save(Report.create(fromMember, toMember, "content", ReportPath.CHAT, null));
+            reportTypeMappingRepository.save(ReportTypeMapping.create(savedReport, 4));
+            reportTypeMappingRepository.save(ReportTypeMapping.create(savedReport, 2));
+
+            // when
+            String result = reportService.getReportTypeString(savedReport.getId());
+
+            // then
+            assertThat(result).contains("욕설/ 혐오/ 차별적 표현");
+            assertThat(result).contains("불법 정보 포함");
+            assertThat(result).contains(", ");
+        }
+
+        @DisplayName("성공: 단일 신고 유형 문자열 조회")
+        @Test
+        void getReportTypeStringSucceedsWithSingleType() {
+            // given
+            Report savedReport = reportRepository.save(Report.create(fromMember, toMember, "content", ReportPath.CHAT, null));
+            reportTypeMappingRepository.save(ReportTypeMapping.create(savedReport, 4));
+
+            // when
+            String result = reportService.getReportTypeString(savedReport.getId());
+
+            // then
+            assertThat(result).isEqualTo("욕설/ 혐오/ 차별적 표현");
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 신고 목록 조회")
+    class GetAllReportsTest {
+
+        @DisplayName("성공: 전체 신고 목록 조회")
+        @Test
+        void getAllReportsSucceeds() {
+            // given
+            Report report1 = reportRepository.save(Report.create(fromMember, toMember, "content1", ReportPath.CHAT, null));
+            Report report2 = reportRepository.save(Report.create(toMember, fromMember, "content2", ReportPath.BOARD, board));
+
+            // when
+            List<Report> results = reportService.getAllReports();
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).extracting(Report::getId)
+                    .containsExactlyInAnyOrder(report1.getId(), report2.getId());
+        }
+
+        @DisplayName("성공: 신고가 없는 경우 빈 리스트 반환")
+        @Test
+        void getAllReportsSucceedsWhenEmpty() {
+            // when
+            List<Report> results = reportService.getAllReports();
+
+            // then
+            assertThat(results).isEmpty();
+        }
+    }
+
+    private Member createMember(String email, String gameName) {
+        return memberRepository.save(Member.builder()
+                .email(email)
+                .password("testPassword")
+                .profileImage(1)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag("TAG")
+                .soloTier(Tier.IRON)
+                .soloRank(0)
+                .soloWinRate(0.0)
+                .soloGameCount(0)
+                .freeTier(Tier.IRON)
+                .freeRank(0)
+                .freeWinRate(0.0)
+                .freeGameCount(0)
+                .isAgree(true)
+                .build());
+    }
+
+    private Board createBoard(Member member) {
+        return boardRepository.save(Board.builder()
+                .member(member)
+                .gameMode(GameMode.SOLO)
+                .mainP(Position.ADC)
+                .subP(Position.JUNGLE)
+                .wantP(List.of(Position.ADC))
+                .mike(Mike.AVAILABLE)
+                .content("content")
+                .boardProfileImage(1)
+                .build());
+    }
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 신고 목록 고급 필터링(다중 조건) 기능 구현

## ⏳ 작업 상세 내용

- [ ] 다중 선택 필터 (체크박스), 신고된 페이지 유형 다중 선택 지원 필요, 신고 사유 다중 선택 지원 필요, 계정 제재 다중 선택 지원 
- [ ] 신고 접수 일시 기준으로 단일 날짜/ 범위 조회 
- [ ] 신고자, 신고대상, 상세 내용 등 텍스트 검색 
- [ ] 신고 누적 횟수 (특정 숫자, 구간)으로 필터링 
- [ ] 삭제된 게시글만 조회 혹은 전체/삭제된 글만 필터링 
- [ ] 테스트 코드 작성 위한 claud.md 추가 테스트 코드 작성 완료   

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] 없을 경우 체크
