### PR TITLE
[Feat/339] 라이엇 챔피언 정보 관련 수정 및 추가

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberChampion.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberChampion.java
@@ -42,6 +42,9 @@ public class MemberChampion extends BaseDateTimeEntity {
     @Column(nullable = false, columnDefinition = "double default 0.0")
     private double csPerMinute;
 
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int totalCs;
+
     @Column(nullable = false)
     private int kills;
 
@@ -58,12 +61,13 @@ public class MemberChampion extends BaseDateTimeEntity {
         return (double) (kills + assists) / deaths;
     }
 
-    public static MemberChampion create(Champion champion, Member member, int wins, int games, double csPerMinute, int kills, int deaths, int assists) {
+    public static MemberChampion create(Champion champion, Member member, int wins, int games, double csPerMinute, int totalCs, int kills, int deaths, int assists) {
         MemberChampion memberChampion = MemberChampion.builder()
                 .champion(champion)
                 .wins(wins)
                 .games(games)
                 .csPerMinute(csPerMinute)
+                .totalCs(totalCs)
                 .kills(kills)
                 .deaths(deaths)
                 .assists(assists)
@@ -73,12 +77,13 @@ public class MemberChampion extends BaseDateTimeEntity {
     }
 
     @Builder
-    private MemberChampion(Champion champion, Member member, int wins, int games, double csPerMinute, int kills, int deaths, int assists) {
+    private MemberChampion(Champion champion, Member member, int wins, int games, double csPerMinute, int totalCs, int kills, int deaths, int assists) {
         this.champion = champion;
         this.member = member;
         this.wins = wins;
         this.games = games;
         this.csPerMinute = csPerMinute;
+        this.totalCs = totalCs;
         this.kills = kills;
         this.deaths = deaths;
         this.assists = assists;

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberRecentStats.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberRecentStats.java
@@ -21,14 +21,20 @@ public class MemberRecentStats {
     private int recTotalLosses;
     private double recWinRate;
     private double recAvgKDA;
+    private double recAvgKills;
+    private double recAvgDeaths;
+    private double recAvgAssists;
     private double recAvgCsPerMinute;
     private int recTotalCs;
 
-    public void update(int recTotalWins, int recTotalLosses, double recWinRate, double recAvgKDA, double recAvgCsPerMinute, int recTotalCs) {
+    public void update(int recTotalWins, int recTotalLosses, double recWinRate, double recAvgKDA, double recAvgKills, double recAvgDeaths, double recAvgAssists, double recAvgCsPerMinute, int recTotalCs) {
         this.recTotalWins = recTotalWins;
         this.recTotalLosses = recTotalLosses;
         this.recWinRate = recWinRate;
         this.recAvgKDA = recAvgKDA;
+        this.recAvgKills = recAvgKills;
+        this.recAvgDeaths = recAvgDeaths;
+        this.recAvgAssists = recAvgAssists;
         this.recAvgCsPerMinute = recAvgCsPerMinute;
         this.recTotalCs = recTotalCs;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponse.java
@@ -11,6 +11,9 @@ public class MemberRecentStatsResponse {
     private int recTotalLosses;
     private double recWinRate;
     private double recAvgKDA;
+    private double recAvgKills;
+    private double recAvgDeaths;
+    private double recAvgAssists;
     private double recAvgCsPerMinute;
     private int recTotalCs;
 
@@ -24,6 +27,9 @@ public class MemberRecentStatsResponse {
                 memberRecentStats.getRecTotalLosses(),
                 memberRecentStats.getRecWinRate(),
                 memberRecentStats.getRecAvgKDA(),
+                memberRecentStats.getRecAvgKills(),
+                memberRecentStats.getRecAvgDeaths(),
+                memberRecentStats.getRecAvgAssists(),
                 memberRecentStats.getRecAvgCsPerMinute(),
                 memberRecentStats.getRecTotalCs()
         );

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/ChampionStatsRefreshService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/ChampionStatsRefreshService.java
@@ -46,6 +46,9 @@ public class ChampionStatsRefreshService {
             recStats.getRecTotalLosses(),
             recStats.getRecWinRate(),
             recStats.getRecAvgKDA(),
+            recStats.getRecAvgKills(),
+            recStats.getRecAvgDeaths(),
+            recStats.getRecAvgAssists(),
             recStats.getRecAvgCsPerMinute(),
             recStats.getRecTotalCs()
         );

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
@@ -32,7 +32,7 @@ public class MemberChampionService {
             // 챔피언이 존재하지 않으면 스킵
             championRepository.findById(championId).ifPresent(champion -> {
                 MemberChampion memberChampion = MemberChampion.create(champion, member, stats.getWins(),
-                        stats.getGames(), stats.getCsPerMinute(), stats.getKills(), stats.getDeaths(), stats.getAssists());
+                        stats.getGames(), stats.getCsPerMinute(), stats.getTotalCs(), stats.getKills(), stats.getDeaths(), stats.getAssists());
                 memberChampionRepository.save(memberChampion);
             });
         });

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
@@ -56,6 +56,9 @@ public class MemberFacadeService {
 
         // 프로필 접근 시 최근 전적 챔피언 정보 자동 갱신
         refreshChampionStatsIfNeeded(targetMember);
+        
+        // 업데이트된 데이터를 반영하기 위해 fresh entity 로딩
+        targetMember = memberService.findMemberById(targetMemberId);
 
         // 친구 정보 얻기
         boolean isFriend = friendService.isFriend(member, targetMember);

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/ChampionStatsResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/ChampionStatsResponse.java
@@ -16,10 +16,11 @@ public class ChampionStatsResponse {
     private int wins;            // 승 수
     private int games;           // 판 수
     private double csPerMinute;  // 분당 CS
+    private double averageCs;    // 평균 CS
     private double kda;          // KDA
-    private int kills;           // 킬
-    private int deaths;          // 데스
-    private int assists;         // 어시스트
+    private double kills;        // 평균 킬
+    private double deaths;       // 평균 데스
+    private double assists;      // 평균 어시스트
 
     public static ChampionStatsResponse from(ChampionStats stats, Champion champion) {
         return ChampionStatsResponse.builder()
@@ -29,10 +30,11 @@ public class ChampionStatsResponse {
                 .wins(stats.getWins())
                 .games(stats.getGames())
                 .csPerMinute(stats.getCsPerMinute())
+                .averageCs(stats.getGames() > 0 ? (double) stats.getTotalCs() / stats.getGames() : 0)
                 .kda(stats.getKDA())
-                .kills(stats.getKills())
-                .deaths(stats.getDeaths())
-                .assists(stats.getAssists())
+                .kills(stats.getGames() > 0 ? (double) stats.getKills() / stats.getGames() : 0)
+                .deaths(stats.getGames() > 0 ? (double) stats.getDeaths() / stats.getGames() : 0)
+                .assists(stats.getGames() > 0 ? (double) stats.getAssists() / stats.getGames() : 0)
                 .build();
     }
 
@@ -48,10 +50,11 @@ public class ChampionStatsResponse {
                 .wins(wins)
                 .games(games)
                 .csPerMinute(memberChampion.getCsPerMinute())
+                .averageCs(games > 0 ? (double) memberChampion.getTotalCs() / games : 0)
                 .kda(memberChampion.getKDA())
-                .kills(memberChampion.getKills())
-                .deaths(memberChampion.getDeaths())
-                .assists(memberChampion.getAssists())
+                .kills(games > 0 ? (double) memberChampion.getKills() / games : 0)
+                .deaths(games > 0 ? (double) memberChampion.getDeaths() / games : 0)
+                .assists(games > 0 ? (double) memberChampion.getAssists() / games : 0)
                 .build();
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/domain/ChampionStats.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/domain/ChampionStats.java
@@ -122,6 +122,10 @@ public class ChampionStats {
         return 0;
     }
 
+    public int getTotalCs() {
+        return totalMinionsKilled;
+    }
+
     public int getKills() {
         return kills;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/response/RiotMatchResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/response/RiotMatchResponse.java
@@ -34,6 +34,7 @@ public class RiotMatchResponse {
         private Long championId;
         private boolean win;
         private int totalMinionsKilled;
+        private int neutralMinionsKilled;
         private int kills;
         private int deaths;
         private int assists;

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
@@ -50,6 +50,9 @@ public class RiotRecordService {
         private int recTotalLosses;
         private double recWinRate;
         private double recAvgKDA;
+        private double recAvgKills;
+        private double recAvgDeaths;
+        private double recAvgAssists;
         private double recAvgCsPerMinute;
         private int recTotalCs;
     }
@@ -82,7 +85,7 @@ public class RiotRecordService {
      */
     private Map<Long, ChampionStats> fetchRecentChampionStats(String gameName, String puuid) {
         Map<Long, ChampionStats> championStatsMap = new HashMap<>();
-        
+
         List<String> matchIds = Optional.ofNullable(fetchMatchIds(puuid, 0, INITIAL_MATCH_COUNT))
                 .orElseGet(Collections::emptyList);
 
@@ -97,7 +100,7 @@ public class RiotRecordService {
                 }
             });
         }
-        
+
         return championStatsMap;
     }
 
@@ -157,9 +160,9 @@ public class RiotRecordService {
                     .map(participant -> {
                         ChampionStats stats = new ChampionStats(participant.getChampionId(), participant.isWin());
                         stats.setGameTime(finalGameDuration);
-                        // CS가 음수인 경우 0으로 설정
-                        int totalMinionsKilled = Math.max(0, participant.getTotalMinionsKilled());
-                        stats.setTotalMinionsKilled(totalMinionsKilled);
+                        // CS가 음수인 경우 0으로 설정 (미니언 + 정글몹)
+                        int totalCs = Math.max(0, participant.getTotalMinionsKilled() + participant.getNeutralMinionsKilled());
+                        stats.setTotalMinionsKilled(totalCs);
                         // KDA 정보 설정
                         stats.setKills(participant.getKills());
                         stats.setDeaths(participant.getDeaths());
@@ -211,8 +214,11 @@ public class RiotRecordService {
                 .recTotalLosses(totalLosses)
                 .recWinRate(recWinRate)
                 .recAvgKDA(recAvgKDA)
+                .recAvgKills((double) totalKills / totalGames)
+                .recAvgDeaths((double) totalDeaths / totalGames)
+                .recAvgAssists((double) totalAssists / totalGames)
                 .recAvgCsPerMinute(recAvgCsPerMinute)
-                .recTotalCs(totalCs)
+                .recTotalCs(totalCs/(totalWins+totalLosses))
                 .build();
     }
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponseTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponseTest.java
@@ -32,6 +32,9 @@ class MemberRecentStatsResponseTest {
             .recTotalLosses(15)
             .recWinRate(62.5)
             .recAvgKDA(2.5)
+            .recAvgKills(8.5)
+            .recAvgDeaths(3.2)
+            .recAvgAssists(9.1)
             .recAvgCsPerMinute(6.8)
             .recTotalCs(1360)
             .build();
@@ -45,6 +48,9 @@ class MemberRecentStatsResponseTest {
         assertThat(response.getRecTotalLosses()).isEqualTo(15);
         assertThat(response.getRecWinRate()).isEqualTo(62.5);
         assertThat(response.getRecAvgKDA()).isEqualTo(2.5);
+        assertThat(response.getRecAvgKills()).isEqualTo(8.5);
+        assertThat(response.getRecAvgDeaths()).isEqualTo(3.2);
+        assertThat(response.getRecAvgAssists()).isEqualTo(9.1);
         assertThat(response.getRecAvgCsPerMinute()).isEqualTo(6.8);
         assertThat(response.getRecTotalCs()).isEqualTo(1360);
     }
@@ -61,6 +67,9 @@ class MemberRecentStatsResponseTest {
             .recTotalLosses(0)
             .recWinRate(0.0)
             .recAvgKDA(0.0)
+            .recAvgKills(0.0)
+            .recAvgDeaths(0.0)
+            .recAvgAssists(0.0)
             .recAvgCsPerMinute(0.0)
             .recTotalCs(0)
             .build();
@@ -74,6 +83,9 @@ class MemberRecentStatsResponseTest {
         assertThat(response.getRecTotalLosses()).isEqualTo(0);
         assertThat(response.getRecWinRate()).isEqualTo(0.0);
         assertThat(response.getRecAvgKDA()).isEqualTo(0.0);
+        assertThat(response.getRecAvgKills()).isEqualTo(0.0);
+        assertThat(response.getRecAvgDeaths()).isEqualTo(0.0);
+        assertThat(response.getRecAvgAssists()).isEqualTo(0.0);
         assertThat(response.getRecAvgCsPerMinute()).isEqualTo(0.0);
         assertThat(response.getRecTotalCs()).isEqualTo(0);
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordServiceTest.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.external.riot.service;
 
 import com.gamegoo.gamegoo_v2.external.riot.domain.ChampionStats;
 import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotMatchResponse;
+import com.gamegoo.gamegoo_v2.external.riot.service.RiotRecordService.Recent30GameStatsResponse;
 import com.gamegoo.gamegoo_v2.utils.RiotApiHelper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,7 @@ class RiotRecordServiceTest {
                 .deaths(2)
                 .assists(15)
                 .totalMinionsKilled(200)
+                .neutralMinionsKilled(30)
                 .build();
 
         RiotMatchResponse.InfoDTO info = RiotMatchResponse.InfoDTO.builder()
@@ -106,6 +108,7 @@ class RiotRecordServiceTest {
                 .deaths(0)
                 .assists(10)
                 .totalMinionsKilled(150)
+                .neutralMinionsKilled(25)
                 .build();
 
         RiotMatchResponse.InfoDTO info = RiotMatchResponse.InfoDTO.builder()
@@ -155,6 +158,8 @@ class RiotRecordServiceTest {
                 .kills(8)
                 .deaths(3)
                 .assists(12)
+                .totalMinionsKilled(180)
+                .neutralMinionsKilled(20)
                 .build();
 
         RiotMatchResponse.InfoDTO info1 = RiotMatchResponse.InfoDTO.builder()
@@ -175,6 +180,8 @@ class RiotRecordServiceTest {
                 .kills(6)
                 .deaths(2)
                 .assists(10)
+                .totalMinionsKilled(160)
+                .neutralMinionsKilled(15)
                 .build();
 
         RiotMatchResponse.InfoDTO info2 = RiotMatchResponse.InfoDTO.builder()
@@ -201,5 +208,116 @@ class RiotRecordServiceTest {
         assertThat(stats.getDeaths()).isEqualTo(5); // 3 + 2
         assertThat(stats.getAssists()).isEqualTo(22); // 12 + 10
         assertThat(stats.getKDA()).isEqualTo(7.2); // (14 + 22) / 5
+    }
+
+    @Test
+    @DisplayName("최근 30게임 통계에서 평균 KDA 개별값이 double로 정확히 계산된다")
+    void calculateRecent30GameStatsWithDoubleAverage() {
+        // given
+        String puuid = "test-puuid";
+        String gameName = "testUser";
+        String[] matchIds = {"match-1", "match-2", "match-3"};
+        
+        ReflectionTestUtils.setField(riotRecordService, "riotAPIKey", "test-api-key");
+
+        when(restTemplate.getForObject(any(String.class), eq(String[].class)))
+                .thenReturn(matchIds);
+
+        // 첫 번째 게임: 11킬, 3데스, 7어시스트
+        RiotMatchResponse.ParticipantDTO participant1 = createParticipant(gameName, 11, 3, 7, true);
+        RiotMatchResponse match1 = createMatchResponse(participant1);
+        
+        // 두 번째 게임: 5킬, 4데스, 8어시스트  
+        RiotMatchResponse.ParticipantDTO participant2 = createParticipant(gameName, 5, 4, 8, false);
+        RiotMatchResponse match2 = createMatchResponse(participant2);
+        
+        // 세 번째 게임: 8킬, 2데스, 12어시스트
+        RiotMatchResponse.ParticipantDTO participant3 = createParticipant(gameName, 8, 2, 12, true);
+        RiotMatchResponse match3 = createMatchResponse(participant3);
+
+        when(restTemplate.getForObject(any(String.class), eq(RiotMatchResponse.class)))
+                .thenReturn(match1)
+                .thenReturn(match2)
+                .thenReturn(match3);
+
+        // when
+        Recent30GameStatsResponse result = riotRecordService.getRecent30GameStats(gameName, puuid);
+
+        // then
+        assertThat(result).isNotNull();
+        
+        // 총합: 24킬, 9데스, 27어시스트, 3게임
+        // 평균: 8.0킬, 3.0데스, 9.0어시스트
+        assertThat(result.getRecAvgKills()).isEqualTo(8.0); // 24 / 3 = 8.0
+        assertThat(result.getRecAvgDeaths()).isEqualTo(3.0); // 9 / 3 = 3.0
+        assertThat(result.getRecAvgAssists()).isEqualTo(9.0); // 27 / 3 = 9.0
+        
+        // 소수점 계산 확인을 위한 추가 테스트
+        assertThat(result.getRecAvgKills()).isInstanceOf(Double.class);
+        assertThat(result.getRecAvgDeaths()).isInstanceOf(Double.class);
+        assertThat(result.getRecAvgAssists()).isInstanceOf(Double.class);
+    }
+
+    @Test
+    @DisplayName("최근 30게임 통계에서 소수점이 있는 평균 KDA가 정확히 계산된다")
+    void calculateRecent30GameStatsWithDecimalAverage() {
+        // given
+        String puuid = "test-puuid";
+        String gameName = "testUser";
+        String[] matchIds = {"match-1", "match-2"};
+        
+        ReflectionTestUtils.setField(riotRecordService, "riotAPIKey", "test-api-key");
+
+        when(restTemplate.getForObject(any(String.class), eq(String[].class)))
+                .thenReturn(matchIds);
+
+        // 첫 번째 게임: 7킬, 2데스, 5어시스트
+        RiotMatchResponse.ParticipantDTO participant1 = createParticipant(gameName, 7, 2, 5, true);
+        RiotMatchResponse match1 = createMatchResponse(participant1);
+        
+        // 두 번째 게임: 4킬, 1데스, 3어시스트
+        RiotMatchResponse.ParticipantDTO participant2 = createParticipant(gameName, 4, 1, 3, false);
+        RiotMatchResponse match2 = createMatchResponse(participant2);
+
+        when(restTemplate.getForObject(any(String.class), eq(RiotMatchResponse.class)))
+                .thenReturn(match1)
+                .thenReturn(match2);
+
+        // when
+        Recent30GameStatsResponse result = riotRecordService.getRecent30GameStats(gameName, puuid);
+
+        // then
+        assertThat(result).isNotNull();
+        
+        // 총합: 11킬, 3데스, 8어시스트, 2게임
+        // 평균: 5.5킬, 1.5데스, 4.0어시스트 (소수점 확인)
+        assertThat(result.getRecAvgKills()).isEqualTo(5.5); // 11 / 2 = 5.5
+        assertThat(result.getRecAvgDeaths()).isEqualTo(1.5); // 3 / 2 = 1.5
+        assertThat(result.getRecAvgAssists()).isEqualTo(4.0); // 8 / 2 = 4.0
+    }
+
+    private RiotMatchResponse.ParticipantDTO createParticipant(String gameName, int kills, int deaths, int assists, boolean win) {
+        return RiotMatchResponse.ParticipantDTO.builder()
+                .riotIdGameName(gameName)
+                .championId(1L)
+                .win(win)
+                .kills(kills)
+                .deaths(deaths)
+                .assists(assists)
+                .totalMinionsKilled(150)
+                .neutralMinionsKilled(20)
+                .build();
+    }
+
+    private RiotMatchResponse createMatchResponse(RiotMatchResponse.ParticipantDTO participant) {
+        RiotMatchResponse.InfoDTO info = RiotMatchResponse.InfoDTO.builder()
+                .participants(Arrays.asList(participant))
+                .gameDuration(1800)
+                .queueId(420)
+                .build();
+
+        return RiotMatchResponse.builder()
+                .info(info)
+                .build();
     }
 } 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -163,10 +163,11 @@ class MemberServiceFacadeTest {
             assertThat(championResponse.getGames()).isEqualTo(memberChampion.getGames());
             assertThat(championResponse.getWinRate()).isEqualTo(memberChampion.getWins() / (double) memberChampion.getGames());
             assertThat(championResponse.getCsPerMinute()).isEqualTo(memberChampion.getCsPerMinute());
+            assertThat(championResponse.getAverageCs()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getTotalCs() / memberChampion.getGames() : 0);
             assertThat(championResponse.getKda()).isEqualTo(memberChampion.getKDA());
-            assertThat(championResponse.getKills()).isEqualTo(memberChampion.getKills());
-            assertThat(championResponse.getDeaths()).isEqualTo(memberChampion.getDeaths());
-            assertThat(championResponse.getAssists()).isEqualTo(memberChampion.getAssists());
+            assertThat(championResponse.getKills()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getKills() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getDeaths()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getDeaths() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getAssists()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getAssists() / memberChampion.getGames() : 0);
         }
     }
 
@@ -229,10 +230,11 @@ class MemberServiceFacadeTest {
             assertThat(championResponse.getGames()).isEqualTo(memberChampion.getGames());
             assertThat(championResponse.getWinRate()).isEqualTo(memberChampion.getWins() / (double) memberChampion.getGames());
             assertThat(championResponse.getCsPerMinute()).isEqualTo(memberChampion.getCsPerMinute());
+            assertThat(championResponse.getAverageCs()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getTotalCs() / memberChampion.getGames() : 0);
             assertThat(championResponse.getKda()).isEqualTo(memberChampion.getKDA());
-            assertThat(championResponse.getKills()).isEqualTo(memberChampion.getKills());
-            assertThat(championResponse.getDeaths()).isEqualTo(memberChampion.getDeaths());
-            assertThat(championResponse.getAssists()).isEqualTo(memberChampion.getAssists());
+            assertThat(championResponse.getKills()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getKills() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getDeaths()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getDeaths() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getAssists()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getAssists() / memberChampion.getGames() : 0);
         }
     }
 
@@ -425,7 +427,7 @@ class MemberServiceFacadeTest {
     private void initMemberChampion(Member member, List<Long> top3ChampionIds) {
         top3ChampionIds.forEach(championId -> {
             championRepository.findById(championId).ifPresent(champion -> {
-                MemberChampion memberChampion = MemberChampion.create(champion, member, 1, 10, 12, 0, 0, 0);
+                MemberChampion memberChampion = MemberChampion.create(champion, member, 1, 10, 12.0, 120, 0, 0, 0);
                 memberChampionRepository.save(memberChampion);
             });
         });
@@ -442,6 +444,9 @@ class MemberServiceFacadeTest {
             .recTotalLosses(15)
             .recWinRate(62.5)
             .recAvgKDA(2.5)
+            .recAvgKills(8.5)
+            .recAvgDeaths(3.2)
+            .recAvgAssists(9.1)
             .recAvgCsPerMinute(6.8)
             .recTotalCs(1360)
             .build();


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 라이엇 챔피언 정보 관련 수정 및 추가

## ⏳ 작업 상세 내용

- [x] 다른 사람 프로필 조회 시 전적 갱신 버그 수정
- [x] 정글러 cs 계산 시 정글몹은 계산 안하고 미니언 킬만 계산하던 로직 수정
- [x] Total cs 반환 시 판당 평균 cs가 아닌 전체 cs를 제공하던 로직 수정
- [x] 최근 30게임의 kill, death, assist 필드 추가
- [x] 각 챔피언의 kill, death, assist 계산 방식 개선
- [x] 테스트 코드 업데이트

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->


- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
