### PR TITLE
[Fix/348]puuid 재사용 및 라이엇 api 호출 실패 시 롤백 처리

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -139,6 +139,9 @@ public class Member extends BaseDateTimeEntity {
 
     private java.time.LocalDateTime banExpireAt;
 
+    @Column(name = "champion_stats_refreshed_at")
+    private java.time.LocalDateTime championStatsRefreshedAt;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private Role role = Role.MEMBER;
@@ -276,6 +279,10 @@ public class Member extends BaseDateTimeEntity {
 
     public void updateRole(Role role) {
         this.role = role;
+    }
+
+    public void updateChampionStatsRefreshedAt() {
+        this.championStatsRefreshedAt = java.time.LocalDateTime.now();
     }
 
     public boolean isBanned() {

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
@@ -81,8 +81,8 @@ public class MemberFacadeService {
      * @param member 갱신 대상 사용자
      */
     private void refreshChampionStatsIfNeeded(Member member) {
-        // 마지막 갱신 시간 체크 (5분마다 갱신)
-        LocalDateTime lastRefreshTime = member.getUpdatedAt();
+        // 마지막 챔피언 통계 갱신 시간 체크 (5분마다 갱신)
+        LocalDateTime lastRefreshTime = member.getChampionStatsRefreshedAt();
         LocalDateTime now = LocalDateTime.now();
 
         // 5분 이상 지났거나, 처음 접근하는 경우 갱신
@@ -90,6 +90,8 @@ public class MemberFacadeService {
             ChronoUnit.MINUTES.between(lastRefreshTime, now) >= 5) {
             try {
                 championStatsRefreshService.refreshChampionStats(member);
+                // 갱신 성공 시에만 시간 업데이트
+                member.updateChampionStatsRefreshedAt();
             } catch (Exception e) {
                 // 갱신에 실패하더라도 프로필 조회는 정상적으로 진행되어야 하므로,
                 // 트랜잭션을 분리하고 예외를 전파하지 않습니다.

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberFacadeService.java
@@ -40,7 +40,10 @@ public class MemberFacadeService {
     public MyProfileResponse getMyProfile(Member member) {
         // 프로필 접근 시 최근 전적 챔피언 정보 자동 갱신
         refreshChampionStatsIfNeeded(member);
-        return MyProfileResponse.of(member);
+        
+        // 업데이트된 데이터를 반영하기 위해 fresh entity 로딩
+        Member freshMember = memberService.findMemberById(member.getId());
+        return MyProfileResponse.of(freshMember);
     }
 
     /**

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/member/ChampionStatsRefreshServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/member/ChampionStatsRefreshServiceTest.java
@@ -1,0 +1,276 @@
+package com.gamegoo.gamegoo_v2.service.member;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberChampionRepository;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
+import com.gamegoo.gamegoo_v2.account.member.service.ChampionStatsRefreshService;
+import com.gamegoo.gamegoo_v2.account.member.service.MemberChampionService;
+import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
+import com.gamegoo.gamegoo_v2.external.riot.domain.ChampionStats;
+import com.gamegoo.gamegoo_v2.external.riot.service.RiotAuthService;
+import com.gamegoo.gamegoo_v2.external.riot.service.RiotRecordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChampionStatsRefreshServiceTest {
+
+    @InjectMocks
+    private ChampionStatsRefreshService championStatsRefreshService;
+
+    @Mock
+    private RiotAuthService riotAuthService;
+
+    @Mock
+    private MemberChampionService memberChampionService;
+
+    @Mock
+    private MemberChampionRepository memberChampionRepository;
+
+    @Mock
+    private RiotRecordService riotRecordService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
+    private Member testMemberWithPuuid;
+    private Member testMemberWithoutPuuid;
+    private List<ChampionStats> mockChampionStats;
+    private RiotRecordService.Recent30GameStatsResponse mockRecentStats;
+    private MemberRecentStats mockMemberRecentStats;
+
+    @BeforeEach
+    void setUp() {
+        // Member with puuid
+        testMemberWithPuuid = mock(Member.class);
+        when(testMemberWithPuuid.getId()).thenReturn(1L);
+        when(testMemberWithPuuid.getGameName()).thenReturn("TestUser");
+        when(testMemberWithPuuid.getTag()).thenReturn("KR1");
+        when(testMemberWithPuuid.getPuuid()).thenReturn("test-puuid-123");
+
+        // Member without puuid
+        testMemberWithoutPuuid = mock(Member.class);
+        when(testMemberWithoutPuuid.getId()).thenReturn(2L);
+        when(testMemberWithoutPuuid.getGameName()).thenReturn("TestUser2");
+        when(testMemberWithoutPuuid.getTag()).thenReturn("KR1");
+        when(testMemberWithoutPuuid.getPuuid()).thenReturn(null);
+
+        // Mock ChampionStats
+        mockChampionStats = Arrays.asList(
+                createChampionStats(1L, true, 10, 5, 3, 150),
+                createChampionStats(2L, false, 8, 7, 12, 120)
+        );
+
+        // Mock Recent30GameStatsResponse
+        mockRecentStats = RiotRecordService.Recent30GameStatsResponse.builder()
+                .recTotalWins(18)
+                .recTotalLosses(12)
+                .recWinRate(60.0)
+                .recAvgKDA(2.5)
+                .recAvgKills(8.5)
+                .recAvgDeaths(5.2)
+                .recAvgAssists(10.3)
+                .recAvgCsPerMinute(6.5)
+                .recTotalCs(150)
+                .build();
+
+        // Mock MemberRecentStats
+        mockMemberRecentStats = mock(MemberRecentStats.class);
+    }
+
+    @Test
+    @DisplayName("puuid가 있는 멤버의 챔피언 통계 갱신 성공 - API 호출 없이 캐시된 puuid 사용")
+    void refreshChampionStats_WithPuuid_Success() {
+        // Given
+        given(memberService.findMemberById(1L)).willReturn(testMemberWithPuuid);
+        given(riotRecordService.getPreferChampionfromMatch("TestUser", "test-puuid-123"))
+                .willReturn(mockChampionStats);
+        given(riotRecordService.getRecent30GameStats("TestUser", "test-puuid-123"))
+                .willReturn(mockRecentStats);
+        given(memberRecentStatsRepository.findById(1L))
+                .willReturn(Optional.of(mockMemberRecentStats));
+
+        // When
+        assertDoesNotThrow(() -> championStatsRefreshService.refreshChampionStats(testMemberWithPuuid));
+
+        // Then
+        verify(memberService).findMemberById(1L);
+        verify(riotAuthService, never()).getPuuid(anyString(), anyString()); // puuid 캐시 확인
+        verify(riotRecordService).getPreferChampionfromMatch("TestUser", "test-puuid-123");
+        verify(riotRecordService).getRecent30GameStats("TestUser", "test-puuid-123");
+        verify(memberChampionRepository).deleteByMember(testMemberWithPuuid);
+        verify(memberChampionService).saveMemberChampions(testMemberWithPuuid, mockChampionStats);
+        verify(memberRecentStatsRepository).save(any(MemberRecentStats.class));
+    }
+
+    @Test
+    @DisplayName("puuid가 없는 멤버의 챔피언 통계 갱신 성공 - API 호출로 puuid 조회")
+    void refreshChampionStats_WithoutPuuid_Success() {
+        // Given
+        given(memberService.findMemberById(2L)).willReturn(testMemberWithoutPuuid);
+        given(riotAuthService.getPuuid("TestUser2", "KR1")).willReturn("fetched-puuid-123");
+        given(riotRecordService.getPreferChampionfromMatch("TestUser2", "fetched-puuid-123"))
+                .willReturn(mockChampionStats);
+        given(riotRecordService.getRecent30GameStats("TestUser2", "fetched-puuid-123"))
+                .willReturn(mockRecentStats);
+        given(memberRecentStatsRepository.findById(2L))
+                .willReturn(Optional.of(mockMemberRecentStats));
+
+        // When
+        assertDoesNotThrow(() -> championStatsRefreshService.refreshChampionStats(testMemberWithoutPuuid));
+
+        // Then
+        verify(memberService).findMemberById(2L);
+        verify(riotAuthService).getPuuid("TestUser2", "KR1");
+        verify(riotRecordService).getPreferChampionfromMatch("TestUser2", "fetched-puuid-123");
+        verify(riotRecordService).getRecent30GameStats("TestUser2", "fetched-puuid-123");
+        verify(memberChampionRepository).deleteByMember(testMemberWithoutPuuid);
+        verify(memberChampionService).saveMemberChampions(testMemberWithoutPuuid, mockChampionStats);
+        verify(memberRecentStatsRepository).save(any(MemberRecentStats.class));
+    }
+
+    @Test
+    @DisplayName("신규 멤버 최근 통계 생성 성공")
+    void refreshChampionStats_NewMemberRecentStats_Success() {
+        // Given
+        given(memberService.findMemberById(1L)).willReturn(testMemberWithPuuid);
+        given(riotRecordService.getPreferChampionfromMatch("TestUser", "test-puuid-123"))
+                .willReturn(mockChampionStats);
+        given(riotRecordService.getRecent30GameStats("TestUser", "test-puuid-123"))
+                .willReturn(mockRecentStats);
+        given(memberRecentStatsRepository.findById(1L))
+                .willReturn(Optional.empty()); // 신규 멤버
+
+        // When
+        assertDoesNotThrow(() -> championStatsRefreshService.refreshChampionStats(testMemberWithPuuid));
+
+        // Then
+        verify(memberService).findMemberById(1L);
+        verify(riotRecordService).getPreferChampionfromMatch("TestUser", "test-puuid-123");
+        verify(riotRecordService).getRecent30GameStats("TestUser", "test-puuid-123");
+        verify(memberChampionRepository).deleteByMember(testMemberWithPuuid);
+        verify(memberChampionService).saveMemberChampions(testMemberWithPuuid, mockChampionStats);
+        verify(memberRecentStatsRepository).save(any(MemberRecentStats.class));
+    }
+
+    @Test
+    @DisplayName("선호 챔피언 조회 실패 시 롤백 - 기존 데이터 유지")
+    void refreshChampionStats_PreferChampionsFetchFails_Rollback() {
+        // Given
+        given(memberService.findMemberById(1L)).willReturn(testMemberWithPuuid);
+        given(riotRecordService.getPreferChampionfromMatch("TestUser", "test-puuid-123"))
+                .willThrow(new RuntimeException("Riot API 호출 실패"));
+
+        // When & Then
+        RuntimeException exception = assertThrows(RuntimeException.class, 
+                () -> championStatsRefreshService.refreshChampionStats(testMemberWithPuuid));
+        
+        assertTrue(exception.getMessage().contains("Riot API 호출 실패로 인한 챔피언 통계 업데이트 실패"));
+        
+        // 기존 데이터 삭제가 호출되지 않았는지 확인 (롤백)
+        verify(memberChampionRepository, never()).deleteByMember(any(Member.class));
+        verify(memberChampionService, never()).saveMemberChampions(any(Member.class), anyList());
+        verify(memberRecentStatsRepository, never()).save(any(MemberRecentStats.class));
+    }
+
+    @Test
+    @DisplayName("최근 30게임 통계 조회 실패 시 롤백 - 기존 데이터 유지")
+    void refreshChampionStats_RecentStatsFetchFails_Rollback() {
+        // Given
+        given(memberService.findMemberById(1L)).willReturn(testMemberWithPuuid);
+        given(riotRecordService.getPreferChampionfromMatch("TestUser", "test-puuid-123"))
+                .willReturn(mockChampionStats);
+        given(riotRecordService.getRecent30GameStats("TestUser", "test-puuid-123"))
+                .willThrow(new RuntimeException("Riot API 호출 실패"));
+
+        // When & Then
+        RuntimeException exception = assertThrows(RuntimeException.class, 
+                () -> championStatsRefreshService.refreshChampionStats(testMemberWithPuuid));
+        
+        assertTrue(exception.getMessage().contains("Riot API 호출 실패로 인한 챔피언 통계 업데이트 실패"));
+        
+        // 기존 데이터 삭제가 호출되지 않았는지 확인 (롤백)
+        verify(memberChampionRepository, never()).deleteByMember(any(Member.class));
+        verify(memberChampionService, never()).saveMemberChampions(any(Member.class), anyList());
+        verify(memberRecentStatsRepository, never()).save(any(MemberRecentStats.class));
+    }
+
+    @Test
+    @DisplayName("puuid 조회 실패 시 예외 발생")
+    void refreshChampionStats_PuuidFetchFails_ThrowsException() {
+        // Given
+        given(memberService.findMemberById(2L)).willReturn(testMemberWithoutPuuid);
+        given(riotAuthService.getPuuid("TestUser2", "KR1"))
+                .willThrow(new RuntimeException("Riot API 호출 실패"));
+
+        // When & Then
+        RuntimeException exception = assertThrows(RuntimeException.class, 
+                () -> championStatsRefreshService.refreshChampionStats(testMemberWithoutPuuid));
+        
+        assertNotNull(exception.getMessage());
+        
+        // 기존 데이터 삭제가 호출되지 않았는지 확인 (롤백)
+        verify(memberChampionRepository, never()).deleteByMember(any(Member.class));
+        verify(memberChampionService, never()).saveMemberChampions(any(Member.class), anyList());
+        verify(memberRecentStatsRepository, never()).save(any(MemberRecentStats.class));
+    }
+
+    @Test
+    @DisplayName("데이터 저장 중 실패 시 트랜잭션 롤백")
+    void refreshChampionStats_SaveFails_TransactionRollback() {
+        // Given
+        given(memberService.findMemberById(1L)).willReturn(testMemberWithPuuid);
+        given(riotRecordService.getPreferChampionfromMatch("TestUser", "test-puuid-123"))
+                .willReturn(mockChampionStats);
+        given(riotRecordService.getRecent30GameStats("TestUser", "test-puuid-123"))
+                .willReturn(mockRecentStats);
+        given(memberRecentStatsRepository.findById(1L))
+                .willReturn(Optional.of(mockMemberRecentStats));
+        doThrow(new RuntimeException("DB 저장 실패"))
+                .when(memberRecentStatsRepository).save(any(MemberRecentStats.class));
+
+        // When & Then
+        RuntimeException exception = assertThrows(RuntimeException.class, 
+                () -> championStatsRefreshService.refreshChampionStats(testMemberWithPuuid));
+        
+        assertTrue(exception.getMessage().contains("Riot API 호출 실패로 인한 챔피언 통계 업데이트 실패"));
+        
+        // API 호출은 성공했지만 저장에서 실패한 경우
+        verify(memberChampionRepository).deleteByMember(testMemberWithPuuid);
+        verify(memberChampionService).saveMemberChampions(testMemberWithPuuid, mockChampionStats);
+        verify(memberRecentStatsRepository).save(any(MemberRecentStats.class));
+    }
+
+    private ChampionStats createChampionStats(Long championId, boolean win, int kills, int deaths, int assists, int cs) {
+        ChampionStats stats = new ChampionStats(championId, win);
+        stats.setKills(kills);
+        stats.setDeaths(deaths);
+        stats.setAssists(assists);
+        stats.setTotalMinionsKilled(cs);
+        stats.setGameTime(1800); // 30분
+        return stats;
+    }
+}

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/member/MemberFacadeServiceRefreshTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/member/MemberFacadeServiceRefreshTest.java
@@ -57,7 +57,7 @@ class MemberFacadeServiceRefreshTest {
         when(testMember.getId()).thenReturn(1L);
         when(testMember.getGameName()).thenReturn("TestUser");
         when(testMember.getTag()).thenReturn("KR1");
-        when(testMember.getUpdatedAt()).thenReturn(LocalDateTime.now().minusMinutes(10)); // 10분 전 (갱신 필요)
+        when(testMember.getChampionStatsRefreshedAt()).thenReturn(LocalDateTime.now().minusMinutes(10)); // 10분 전 (갱신 필요)
 
         // Updated member
         updatedMember = mock(Member.class);
@@ -71,7 +71,7 @@ class MemberFacadeServiceRefreshTest {
         when(targetMember.getId()).thenReturn(2L);
         when(targetMember.getGameName()).thenReturn("TargetUser");
         when(targetMember.getTag()).thenReturn("KR1");
-        when(targetMember.getUpdatedAt()).thenReturn(LocalDateTime.now().minusMinutes(6)); // 6분 전 (갱신 필요)
+        when(targetMember.getChampionStatsRefreshedAt()).thenReturn(LocalDateTime.now().minusMinutes(6)); // 6분 전 (갱신 필요)
 
         // Updated target member
         updatedTargetMember = mock(Member.class);
@@ -161,7 +161,7 @@ class MemberFacadeServiceRefreshTest {
         // Given
         Member recentlyUpdatedMember = mock(Member.class);
         when(recentlyUpdatedMember.getId()).thenReturn(1L);
-        when(recentlyUpdatedMember.getUpdatedAt()).thenReturn(LocalDateTime.now().minusMinutes(2)); // 2분 전 (갱신 불필요)
+        when(recentlyUpdatedMember.getChampionStatsRefreshedAt()).thenReturn(LocalDateTime.now().minusMinutes(2)); // 2분 전 (갱신 불필요)
 
         given(memberService.findMemberById(1L)).willReturn(updatedMember);
 
@@ -175,20 +175,20 @@ class MemberFacadeServiceRefreshTest {
     }
 
     @Test
-    @DisplayName("updatedAt이 null인 멤버는 항상 챔피언 통계 갱신 수행")
-    void getMyProfile_AlwaysRefreshesWhenUpdatedAtIsNull() {
+    @DisplayName("championStatsRefreshedAt이 null인 멤버는 항상 챔피언 통계 갱신 수행")
+    void getMyProfile_AlwaysRefreshesWhenChampionStatsRefreshedAtIsNull() {
         // Given
-        Member memberWithNullUpdatedAt = mock(Member.class);
-        when(memberWithNullUpdatedAt.getId()).thenReturn(1L);
-        when(memberWithNullUpdatedAt.getUpdatedAt()).thenReturn(null); // null인 경우
+        Member memberWithNullChampionStatsRefreshedAt = mock(Member.class);
+        when(memberWithNullChampionStatsRefreshedAt.getId()).thenReturn(1L);
+        when(memberWithNullChampionStatsRefreshedAt.getChampionStatsRefreshedAt()).thenReturn(null); // null인 경우
 
         given(memberService.findMemberById(1L)).willReturn(updatedMember);
 
         // When
-        MyProfileResponse result = memberFacadeService.getMyProfile(memberWithNullUpdatedAt);
+        MyProfileResponse result = memberFacadeService.getMyProfile(memberWithNullChampionStatsRefreshedAt);
 
         // Then
-        verify(championStatsRefreshService).refreshChampionStats(memberWithNullUpdatedAt); // null이면 항상 갱신
+        verify(championStatsRefreshService).refreshChampionStats(memberWithNullChampionStatsRefreshedAt); // null이면 항상 갱신
         verify(memberService).findMemberById(1L); // fresh entity 로딩 확인
         assertNotNull(result);
     }

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/member/MemberFacadeServiceRefreshTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/member/MemberFacadeServiceRefreshTest.java
@@ -1,0 +1,246 @@
+package com.gamegoo.gamegoo_v2.service.member;
+
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
+import com.gamegoo.gamegoo_v2.account.member.dto.response.MyProfileResponse;
+import com.gamegoo.gamegoo_v2.account.member.dto.response.OtherProfileResponse;
+import com.gamegoo.gamegoo_v2.account.member.service.ChampionStatsRefreshService;
+import com.gamegoo.gamegoo_v2.account.member.service.MemberFacadeService;
+import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
+import com.gamegoo.gamegoo_v2.social.block.service.BlockService;
+import com.gamegoo.gamegoo_v2.social.friend.service.FriendService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MemberFacadeServiceRefreshTest {
+
+    @InjectMocks
+    private MemberFacadeService memberFacadeService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private FriendService friendService;
+
+    @Mock
+    private BlockService blockService;
+
+    @Mock
+    private ChampionStatsRefreshService championStatsRefreshService;
+
+    private Member testMember;
+    private Member updatedMember;
+    private Member targetMember;
+    private Member updatedTargetMember;
+
+    @BeforeEach
+    void setUp() {
+        // Original member
+        testMember = mock(Member.class);
+        when(testMember.getId()).thenReturn(1L);
+        when(testMember.getGameName()).thenReturn("TestUser");
+        when(testMember.getTag()).thenReturn("KR1");
+        when(testMember.getUpdatedAt()).thenReturn(LocalDateTime.now().minusMinutes(10)); // 10분 전 (갱신 필요)
+
+        // Updated member
+        updatedMember = mock(Member.class);
+        when(updatedMember.getId()).thenReturn(1L);
+        when(updatedMember.getGameName()).thenReturn("TestUser");
+        when(updatedMember.getTag()).thenReturn("KR1");
+        when(updatedMember.getUpdatedAt()).thenReturn(LocalDateTime.now()); // 방금 갱신됨
+
+        // Target member
+        targetMember = mock(Member.class);
+        when(targetMember.getId()).thenReturn(2L);
+        when(targetMember.getGameName()).thenReturn("TargetUser");
+        when(targetMember.getTag()).thenReturn("KR1");
+        when(targetMember.getUpdatedAt()).thenReturn(LocalDateTime.now().minusMinutes(6)); // 6분 전 (갱신 필요)
+
+        // Updated target member
+        updatedTargetMember = mock(Member.class);
+        when(updatedTargetMember.getId()).thenReturn(2L);
+        when(updatedTargetMember.getGameName()).thenReturn("TargetUser");
+        when(updatedTargetMember.getTag()).thenReturn("KR1");
+        when(updatedTargetMember.getUpdatedAt()).thenReturn(LocalDateTime.now()); // 방금 갱신됨
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 시 DB 재로딩으로 최신 데이터 반영")
+    void getMyProfile_RefreshesAndReloadsFromDB() {
+        // Given
+        given(memberService.findMemberById(1L)).willReturn(updatedMember);
+
+        // When
+        MyProfileResponse result = memberFacadeService.getMyProfile(testMember);
+
+        // Then
+        verify(championStatsRefreshService).refreshChampionStats(testMember); // 갱신 호출 확인
+        verify(memberService).findMemberById(1L); // fresh entity 로딩 확인
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 시 갱신 실패해도 DB 재로딩은 수행")
+    void getMyProfile_ReloadsFromDBEvenWhenRefreshFails() {
+        // Given
+        doThrow(new RuntimeException("Riot API 실패")).when(championStatsRefreshService).refreshChampionStats(testMember);
+        given(memberService.findMemberById(1L)).willReturn(updatedMember);
+
+        // When
+        MyProfileResponse result = memberFacadeService.getMyProfile(testMember);
+
+        // Then
+        verify(championStatsRefreshService).refreshChampionStats(testMember); // 갱신 시도 확인
+        verify(memberService).findMemberById(1L); // 실패해도 fresh entity 로딩 확인
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("다른 사람 프로필 조회 시 DB 재로딩으로 최신 데이터 반영")
+    void getOtherProfile_RefreshesAndReloadsFromDB() {
+        // Given
+        given(memberService.findMemberById(2L))
+                .willReturn(targetMember) // 첫 번째 호출 (갱신 전)
+                .willReturn(updatedTargetMember); // 두 번째 호출 (갱신 후 fresh entity)
+        given(friendService.isFriend(testMember, updatedTargetMember)).willReturn(false);
+        given(friendService.getFriendRequestMemberId(testMember, updatedTargetMember)).willReturn(null);
+        given(blockService.isBlocked(testMember, updatedTargetMember)).willReturn(false);
+
+        // When
+        OtherProfileResponse result = memberFacadeService.getOtherProfile(testMember, 2L);
+
+        // Then
+        verify(championStatsRefreshService).refreshChampionStats(targetMember); // 갱신 호출 확인
+        verify(memberService, times(2)).findMemberById(2L); // DB에서 2번 로딩 확인 (갱신 전/후)
+        verify(friendService).isFriend(testMember, updatedTargetMember); // 갱신된 엔티티로 친구 확인
+        verify(blockService).isBlocked(testMember, updatedTargetMember); // 갱신된 엔티티로 차단 확인
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("다른 사람 프로필 조회 시 갱신 실패해도 DB 재로딩은 수행")
+    void getOtherProfile_ReloadsFromDBEvenWhenRefreshFails() {
+        // Given
+        doThrow(new RuntimeException("Riot API 실패")).when(championStatsRefreshService).refreshChampionStats(targetMember);
+        given(memberService.findMemberById(2L))
+                .willReturn(targetMember) // 첫 번째 호출 (갱신 전)
+                .willReturn(updatedTargetMember); // 두 번째 호출 (갱신 후 fresh entity)
+        given(friendService.isFriend(testMember, updatedTargetMember)).willReturn(false);
+        given(friendService.getFriendRequestMemberId(testMember, updatedTargetMember)).willReturn(null);
+        given(blockService.isBlocked(testMember, updatedTargetMember)).willReturn(false);
+
+        // When
+        OtherProfileResponse result = memberFacadeService.getOtherProfile(testMember, 2L);
+
+        // Then
+        verify(championStatsRefreshService).refreshChampionStats(targetMember); // 갱신 시도 확인
+        verify(memberService, times(2)).findMemberById(2L); // 실패해도 fresh entity 로딩 확인
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("최근 갱신된 멤버는 챔피언 통계 갱신을 건너뛰지만 DB 재로딩은 수행")
+    void getMyProfile_SkipsRefreshButStillReloadsWhenRecentlyUpdated() {
+        // Given
+        Member recentlyUpdatedMember = mock(Member.class);
+        when(recentlyUpdatedMember.getId()).thenReturn(1L);
+        when(recentlyUpdatedMember.getUpdatedAt()).thenReturn(LocalDateTime.now().minusMinutes(2)); // 2분 전 (갱신 불필요)
+
+        given(memberService.findMemberById(1L)).willReturn(updatedMember);
+
+        // When
+        MyProfileResponse result = memberFacadeService.getMyProfile(recentlyUpdatedMember);
+
+        // Then
+        verify(championStatsRefreshService, never()).refreshChampionStats(any(Member.class)); // 갱신 건너뛰기 확인
+        verify(memberService).findMemberById(1L); // 그래도 fresh entity 로딩은 수행
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("updatedAt이 null인 멤버는 항상 챔피언 통계 갱신 수행")
+    void getMyProfile_AlwaysRefreshesWhenUpdatedAtIsNull() {
+        // Given
+        Member memberWithNullUpdatedAt = mock(Member.class);
+        when(memberWithNullUpdatedAt.getId()).thenReturn(1L);
+        when(memberWithNullUpdatedAt.getUpdatedAt()).thenReturn(null); // null인 경우
+
+        given(memberService.findMemberById(1L)).willReturn(updatedMember);
+
+        // When
+        MyProfileResponse result = memberFacadeService.getMyProfile(memberWithNullUpdatedAt);
+
+        // Then
+        verify(championStatsRefreshService).refreshChampionStats(memberWithNullUpdatedAt); // null이면 항상 갱신
+        verify(memberService).findMemberById(1L); // fresh entity 로딩 확인
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("DB 재로딩 후 최신 챔피언 통계가 포함된 프로필 반환")
+    void getMyProfile_ReturnsProfileWithLatestChampionStats() {
+        // Given
+        // Mock MemberRecentStats for updated member
+        MemberRecentStats mockRecentStats = mock(MemberRecentStats.class);
+        when(mockRecentStats.getRecTotalWins()).thenReturn(20); // 갱신된 승수
+        when(mockRecentStats.getRecTotalLosses()).thenReturn(10); // 갱신된 패배수
+        when(mockRecentStats.getRecWinRate()).thenReturn(66.7); // 갱신된 승률
+
+        when(updatedMember.getMemberRecentStats()).thenReturn(mockRecentStats);
+        given(memberService.findMemberById(1L)).willReturn(updatedMember);
+
+        // When
+        MyProfileResponse result = memberFacadeService.getMyProfile(testMember);
+
+        // Then
+        verify(championStatsRefreshService).refreshChampionStats(testMember); // 갱신 호출 확인
+        verify(memberService).findMemberById(1L); // fresh entity로부터 로딩 확인
+        assertNotNull(result);
+        // 실제 MyProfileResponse.of() 메서드가 updatedMember로부터 생성되는지 확인
+        // (실제 구현에서는 갱신된 통계가 포함된 응답이 반환됨)
+    }
+
+    @Test
+    @DisplayName("친구/차단 정보 조회 시에도 갱신된 엔티티 사용")
+    void getOtherProfile_UsesFreshEntityForFriendAndBlockChecks() {
+        // Given
+        given(memberService.findMemberById(2L))
+                .willReturn(targetMember) // 첫 번째 호출
+                .willReturn(updatedTargetMember); // 두 번째 호출 (fresh entity)
+        given(friendService.isFriend(testMember, updatedTargetMember)).willReturn(true);
+        given(friendService.getFriendRequestMemberId(testMember, updatedTargetMember)).willReturn(5L);
+        given(blockService.isBlocked(testMember, updatedTargetMember)).willReturn(false);
+
+        // When
+        OtherProfileResponse result = memberFacadeService.getOtherProfile(testMember, 2L);
+
+        // Then
+        // fresh entity(updatedTargetMember)로 친구/차단 상태 확인
+        verify(friendService).isFriend(testMember, updatedTargetMember);
+        verify(friendService).getFriendRequestMemberId(testMember, updatedTargetMember);
+        verify(blockService).isBlocked(testMember, updatedTargetMember);
+
+        // 갱신되지 않은 원본 엔티티로는 확인하지 않음
+        verify(friendService, never()).isFriend(testMember, targetMember);
+        verify(blockService, never()).isBlocked(testMember, targetMember);
+
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> puuid 재사용 및 라이엇 api 호출 실패 시 롤백 처리

## ⏳ 작업 상세 내용

- [x] puuid 재사용 로직
- [x] 라이엇 api 호출 실패 시 기존 정보 롤백
- [x] 내 프로필 불러오기 시 db 리로딩
- [x] 테스트 코드 작성

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
