### PR TITLE
[Fix/343] 서버에 에러 발생 시, COMMON 401 대신 500 나오도록 변경

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/EntryPointHandler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/EntryPointHandler.java
@@ -18,7 +18,7 @@ import static com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode._INTERNAL_S
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class EntryPointUnauthorizedHandler implements AuthenticationEntryPoint {
+public class EntryPointHandler implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -3,7 +3,7 @@ package com.gamegoo.gamegoo_v2.core.config;
 import com.gamegoo.gamegoo_v2.account.auth.jwt.JwtProvider;
 import com.gamegoo.gamegoo_v2.account.auth.security.CustomAccessDeniedHandler;
 import com.gamegoo.gamegoo_v2.account.auth.security.CustomUserDetailsService;
-import com.gamegoo.gamegoo_v2.account.auth.security.EntryPointUnauthorizedHandler;
+import com.gamegoo.gamegoo_v2.account.auth.security.EntryPointHandler;
 import com.gamegoo.gamegoo_v2.account.auth.security.JwtAuthFilter;
 import com.gamegoo.gamegoo_v2.account.auth.security.JwtAuthenticationExceptionHandler;
 import com.gamegoo.gamegoo_v2.core.log.LoggingFilter;
@@ -38,7 +38,7 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService customUserDetailsService;
     private final CustomAccessDeniedHandler accessDeniedHandler;
-    private final EntryPointUnauthorizedHandler unauthorizedHandler;
+    private final EntryPointHandler unauthorizedHandler;
     private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler;
     private final LoggingFilter loggingFilter;
     private final SecurityJwtProperties securityJwtProperties;


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 서버에 에러 발생 시, COMMON 401 대신 500 나오도록 변경

## ⏳ 작업 상세 내용

- [x] EntryPointUnauthorizedHandler 에서 401 대신 무조건 500이 나오도록 변경

의도적으로 서버에 에러를 발생시켜서 확인했다. Spring security Filter는 예외가 발생한 상황에서 Context를 비우고 다시 Filter를 거친다. 초반에는 jwt 토큰이 있는 상태이고, 올바르게 인증이 완료되었다고 해도 Spring Security는 예외가 발생한 시점에서 인증 상태를 다시 검사하기 때문에, 요청 초반만이 아니라, 언제든 인증 정보가 없으면 작동할 수 있는 것이었다. 그런데 Spring Security는 예외가 발생한 시점에서 Security Context를 지운다. 그래서 사용자 정보가 없기 때문에 401 에러가 발생하는 것이었다. 

기존 SecurityConfig의 ExceptionFilter에 적용시켰던 EntryPointUnauthorizedHandler를 수정했다. EntryPointUnauthorizedHandler 가 실행되는 경우에는 항상 /error request가 실행되는 것을 디버깅을 통해 확인했다. EntryPointUnauthorizedHandler의 commence 메소드 실행 시 매개변수로 있는 request를 확인하니 /error 였다. 그래서 auth 관련 에러가 아니라 항상 서버 에러가 발생했을 때 이 페이지로 가는 것 같아서 그냥 무조건 Internel server error를 발생시키도록 했다.

원래 이름이 Unauthorized가 있었는데 이것도 unauthorized 일 때만 발생하는 필터가 아니기 때문에 네이밍이 적절하지 않은 것 같아서 뺐다.



Spring Security 구조상

1. 컨트롤러 내부에서 RuntimeException이 발생하면

2. ExceptionTranslationFilter가 이 예외를 잡고

3. 그 시점에서 SecurityContextHolder.getContext().getAuthenticatino()이 null 또는 anonymous라면

4. Spring은 이를 인증 실패로 간주하고 -> AuthenticationEntryPoint.commence()를 호출한다.


## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
