### PR TITLE
[Refactor/360] 친구목록 조회 API 쿼리 테스트 및 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // show sql
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1'
+
 }
 
 // Querydsl 설정부

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -130,7 +130,7 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberGameStyle> memberGameStyleList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
     private MemberRecentStats memberRecentStats;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -146,6 +146,13 @@ public class Member extends BaseDateTimeEntity {
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private Role role = Role.MEMBER;
 
+    public void setMemberRecentStats(MemberRecentStats stats) {
+        this.memberRecentStats = stats;
+        if (stats.getMember() != this) {
+            stats.setMember(this);
+        }
+    }
+
     // puuid 전용
     public static Member createForGeneral(String email, String password, LoginType loginType, String gameName,
                                           String tag,

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberRecentStats.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberRecentStats.java
@@ -1,7 +1,16 @@
 package com.gamegoo.gamegoo_v2.account.member.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -9,6 +18,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class MemberRecentStats {
+
     @Id
     private Long memberId;
 
@@ -27,7 +37,15 @@ public class MemberRecentStats {
     private double recAvgCsPerMinute;
     private int recTotalCs;
 
-    public void update(int recTotalWins, int recTotalLosses, double recWinRate, double recAvgKDA, double recAvgKills, double recAvgDeaths, double recAvgAssists, double recAvgCsPerMinute, int recTotalCs) {
+    public void setMember(Member member) {
+        this.member = member;
+        if (member.getMemberRecentStats() != this) {
+            member.setMemberRecentStats(this);
+        }
+    }
+
+    public void update(int recTotalWins, int recTotalLosses, double recWinRate, double recAvgKDA, double recAvgKills,
+                       double recAvgDeaths, double recAvgAssists, double recAvgCsPerMinute, int recTotalCs) {
         this.recTotalWins = recTotalWins;
         this.recTotalLosses = recTotalLosses;
         this.recWinRate = recWinRate;
@@ -38,4 +56,5 @@ public class MemberRecentStats {
         this.recAvgCsPerMinute = recAvgCsPerMinute;
         this.recTotalCs = recTotalCs;
     }
-} 
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/P6SpyConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/P6SpyConfig.java
@@ -1,0 +1,52 @@
+package com.gamegoo.gamegoo_v2.core.config;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import jakarta.annotation.PostConstruct;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.ClassUtils;
+
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Configuration
+@Profile("local")
+public class P6SpyConfig implements MessageFormattingStrategy {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(this.getClass().getName());
+    }
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category,
+                                String prepared, String sql, String url) {
+        return String.format("[%s] | %d ms | %s", category, elapsed,
+                formatSql(category, sql));
+    }
+
+    private String stackTrace() {
+        return Stream.of(new Throwable().getStackTrace())
+                .filter(t -> t.toString().startsWith("com.gamegoo") && !t.toString().contains(
+                        ClassUtils.getUserClass(this).getName()))
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql != null && !sql.trim().isEmpty() && Category.STATEMENT.getName().equals(category)) {
+            String trimmedSql = sql.trim().toLowerCase(Locale.ROOT);
+            return stackTrace() + (trimmedSql.startsWith("create") || trimmedSql.startsWith("alter")
+                    || trimmedSql.startsWith("comment")
+                    ? FormatStyle.DDL.getFormatter().format(sql)
+                    : FormatStyle.BASIC.getFormatter().format(sql));
+        }
+        return sql;
+    }
+
+}
+

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/repository/FriendRepositoryCustomImpl.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/repository/FriendRepositoryCustomImpl.java
@@ -21,6 +21,7 @@ public class FriendRepositoryCustomImpl implements FriendRepositoryCustom {
     public List<Friend> findAllFriendsOrdered(Long memberId) {
         // 전체 친구 목록 조회
         List<Friend> allFriends = queryFactory.selectFrom(friend)
+                .join(friend.toMember).fetchJoin()
                 .where(friend.fromMember.id.eq(memberId))
                 .fetch();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,11 @@ logging:
   discord:
     webhook: ${DISCORD_MONITORING_WEBHOOK_URL_DEV}
 
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false
+
 ---
 # 운영 환경
 server:
@@ -138,3 +143,8 @@ spring:
 logging:
   discord:
     webhook: ${DISCORD_MONITORING_WEBHOOK_URL_PROD}
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false

--- a/src/test/java/com/gamegoo/gamegoo_v2/feature/BanFeatureTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/feature/BanFeatureTest.java
@@ -3,7 +3,9 @@ package com.gamegoo.gamegoo_v2.feature;
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.account.member.service.BanService;
 import com.gamegoo.gamegoo_v2.core.common.validator.BanValidator;
@@ -31,6 +33,9 @@ class BanFeatureTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
+    @Autowired
     private BanService banService;
 
     @Autowired
@@ -45,7 +50,8 @@ class BanFeatureTest {
 
     @AfterEach
     void tearDown() {
-        memberRepository.deleteAll();
+        memberRecentStatsRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
     }
 
     @Test
@@ -220,6 +226,12 @@ class BanFeatureTest {
                 5,
                 true
         );
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
+                .build());
+
         return memberRepository.save(member);
     }
+
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/batch/BatchFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/batch/BatchFacadeServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.integration.batch;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.batch.BatchFacadeService;
 import jakarta.persistence.EntityManager;
@@ -34,6 +36,9 @@ class BatchFacadeServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
     @MockitoSpyBean
     private EntityManager entityManager;
 
@@ -42,6 +47,7 @@ class BatchFacadeServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         memberRepository.deleteAllInBatch();
     }
 
@@ -199,7 +205,7 @@ class BatchFacadeServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -215,7 +221,13 @@ class BatchFacadeServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/block/BlockFacadeServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.integration.block;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.exception.BlockException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
@@ -49,6 +51,9 @@ class BlockFacadeServiceTest {
     @Autowired
     private FriendRequestRepository friendRequestRepository;
 
+    @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
     private static final String MEMBER_EMAIL = "test@gmail.com";
     private static final String MEMBER_GAMENAME = "member";
     private static final String TARGET_EMAIL = "target@naver.com";
@@ -63,6 +68,7 @@ class BlockFacadeServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         blockRepository.deleteAllInBatch();
         friendRepository.deleteAllInBatch();
         friendRequestRepository.deleteAllInBatch();
@@ -353,7 +359,7 @@ class BlockFacadeServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -369,7 +375,13 @@ class BlockFacadeServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/chat/ChatFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/chat/ChatFacadeServiceTest.java
@@ -2,9 +2,11 @@ package com.gamegoo.gamegoo_v2.integration.chat;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
 import com.gamegoo.gamegoo_v2.chat.domain.Chat;
@@ -93,6 +95,9 @@ class ChatFacadeServiceTest {
     @Autowired
     private FriendRequestRepository friendRequestRepository;
 
+    @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
     @MockitoSpyBean
     private MemberRepository memberRepository;
 
@@ -117,6 +122,7 @@ class ChatFacadeServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         chatRepository.deleteAllInBatch();
         memberChatroomRepository.deleteAllInBatch();
         chatroomRepository.deleteAllInBatch();
@@ -1081,7 +1087,7 @@ class ChatFacadeServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -1097,7 +1103,13 @@ class ChatFacadeServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
     private Chatroom createChatroom() {

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendFacadeServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.integration.friend;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.exception.FriendException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
@@ -46,6 +48,9 @@ class FriendFacadeServiceTest {
     @Autowired
     FriendRepository friendRepository;
 
+    @Autowired
+    MemberRecentStatsRepository memberRecentStatsRepository;
+
     private static final String TARGET_EMAIL = "target@naver.com";
     private static final String TARGET_GAMENAME = "target";
 
@@ -58,6 +63,7 @@ class FriendFacadeServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         friendRepository.deleteAllInBatch();
         blockRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
@@ -331,7 +337,7 @@ class FriendFacadeServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -347,7 +353,13 @@ class FriendFacadeServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/friend/FriendRequestFacadeServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.integration.friend;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.config.AsyncConfig;
 import com.gamegoo.gamegoo_v2.core.exception.FriendException;
@@ -59,6 +61,9 @@ class FriendRequestFacadeServiceTest {
     @Autowired
     private FriendRequestRepository friendRequestRepository;
 
+    @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
     @MockitoSpyBean
     private NotificationRepository notificationRepository;
 
@@ -74,6 +79,7 @@ class FriendRequestFacadeServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         friendRepository.deleteAllInBatch();
         friendRequestRepository.deleteAllInBatch();
         blockRepository.deleteAllInBatch();
@@ -375,7 +381,7 @@ class FriendRequestFacadeServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -391,7 +397,13 @@ class FriendRequestFacadeServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/manner/MannerFacadeServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.integration.manner;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.exception.MannerException;
 import com.gamegoo.gamegoo_v2.core.exception.MemberException;
@@ -70,6 +72,9 @@ class MannerFacadeServiceTest {
     @Autowired
     private NotificationRepository notificationRepository;
 
+    @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
     @MockitoSpyBean
     private NotificationService notificationService;
 
@@ -84,6 +89,7 @@ class MannerFacadeServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         notificationRepository.deleteAllInBatch();
         mannerRatingKeywordRepository.deleteAllInBatch();
         mannerRatingRepository.deleteAllInBatch();
@@ -1013,7 +1019,7 @@ class MannerFacadeServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -1029,7 +1035,13 @@ class MannerFacadeServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
     private MannerRating createMannerRating(List<Long> mannerKeywordIds, Member member, Member targetMember,

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -18,11 +18,13 @@ import com.gamegoo.gamegoo_v2.account.member.repository.MemberGameStyleRepositor
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.account.member.service.MemberFacadeService;
+import com.gamegoo.gamegoo_v2.content.board.dto.response.ChampionStatsResponse;
 import com.gamegoo.gamegoo_v2.game.domain.Champion;
 import com.gamegoo.gamegoo_v2.game.domain.GameStyle;
 import com.gamegoo.gamegoo_v2.game.repository.ChampionRepository;
 import com.gamegoo.gamegoo_v2.game.repository.GameStyleRepository;
-import com.gamegoo.gamegoo_v2.content.board.dto.response.ChampionStatsResponse;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,9 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -176,13 +175,21 @@ class MemberServiceFacadeTest {
             assertThat(championResponse.getChampionName()).isEqualTo(memberChampion.getChampion().getName());
             assertThat(championResponse.getWins()).isEqualTo(memberChampion.getWins());
             assertThat(championResponse.getGames()).isEqualTo(memberChampion.getGames());
-            assertThat(championResponse.getWinRate()).isEqualTo(memberChampion.getWins() / (double) memberChampion.getGames());
+            assertThat(championResponse.getWinRate()).isEqualTo(
+                    memberChampion.getWins() / (double) memberChampion.getGames());
             assertThat(championResponse.getCsPerMinute()).isEqualTo(memberChampion.getCsPerMinute());
-            assertThat(championResponse.getAverageCs()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getTotalCs() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getAverageCs()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getTotalCs() / memberChampion.getGames()
+                            : 0);
             assertThat(championResponse.getKda()).isEqualTo(memberChampion.getKDA());
-            assertThat(championResponse.getKills()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getKills() / memberChampion.getGames() : 0);
-            assertThat(championResponse.getDeaths()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getDeaths() / memberChampion.getGames() : 0);
-            assertThat(championResponse.getAssists()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getAssists() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getKills()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getKills() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getDeaths()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getDeaths() / memberChampion.getGames() :
+                            0);
+            assertThat(championResponse.getAssists()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getAssists() / memberChampion.getGames()
+                            : 0);
         }
     }
 
@@ -243,13 +250,21 @@ class MemberServiceFacadeTest {
             assertThat(championResponse.getChampionName()).isEqualTo(memberChampion.getChampion().getName());
             assertThat(championResponse.getWins()).isEqualTo(memberChampion.getWins());
             assertThat(championResponse.getGames()).isEqualTo(memberChampion.getGames());
-            assertThat(championResponse.getWinRate()).isEqualTo(memberChampion.getWins() / (double) memberChampion.getGames());
+            assertThat(championResponse.getWinRate()).isEqualTo(
+                    memberChampion.getWins() / (double) memberChampion.getGames());
             assertThat(championResponse.getCsPerMinute()).isEqualTo(memberChampion.getCsPerMinute());
-            assertThat(championResponse.getAverageCs()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getTotalCs() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getAverageCs()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getTotalCs() / memberChampion.getGames()
+                            : 0);
             assertThat(championResponse.getKda()).isEqualTo(memberChampion.getKDA());
-            assertThat(championResponse.getKills()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getKills() / memberChampion.getGames() : 0);
-            assertThat(championResponse.getDeaths()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getDeaths() / memberChampion.getGames() : 0);
-            assertThat(championResponse.getAssists()).isEqualTo(memberChampion.getGames() > 0 ? (double) memberChampion.getAssists() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getKills()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getKills() / memberChampion.getGames() : 0);
+            assertThat(championResponse.getDeaths()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getDeaths() / memberChampion.getGames() :
+                            0);
+            assertThat(championResponse.getAssists()).isEqualTo(
+                    memberChampion.getGames() > 0 ? (double) memberChampion.getAssists() / memberChampion.getGames()
+                            : 0);
         }
     }
 
@@ -412,9 +427,8 @@ class MemberServiceFacadeTest {
 
     }
 
-
     private Member createForGeneralMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -430,7 +444,13 @@ class MemberServiceFacadeTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
     private Champion initChampion(Long id, String name) {
@@ -453,18 +473,18 @@ class MemberServiceFacadeTest {
         Member refreshedMember = memberRepository.findById(member.getId()).orElseThrow();
 
         MemberRecentStats recentStats = MemberRecentStats.builder()
-            .memberId(refreshedMember.getId())
-            .member(refreshedMember)
-            .recTotalWins(25)
-            .recTotalLosses(15)
-            .recWinRate(62.5)
-            .recAvgKDA(2.5)
-            .recAvgKills(8.5)
-            .recAvgDeaths(3.2)
-            .recAvgAssists(9.1)
-            .recAvgCsPerMinute(6.8)
-            .recTotalCs(1360)
-            .build();
+                .memberId(refreshedMember.getId())
+                .member(refreshedMember)
+                .recTotalWins(25)
+                .recTotalLosses(15)
+                .recWinRate(62.5)
+                .recAvgKDA(2.5)
+                .recAvgKills(8.5)
+                .recAvgDeaths(3.2)
+                .recAvgAssists(9.1)
+                .recAvgCsPerMinute(6.8)
+                .recTotalCs(1360)
+                .build();
         memberRecentStatsRepository.save(recentStats);
     }
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/batch/BatchServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/batch/BatchServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.service.batch;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.core.batch.BatchService;
 import jakarta.persistence.EntityManager;
@@ -36,11 +38,15 @@ public class BatchServiceTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    MemberRecentStatsRepository memberRecentStatsRepository;
+
     @MockitoSpyBean
     EntityManager entityManager;
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         memberRepository.deleteAllInBatch();
     }
 
@@ -143,7 +149,7 @@ public class BatchServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -159,7 +165,13 @@ public class BatchServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/chat/ChatCommandServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/chat/ChatCommandServiceTest.java
@@ -2,9 +2,11 @@ package com.gamegoo.gamegoo_v2.service.chat;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.chat.domain.Chat;
 import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
@@ -75,6 +77,9 @@ class ChatCommandServiceTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private MemberRecentStatsRepository memberRecentStatsRepository;
+
     @MockitoSpyBean
     private MemberRepository memberRepository;
 
@@ -92,6 +97,7 @@ class ChatCommandServiceTest {
 
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         chatRepository.deleteAllInBatch();
         memberChatroomRepository.deleteAllInBatch();
         chatroomRepository.deleteAllInBatch();
@@ -479,8 +485,9 @@ class ChatCommandServiceTest {
 
     }
 
+
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -496,7 +503,13 @@ class ChatCommandServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
     private Chatroom createChatroom() {

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/manner/MannerServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/manner/MannerServiceTest.java
@@ -2,7 +2,9 @@ package com.gamegoo.gamegoo_v2.service.manner;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerKeyword;
 import com.gamegoo.gamegoo_v2.social.manner.domain.MannerRating;
@@ -44,8 +46,12 @@ public class MannerServiceTest {
     @Autowired
     MannerRatingKeywordRepository mannerRatingKeywordRepository;
 
+    @Autowired
+    MemberRecentStatsRepository memberRecentStatsRepository;
+
     @AfterEach
     void tearDown() {
+        memberRecentStatsRepository.deleteAll();
         mannerRatingKeywordRepository.deleteAllInBatch();
         mannerRatingRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
@@ -238,7 +244,7 @@ public class MannerServiceTest {
     }
 
     private Member createMember(String email, String gameName) {
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .email(email)
                 .password("testPassword")
                 .profileImage(1)
@@ -254,7 +260,13 @@ public class MannerServiceTest {
                 .freeWinRate(0.0)
                 .freeGameCount(0)
                 .isAgree(true)
+                .build();
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
                 .build());
+
+        return memberRepository.save(member);
     }
 
 }

--- a/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingStrategyProcessorTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/service/matching/MatchingStrategyProcessorTest.java
@@ -1,10 +1,12 @@
 package com.gamegoo.gamegoo_v2.service.matching;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Member;
+import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
-import com.gamegoo.gamegoo_v2.account.member.domain.Member;
-import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.repository.MemberRecentStatsRepository;
 import com.gamegoo.gamegoo_v2.account.member.repository.MemberRepository;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.matching.domain.MatchingRecord;
@@ -33,9 +35,13 @@ class MatchingStrategyProcessorTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    MemberRecentStatsRepository memberRecentStatsRepository;
+
     @AfterEach
     void tearDown() {
-        memberRepository.deleteAll();
+        memberRecentStatsRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
     }
 
     @Test
@@ -337,6 +343,10 @@ class MatchingStrategyProcessorTest {
         } else {
             member.updateMike(Mike.UNAVAILABLE);
         }
+
+        memberRecentStatsRepository.save(MemberRecentStats.builder()
+                .member(member)
+                .build());
 
         return memberRepository.save(member);
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 친구목록 조회 API 쿼리 테스트 및 최적화

## ⏳ 작업 상세 내용

- [x] 로컬에서 쿼리 로그를 보기 위한 P6Spy 설정 추가
- [x] Member <-> MemberRecentStats 간 연관관계 메소드 추가
- [x] Member -> MemberRecentStats LAZY 로딩 가능하도록 수정
- [x] 전체 친구 목록 조회 쿼리에서 fetchJoin하도록 수정
- [x] 테스트 코드 createMember 메소드 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] Member <-> MemberRecentStats 간 연관관계 메소드가 정의되어 있지 않아서 추가했습니다.
- [ ] Member -> MemberRecentStats로 즉시 로딩되도록 설정되어 있어, N+1 문제가 발생했습니다. optional = false 옵션을 추가해 LAZY로딩이 가능하도록 수정했습니다.
- [ ] 테스트 코드의 createMember 메소드에서도 MemberRecentStats 엔티티를 명시적으로 생성하여 모든 member가 memberRecentStats 엔티티와의 연관관계를 확실히 가짐을 보장하도록 수정했습니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
