### PR TITLE
[Feat/356] 비회원 게시물 등록 로직

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
@@ -23,4 +23,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m.id FROM Member m WHERE m.mannerScore IS NULL AND m.mannerRank IS NOT NULL")
     List<Long> getMemberIdsWhereMannerScoreIsNullAndMannerRankIsNotNull();
 
+    boolean existsByGameNameAndTag(String gameName, String tag);
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -6,6 +6,7 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardInsertRequest;
+import com.gamegoo.gamegoo_v2.content.board.dto.request.GuestBoardInsertRequest;
 import com.gamegoo.gamegoo_v2.content.board.dto.request.BoardUpdateRequest;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.*;
 import com.gamegoo.gamegoo_v2.content.board.service.BoardFacadeService;
@@ -55,6 +56,17 @@ public class BoardController {
             @AuthMember Member member,
             @Valid @RequestBody BoardInsertRequest request) {
         return ApiResponse.ok(boardFacadeService.createBoard(request, member));
+    }
+
+    @PostMapping("/guest")
+    @Operation(summary = "비회원 게시판 글 작성 API",
+            description = "비회원이 게시판에서 글을 작성하는 API 입니다. 프로필이미지 값: 1~8, gameMode: < 빠른대전: FAST, 솔로랭크: SOLO, 자유랭크: FREE, 칼바람 " +
+                    "나락: ARAM >, " +
+                    "주 포지션, 부포지션, 희망 포지션: < TOP, JUNGLE, MID, ADC, SUP, ANY >, 마이크 여부: < AVAILABLE, UNAVAILABLE >, 게임" +
+                    " 스타일 리스트: 1~3개 선택 가능")
+    public ApiResponse<BoardInsertResponse> guestBoardInsert(
+            @Valid @RequestBody GuestBoardInsertRequest request) {
+        return ApiResponse.ok(boardFacadeService.createGuestBoard(request, request.getGameName(), request.getTag()));
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/domain/Board.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/domain/Board.java
@@ -71,7 +71,7 @@ public class Board extends BaseDateTimeEntity {
     private boolean deleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = true)
     private Member member;
 
     @Column(length = 50)

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/domain/Board.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/domain/Board.java
@@ -71,8 +71,17 @@ public class Board extends BaseDateTimeEntity {
     private boolean deleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
+
+    @Column(length = 50)
+    private String gameName;
+
+    @Column(length = 10)
+    private String tag;
+
+    @Column(nullable = false)
+    private boolean isGuest = false;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<BoardGameStyle> boardGameStyles = new ArrayList<>();
@@ -88,6 +97,23 @@ public class Board extends BaseDateTimeEntity {
                                Mike mike, String content, int boardProfileImage) {
         return Board.builder()
                 .member(member)
+                .isGuest(false)
+                .gameMode(gameMode)
+                .mainP(mainP)
+                .subP(subP)
+                .wantP(wantP)
+                .mike(mike)
+                .content(content)
+                .boardProfileImage(boardProfileImage)
+                .build();
+    }
+
+    public static Board createForGuest(String gameName, String tag, GameMode gameMode, Position mainP, Position subP,
+                                       List<Position> wantP, Mike mike, String content, int boardProfileImage) {
+        return Board.builder()
+                .gameName(gameName)
+                .tag(tag)
+                .isGuest(true)
                 .gameMode(gameMode)
                 .mainP(mainP)
                 .subP(subP)
@@ -100,8 +126,8 @@ public class Board extends BaseDateTimeEntity {
 
     @Builder
     private Board(GameMode gameMode, Position mainP, Position subP, List<Position> wantP, Mike mike,
-                  String content,
-                  int boardProfileImage, boolean deleted, Member member) {
+                  String content, int boardProfileImage, boolean deleted, Member member,
+                  String gameName, String tag, boolean isGuest) {
         this.gameMode = gameMode;
         this.mainP = mainP;
         this.subP = subP;
@@ -111,6 +137,9 @@ public class Board extends BaseDateTimeEntity {
         this.boardProfileImage = boardProfileImage;
         this.deleted = deleted;
         this.member = member;
+        this.gameName = gameName;
+        this.tag = tag;
+        this.isGuest = isGuest;
     }
 
     public void addBoardGameStyle(BoardGameStyle boardGameStyle) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/request/GuestBoardInsertRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/request/GuestBoardInsertRequest.java
@@ -1,0 +1,17 @@
+package com.gamegoo.gamegoo_v2.content.board.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class GuestBoardInsertRequest extends BoardInsertRequest {
+
+    @NotBlank(message = "게임 닉네임은 필수입니다.")
+    @Schema(description = "게임 내 닉네임")
+    private String gameName;
+
+    @NotBlank(message = "태그는 필수입니다.")
+    @Schema(description = "게임 태그")
+    private String tag;
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
@@ -11,16 +11,16 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
 @Builder
-
 public class BoardByIdResponse {
 
     long boardId;
-    long memberId;
+    Long memberId;
     LocalDateTime createdAt;
     Integer profileImage;
     String gameName;
@@ -44,6 +44,38 @@ public class BoardByIdResponse {
 
     public static BoardByIdResponse of(Board board) {
         Member poster = board.getMember();
+        List<Long> gameStyleIds = board.getBoardGameStyles().stream()
+                .map(bgs -> bgs.getGameStyle().getId())
+                .collect(Collectors.toList());
+
+        if (poster == null) { // 비회원 게시글 처리
+            return BoardByIdResponse.builder()
+                    .boardId(board.getId())
+                    .memberId(null)
+                    .createdAt(board.getCreatedAt())
+                    .profileImage(board.getBoardProfileImage())
+                    .gameName(board.getGameName())
+                    .tag(board.getTag())
+                    .mannerLevel(null)
+                    .soloTier(null)
+                    .soloRank(0)
+                    .freeTier(null)
+                    .freeRank(0)
+                    .mike(board.getMike())
+                    .championStatsResponseList(Collections.emptyList())
+                    .memberRecentStats(null)
+                    .gameMode(board.getGameMode())
+                    .mainP(board.getMainP())
+                    .subP(board.getSubP())
+                    .wantP(board.getWantP())
+                    .recentGameCount(null)
+                    .winRate(null)
+                    .gameStyles(gameStyleIds)
+                    .contents(board.getContent())
+                    .build();
+        }
+
+        // 회원 게시글 처리
         List<ChampionStatsResponse> championStatsResponseList = poster.getMemberChampionList() == null
                 ? List.of()
                 : poster.getMemberChampionList().stream()
@@ -57,11 +89,6 @@ public class BoardByIdResponse {
                         .kda(mc.getKDA())
                         .build())
                 .collect(Collectors.toList());
-
-        List<Long> gameStyleIds = board.getBoardGameStyles().stream()
-                .map(bgs -> bgs.getGameStyle().getId())
-                .collect(Collectors.toList());
-
 
         Integer recentGameCount;
         Double winRate;
@@ -98,7 +125,5 @@ public class BoardByIdResponse {
                 .gameStyles(gameStyleIds)
                 .contents(board.getContent())
                 .build();
-
     }
-
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
@@ -12,16 +12,16 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
 @Builder
-
 public class BoardByIdResponseForMember {
 
     long boardId;
-    long memberId;
+    Long memberId;
     Boolean isBlocked;
     Boolean isFriend;
     Long friendRequestMemberId;
@@ -57,7 +57,43 @@ public class BoardByIdResponseForMember {
             MannerService mannerService
     ) {
         Member poster = board.getMember();
+        List<Long> gameStyleIds = board.getBoardGameStyles().stream()
+                .map(bgs -> bgs.getGameStyle().getId())
+                .collect(Collectors.toList());
 
+        if (poster == null) { // 비회원 게시글 처리
+            return BoardByIdResponseForMember.builder()
+                    .boardId(board.getId())
+                    .memberId(null)
+                    .isBlocked(null)
+                    .isFriend(null)
+                    .friendRequestMemberId(null)
+                    .createdAt(board.getCreatedAt())
+                    .profileImage(board.getBoardProfileImage())
+                    .gameName(board.getGameName())
+                    .tag(board.getTag())
+                    .mannerLevel(null)
+                    .mannerRank(null)
+                    .mannerRatingCount(null)
+                    .soloTier(null)
+                    .soloRank(0)
+                    .freeTier(null)
+                    .freeRank(0)
+                    .mike(board.getMike())
+                    .championStatsResponseList(Collections.emptyList())
+                    .memberRecentStats(null)
+                    .gameMode(board.getGameMode())
+                    .mainP(board.getMainP())
+                    .subP(board.getSubP())
+                    .wantP(board.getWantP())
+                    .recentGameCount(null)
+                    .winRate(null)
+                    .gameStyles(gameStyleIds)
+                    .contents(board.getContent())
+                    .build();
+        }
+
+        // 회원 게시글 처리
         List<ChampionStatsResponse> championStatsResponseList = poster.getMemberChampionList() == null
                 ? List.of()
                 : poster.getMemberChampionList().stream()
@@ -70,11 +106,6 @@ public class BoardByIdResponseForMember {
                         .csPerMinute(mc.getCsPerMinute())
                         .kda(mc.getKDA())
                         .build())
-                .collect(Collectors.toList());
-
-
-        List<Long> gameStyleIds = board.getBoardGameStyles().stream()
-                .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
 
         Integer recentGameCount;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class BoardInsertResponse {
 
     private long boardId;
-    private long memberId;
+    private Long memberId;
     private Integer profileImage;
     private String gameName;
     private String tag;
@@ -50,6 +50,27 @@ public class BoardInsertResponse {
                 .tag(member.getTag())
                 .tier(tier)
                 .rank(rank)
+                .gameMode(board.getGameMode())
+                .mainP(board.getMainP())
+                .subP(board.getSubP())
+                .wantP(board.getWantP())
+                .mike(board.getMike())
+                .gameStyles(board.getBoardGameStyles().stream()
+                        .map(bg -> bg.getGameStyle().getId())
+                        .toList())
+                .contents(board.getContent())
+                .build();
+    }
+
+    public static BoardInsertResponse ofGuest(Board board) {
+        return BoardInsertResponse.builder()
+                .boardId(board.getId())
+                .memberId(null) // 게스트는 memberId null
+                .profileImage(board.getBoardProfileImage())
+                .gameName(board.getGameName())
+                .tag(board.getTag())
+                .tier(null) // 게스트는 티어 없음
+                .rank(0) // 게스트는 랭크 없음
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -45,6 +46,37 @@ public class BoardListResponse {
 
     public static BoardListResponse of(Board board) {
         Member member = board.getMember();
+
+        if (member == null) { // 비회원 게시글 처리
+            return BoardListResponse.builder()
+                    .boardId(board.getId())
+                    .memberId(null)
+                    .gameName(board.getGameName())
+                    .tag(board.getTag())
+                    .mainP(board.getMainP())
+                    .subP(board.getSubP())
+                    .wantP(board.getWantP())
+                    .mike(board.getMike())
+                    .contents(board.getContent())
+                    .boardProfileImage(board.getBoardProfileImage())
+                    .createdAt(board.getCreatedAt())
+                    .profileImage(null)
+                    .mannerLevel(null)
+                    .tier(null)
+                    .rank(0)
+                    .gameMode(board.getGameMode())
+                    .winRate(null)
+                    .bumpTime(board.getBumpTime())
+                    .championStatsResponseList(Collections.emptyList())
+                    .memberRecentStats(null)
+                    .freeTier(null)
+                    .freeRank(0)
+                    .soloTier(null)
+                    .soloRank(0)
+                    .build();
+        }
+
+        // 회원 게시글 처리
         Tier tier;
         int rank;
         Double winRate;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/repository/BoardRepository.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query("SELECT b FROM Board b JOIN b.member m WHERE " +
+    @Query("SELECT b FROM Board b LEFT JOIN b.member m WHERE " +
             "b.deleted = false AND " +
             "(:gameMode IS NULL OR b.gameMode = :gameMode) AND " +
             "(:tier IS NULL OR (CASE WHEN b.gameMode = com.gamegoo.gamegoo_v2.matching.domain.GameMode.FREE THEN m.freeTier ELSE m.soloTier END) = :tier) AND " +
@@ -54,7 +54,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("activityTime") LocalDateTime activityTime,
             Pageable pageable);
 
-    @Query("SELECT b FROM Board b JOIN b.member m " +
+    @Query("SELECT b FROM Board b LEFT JOIN b.member m " +
            "WHERE b.deleted = false " +
            "AND (" +
            "  :activityTime IS NULL " +

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -64,6 +64,29 @@ public class BoardService {
     }
 
     /**
+     * 게스트 게시글 엔티티 생성 및 저장
+     */
+    @Transactional
+    public Board createAndSaveGuestBoard(BoardInsertRequest request, String gameName, String tag) {
+        int boardProfileImage = (request.getBoardProfileImage() != null)
+                ? request.getBoardProfileImage()
+                : 1; // 기본 이미지
+
+        Board board = Board.createForGuest(
+                gameName,
+                tag,
+                request.getGameMode(),
+                request.getMainP(),
+                request.getSubP(),
+                request.getWantP(),
+                request.getMike(),
+                request.getContents(),
+                boardProfileImage
+        );
+        return boardRepository.save(board);
+    }
+
+    /**
      * 게시글 목록 조회
      */
     public Page<Board> findBoards(GameMode gameMode, Tier tier, Position mainP, Position subP, Mike mike,

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/v2/riot/verify",
                         "/api/v2/riot/oauth/callback",
                         "/api/v2/riot/join").permitAll() // riot
-                .requestMatchers("/api/v2/posts/list/**", "/api/v2/posts/cursor").permitAll() // board
+                .requestMatchers("/api/v2/posts/list/**", "/api/v2/posts/cursor", "/api/v2/posts/guest").permitAll() // board
                 .requestMatchers(
                         "/api/v2/auth/token/**",
                         "/api/v2/auth/join",

--- a/src/main/resources/excluded-paths.yml
+++ b/src/main/resources/excluded-paths.yml
@@ -25,6 +25,8 @@ security:
         pattern: /api/v2/riot/verify # riot 계정 검증
       - method: GET
         pattern: /api/v2/posts/list # 게시글 목록 조회
+      - method: POST
+        pattern: /api/v2/posts/guest # 비회원 게시물 등록
       - method: GET
         pattern: /api/v2/posts/list/* # 비회원용 특정 게시글 조회
       - method: GET


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 비회원 게시물 등록 로직입니다.

## ⏳ 작업 상세 내용

- [x] member가 null일때도 처리할 수 있게 dto 수정
- [x] 비회원 게시물 등록시 요청 dto 추가
- [x] 게시물 조회 시 비회원 게시글 누락을 막기 위해 INNER JOIN에서 LEFT JOIN으로 수정
- [x] 이미 있는 회원의 닉네임을 사용하면 거절
- [x] 비회원 게시물 등록 테스트 코드 작성

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->
일단 member 관련 데이터 전부 null로 뒀습니다. 
전적 관련 데이터를 어떻게 처리해야할지 고민입니다 ㅎㅎ...

- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
