### PR TITLE
[Fix/352] summonerId 사용하는 API 제거

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/service/AuthFacadeService.java
@@ -48,26 +48,23 @@ public class AuthFacadeService {
      * @param request 회원가입용 정보
      */
     public String join(JoinRequest request) {
-        // 1. [Member] 중복확인
+        // [Member] 중복확인
         memberService.checkDuplicateMemberByEmail(request.getEmail());
 
-        // 2. [Riot] 존재하는 소환사인지 검증 & puuid 얻기
+        // [Riot] 존재하는 소환사인지 검증 & puuid 얻기
         String puuid = riotAccountService.getPuuid(request.getGameName(), request.getTag());
 
-        // 3. [Riot] summonerId 얻기
-        String summonerId = riotAccountService.getSummonerId(puuid);
+        // [Riot] tier, rank, winrate 얻기
+        List<TierDetails> tierWinrateRank = riotInfoService.getTierWinrateRank(puuid);
 
-        // 3. [Riot] tier, rank, winrate 얻기
-        List<TierDetails> tierWinrateRank = riotInfoService.getTierWinrateRank(summonerId);
-
-        // 4. [Member] member DB에 저장
+        // [Member] member DB에 저장
         Member member = memberService.createMemberGeneral(request, tierWinrateRank);
 
-        // 5. [Riot] 최근 사용한 챔피언 3개 가져오기
+        // [Riot] 최근 사용한 챔피언 3개 가져오기
         List<ChampionStats> preferChampionStats = riotRecordService.getPreferChampionfromMatch(request.getGameName(),
                 puuid);
 
-        // 6. [Member] Member Champion DB에서 매핑하기
+        // [Member] Member Champion DB에서 매핑하기
         memberChampionService.saveMemberChampions(member, preferChampionStats);
 
         return "회원가입이 완료되었습니다.";

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/response/RiotInfoResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/response/RiotInfoResponse.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 public class RiotInfoResponse {
 
     String leagueId;
+    String puuid;
     String queueType;
     String tier;
     String rank;
-    String summonerId;
     int leaguePoints;
     int wins;
     int losses;

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotAuthService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotAuthService.java
@@ -3,7 +3,6 @@ package com.gamegoo.gamegoo_v2.external.riot.service;
 import com.gamegoo.gamegoo_v2.core.exception.RiotException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotPuuidGameNameResponse;
-import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotSummonerResponse;
 import com.gamegoo.gamegoo_v2.utils.RiotApiHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,9 +23,8 @@ public class RiotAuthService {
 
     private static final String RIOT_ACCOUNT_API_URL_TEMPLATE = "https://asia.api.riotgames" +
             ".com/riot/account/v1/accounts/by-riot-id/%s/%s?api_key=%s";
-    private static final String RIOT_SUMMONER_API_URL_TEMPLATE = "https://kr.api.riotgames" +
-            ".com/lol/summoner/v4/summoners/by-puuid/%s?api_key=%s";
-    private static final String RIOT_ACCOUNT_BY_PUUID_API_URL_TEMPLATE = "https://asia.api.riotgames.com/riot/account/v1/accounts/by-puuid/%s?api_key=%s";
+    private static final String RIOT_ACCOUNT_BY_PUUID_API_URL_TEMPLATE = "https://asia.api.riotgames" +
+            ".com/riot/account/v1/accounts/by-puuid/%s?api_key=%s";
 
     /**
      * puuid로 게임 이름과 태그 얻기
@@ -53,46 +51,22 @@ public class RiotAuthService {
     /**
      * puuid 얻기
      *
-     * @param gameName  소환사명
-     * @param tag       태그
-     * @return          puuid
+     * @param gameName 소환사명
+     * @param tag      태그
+     * @return puuid
      */
     public String getPuuid(String gameName, String tag) {
         String url = String.format(RIOT_ACCOUNT_API_URL_TEMPLATE, gameName, tag, riotAPIKey);
         try {
             RiotPuuidGameNameResponse response = restTemplate.getForObject(url, RiotPuuidGameNameResponse.class);
-
             if (response == null || response.getPuuid() == null) {
                 throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
             }
-
             return response.getPuuid();
         } catch (Exception e) {
             riotApiHelper.handleApiError(e);
-            return null;        }
+            return null;
+        }
     }
-
-    /**
-     * 소환사아이디 얻기
-     *
-     * @param puuid puuid
-     * @return      summonerId
-     */
-    public String getSummonerId(String puuid) {
-        String url = String.format(RIOT_SUMMONER_API_URL_TEMPLATE, puuid, riotAPIKey);
-        try {
-            RiotSummonerResponse summonerResponse = restTemplate.getForObject(url, RiotSummonerResponse.class);
-
-            if (summonerResponse == null || summonerResponse.getId() == null) {
-                throw new RiotException(ErrorCode.RIOT_NOT_FOUND);
-            }
-
-            return summonerResponse.getId();
-        } catch (Exception e) {
-            riotApiHelper.handleApiError(e);
-            return null;        }
-    }
-
-
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
@@ -45,37 +45,32 @@ public class RiotFacadeService {
      * @param request 소환사명, 태그
      */
     public String verifyRiotAccount(RiotVerifyExistUserRequest request) {
-        // 1. puuid 발급 가능한지 검증
-        String puuid = riotAccountService.getPuuid(request.getGameName(), request.getTag());
+        // puuid 발급 가능한지 검증
+        riotAccountService.getPuuid(request.getGameName(), request.getTag());
 
-        // 2. summonerid 발급 가능한지 검증
-        riotAccountService.getSummonerId(puuid);
         return "해당 Riot 계정은 존재합니다";
     }
 
     @Transactional
     public String join(RiotJoinRequest request) {
-        // 1. [Member] puuid 중복 확인
+        // [Member] puuid 중복 확인
         memberService.checkDuplicateMemberByPuuid(request.getPuuid());
 
-        // 2. [Riot] gameName, Tag 얻기
+        // [Riot] gameName, Tag 얻기
         RiotPuuidGameNameResponse response = riotAccountService.getAccountByPuuid(request.getPuuid());
 
-        // 3. [Riot] summonerId 얻기
-        String summonerId = riotAccountService.getSummonerId(request.getPuuid());
+        // [Riot] tier, rank, winrate 얻기
+        List<TierDetails> tierWinrateRank = riotInfoService.getTierWinrateRank(request.getPuuid());
 
-        // 3. [Riot] tier, rank, winrate 얻기
-        List<TierDetails> tierWinrateRank = riotInfoService.getTierWinrateRank(summonerId);
-
-        // 4. [Member] member DB에 저장
+        // [Member] member DB에 저장
         Member member = memberService.createMemberRiot(request, response.getGameName(), response.getTagLine(),
                 tierWinrateRank);
 
-        // 5. [Riot] 최근 사용한 챔피언 3개 가져오기
+        // [Riot] 최근 사용한 챔피언 3개 가져오기
         List<ChampionStats> preferChampionStats = riotRecordService.getPreferChampionfromMatch(response.getGameName()
                 , response.getPuuid());
 
-        // 6. [Member] Member Champion DB 에서 매핑하기
+        // [Member] Member Champion DB 에서 매핑하기
         memberChampionService.saveMemberChampions(member, preferChampionStats);
 
         return "RSO 회원가입이 완료되었습니다.";

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotInfoService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotInfoService.java
@@ -29,7 +29,7 @@ public class RiotInfoService {
     private String riotAPIKey;
 
     private static final String RIOT_LEAGUE_API_URL_TEMPLATE = "https://kr.api.riotgames" +
-            ".com/lol/league/v4/entries/by-summoner/%s?api_key=%s";
+            ".com/lol/league/v4/entries/by-puuid/%s?api_key=%s";
     private static final String RIOT_SOLO_QUEUE_TYPE = "RANKED_SOLO_5x5";
     private static final String RIOT_FREE_QUEUE_TYPE = "RANKED_FLEX_SR";
     private static final Map<String, Integer> romanToIntMap = Map.of(
@@ -39,15 +39,15 @@ public class RiotInfoService {
     /**
      * 티어, 랭크, 승률 조회
      *
-     * @param encryptedSummonerId 암호화된 소환사 id
+     * @param puuid 암호화된 소환사 id
      * @return 소환사 정보
      */
-    public List<TierDetails> getTierWinrateRank(String encryptedSummonerId) {
+    public List<TierDetails> getTierWinrateRank(String puuid) {
         // 티어 정보
         List<TierDetails> tierDetails = new ArrayList<>();
 
         // riot API 호출
-        String url = String.format(RIOT_LEAGUE_API_URL_TEMPLATE, encryptedSummonerId, riotAPIKey);
+        String url = String.format(RIOT_LEAGUE_API_URL_TEMPLATE, puuid, riotAPIKey);
         try {
             RiotInfoResponse[] responses = restTemplate.getForObject(url, RiotInfoResponse[].class);
             if (responses != null) {


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> riot API 사용해서 회원가입할 때 발생한 에러 해결

## ⏳ 작업 상세 내용

- [x] summonerId 사용하는 API 를 puuid로 변경

> Riot 측 안내 
> 
> Hey everybody, as a follow up to our last announcement about the endpoints being removed, we are going to be completely removing SummonerIDs and AccountIDs from all endpoint payloads on July 7th, 2025. If your app is dependent on them, please take steps to ensure that you can use PUUIDs moving forward.
> Also, please 
> make sure to use this endpoint for RSO-related summoner requests: /lol/summoner/v4/summoners/me

기존에는 encryptedSummonerId를 사용했지만 보안 정책에 의해 puuid로 변경되었습니다. 해당 변경사항을 반영했습니다.

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
