### PR TITLE
[Feat/368] 비회원 게시물 라이엇 정보 주입 및 임시 멤버 생성

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/domain/Role.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/domain/Role.java
@@ -1,5 +1,5 @@
 package com.gamegoo.gamegoo_v2.account.auth.domain;
 
 public enum Role {
-    MEMBER, ADMIN
+    MEMBER, ADMIN, TMP
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -204,6 +204,29 @@ public class Member extends BaseDateTimeEntity {
                 .build();
     }
 
+    // 임시 멤버 전용
+    public static Member createForTmp(String gameName, String tag, Tier soloTier, int soloRank, double soloWinRate, 
+                                      Tier freeTier, int freeRank, double freeWinRate, int soloGameCount, int freeGameCount) {
+        // 임시 멤버 랜덤 프로필 사진 설정
+        int randomProfileImage = ThreadLocalRandom.current().nextInt(1, 9);
+
+        return Member.builder()
+                .profileImage(randomProfileImage)
+                .loginType(LoginType.GENERAL)
+                .gameName(gameName)
+                .tag(tag)
+                .soloGameCount(soloGameCount)
+                .freeGameCount(freeGameCount)
+                .soloTier(soloTier)
+                .soloRank(soloRank)
+                .soloWinRate(soloWinRate)
+                .freeTier(freeTier)
+                .freeRank(freeRank)
+                .freeWinRate(freeWinRate)
+                .isAgree(true)
+                .build();
+    }
+
     @Builder
     private Member(String email, String puuid, String password, int profileImage, LoginType loginType, String gameName,
                    String tag, Tier soloTier, int soloRank, double soloWinRate, Tier freeTier, int freeRank,

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberRepository.java
@@ -25,6 +25,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByGameNameAndTag(String gameName, String tag);
 
+    Optional<Member> findByGameNameAndTag(String gameName, String tag);
+
     List<Member> findAllByIdIn(List<Long> memberIds);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
@@ -21,12 +21,17 @@ public class MemberChampionService {
 
     /**
      * 멤버와 챔피언 ID 목록을 기반으로 MemberChampion 엔티티를 생성 및 저장하는 메서드
+     * 기존 데이터를 삭제하고 새로운 데이터를 저장합니다.
      *
      * @param member        대상 멤버
      * @param championStats 챔피언 ID 목록
      */
     @Transactional
     public void saveMemberChampions(Member member, List<ChampionStats> championStats) {
+        // 기존 챔피언 데이터 삭제
+        memberChampionRepository.deleteByMember(member);
+        
+        // 새로운 챔피언 데이터 저장
         championStats.forEach(stats -> {
             Long championId = stats.getChampionId();
             // 챔피언이 존재하지 않으면 스킵

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/domain/Board.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/domain/Board.java
@@ -74,11 +74,6 @@ public class Board extends BaseDateTimeEntity {
     @JoinColumn(name = "member_id", nullable = true)
     private Member member;
 
-    @Column(length = 50)
-    private String gameName;
-
-    @Column(length = 10)
-    private String tag;
 
     @Column(nullable = false)
     private boolean isGuest = false;
@@ -111,11 +106,10 @@ public class Board extends BaseDateTimeEntity {
                 .build();
     }
 
-    public static Board createForGuest(String gameName, String tag, GameMode gameMode, Position mainP, Position subP,
+    public static Board createForGuest(Member tmpMember, GameMode gameMode, Position mainP, Position subP,
                                        List<Position> wantP, Mike mike, String content, int boardProfileImage, String guestPassword) {
         return Board.builder()
-                .gameName(gameName)
-                .tag(tag)
+                .member(tmpMember)
                 .isGuest(true)
                 .gameMode(gameMode)
                 .mainP(mainP)
@@ -131,7 +125,7 @@ public class Board extends BaseDateTimeEntity {
     @Builder
     private Board(GameMode gameMode, Position mainP, Position subP, List<Position> wantP, Mike mike,
                   String content, int boardProfileImage, boolean deleted, Member member,
-                  String gameName, String tag, boolean isGuest, String guestPassword) {
+                  boolean isGuest, String guestPassword) {
         this.gameMode = gameMode;
         this.mainP = mainP;
         this.subP = subP;
@@ -141,8 +135,6 @@ public class Board extends BaseDateTimeEntity {
         this.boardProfileImage = boardProfileImage;
         this.deleted = deleted;
         this.member = member;
-        this.gameName = gameName;
-        this.tag = tag;
         this.isGuest = isGuest;
         this.guestPassword = guestPassword;
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,35 +46,6 @@ public class BoardByIdResponse {
         List<Long> gameStyleIds = board.getBoardGameStyles().stream()
                 .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
-
-        if (poster == null) { // 비회원 게시글 처리
-            return BoardByIdResponse.builder()
-                    .boardId(board.getId())
-                    .memberId(null)
-                    .createdAt(board.getCreatedAt())
-                    .profileImage(board.getBoardProfileImage())
-                    .gameName(board.getGameName())
-                    .tag(board.getTag())
-                    .mannerLevel(null)
-                    .soloTier(null)
-                    .soloRank(0)
-                    .freeTier(null)
-                    .freeRank(0)
-                    .mike(board.getMike())
-                    .championStatsResponseList(Collections.emptyList())
-                    .memberRecentStats(null)
-                    .gameMode(board.getGameMode())
-                    .mainP(board.getMainP())
-                    .subP(board.getSubP())
-                    .wantP(board.getWantP())
-                    .recentGameCount(null)
-                    .winRate(null)
-                    .gameStyles(gameStyleIds)
-                    .contents(board.getContent())
-                    .build();
-        }
-
-        // 회원 게시글 처리
         List<ChampionStatsResponse> championStatsResponseList = poster.getMemberChampionList() == null
                 ? List.of()
                 : poster.getMemberChampionList().stream()
@@ -86,7 +56,11 @@ public class BoardByIdResponse {
                         .games(mc.getGames())
                         .winRate(mc.getGames() > 0 ? (double) mc.getWins() / mc.getGames() : 0)
                         .csPerMinute(mc.getCsPerMinute())
+                        .averageCs(mc.getGames() > 0 ? (double) mc.getTotalCs() / mc.getGames() : 0)
                         .kda(mc.getKDA())
+                        .kills(mc.getGames() > 0 ? (double) mc.getKills() / mc.getGames() : 0)
+                        .deaths(mc.getGames() > 0 ? (double) mc.getDeaths() / mc.getGames() : 0)
+                        .assists(mc.getGames() > 0 ? (double) mc.getAssists() / mc.getGames() : 0)
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
@@ -61,39 +61,7 @@ public class BoardByIdResponseForMember {
                 .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
 
-        if (poster == null) { // 비회원 게시글 처리
-            return BoardByIdResponseForMember.builder()
-                    .boardId(board.getId())
-                    .memberId(null)
-                    .isBlocked(null)
-                    .isFriend(null)
-                    .friendRequestMemberId(null)
-                    .createdAt(board.getCreatedAt())
-                    .profileImage(board.getBoardProfileImage())
-                    .gameName(board.getGameName())
-                    .tag(board.getTag())
-                    .mannerLevel(null)
-                    .mannerRank(null)
-                    .mannerRatingCount(null)
-                    .soloTier(null)
-                    .soloRank(0)
-                    .freeTier(null)
-                    .freeRank(0)
-                    .mike(board.getMike())
-                    .championStatsResponseList(Collections.emptyList())
-                    .memberRecentStats(null)
-                    .gameMode(board.getGameMode())
-                    .mainP(board.getMainP())
-                    .subP(board.getSubP())
-                    .wantP(board.getWantP())
-                    .recentGameCount(null)
-                    .winRate(null)
-                    .gameStyles(gameStyleIds)
-                    .contents(board.getContent())
-                    .build();
-        }
-
-        // 회원 게시글 처리
+        // 임시 멤버든 정식 멤버든 항상 Member가 존재함
         List<ChampionStatsResponse> championStatsResponseList = poster.getMemberChampionList() == null
                 ? List.of()
                 : poster.getMemberChampionList().stream()
@@ -104,7 +72,11 @@ public class BoardByIdResponseForMember {
                         .games(mc.getGames())
                         .winRate(mc.getGames() > 0 ? (double) mc.getWins() / mc.getGames() : 0)
                         .csPerMinute(mc.getCsPerMinute())
+                        .averageCs(mc.getGames() > 0 ? (double) mc.getTotalCs() / mc.getGames() : 0)
                         .kda(mc.getKDA())
+                        .kills(mc.getGames() > 0 ? (double) mc.getKills() / mc.getGames() : 0)
+                        .deaths(mc.getGames() > 0 ? (double) mc.getDeaths() / mc.getGames() : 0)
+                        .assists(mc.getGames() > 0 ? (double) mc.getAssists() / mc.getGames() : 0)
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
@@ -63,14 +63,26 @@ public class BoardInsertResponse {
     }
 
     public static BoardInsertResponse ofGuest(Board board) {
+        Member tmpMember = board.getMember();
+        
+        Tier tier;
+        int rank;
+        if (board.getGameMode() == GameMode.FREE) {
+            tier = tmpMember.getFreeTier();
+            rank = tmpMember.getFreeRank();
+        } else {
+            tier = tmpMember.getSoloTier();
+            rank = tmpMember.getSoloRank();
+        }
+        
         return BoardInsertResponse.builder()
                 .boardId(board.getId())
                 .memberId(null) // 게스트는 memberId null
                 .profileImage(board.getBoardProfileImage())
-                .gameName(board.getGameName())
-                .tag(board.getTag())
-                .tier(null) // 게스트는 티어 없음
-                .rank(0) // 게스트는 랭크 없음
+                .gameName(tmpMember.getGameName())
+                .tag(tmpMember.getTag())
+                .tier(tier)
+                .rank(rank)
                 .gameMode(board.getGameMode())
                 .mainP(board.getMainP())
                 .subP(board.getSubP())

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -47,36 +47,7 @@ public class BoardListResponse {
     public static BoardListResponse of(Board board) {
         Member member = board.getMember();
 
-        if (member == null) { // 비회원 게시글 처리
-            return BoardListResponse.builder()
-                    .boardId(board.getId())
-                    .memberId(null)
-                    .gameName(board.getGameName())
-                    .tag(board.getTag())
-                    .mainP(board.getMainP())
-                    .subP(board.getSubP())
-                    .wantP(board.getWantP())
-                    .mike(board.getMike())
-                    .contents(board.getContent())
-                    .boardProfileImage(board.getBoardProfileImage())
-                    .createdAt(board.getCreatedAt())
-                    .profileImage(null)
-                    .mannerLevel(null)
-                    .tier(null)
-                    .rank(0)
-                    .gameMode(board.getGameMode())
-                    .winRate(null)
-                    .bumpTime(board.getBumpTime())
-                    .championStatsResponseList(Collections.emptyList())
-                    .memberRecentStats(null)
-                    .freeTier(null)
-                    .freeRank(0)
-                    .soloTier(null)
-                    .soloRank(0)
-                    .build();
-        }
-
-        // 회원 게시글 처리
+        // 모든 게시글은 임시 멤버든 정식 멤버든 항상 Member를 가짐
         Tier tier;
         int rank;
         Double winRate;
@@ -100,7 +71,11 @@ public class BoardListResponse {
                         .games(mc.getGames())
                         .winRate(mc.getGames() > 0 ? (double) mc.getWins() / mc.getGames() : 0)
                         .csPerMinute(mc.getCsPerMinute())
+                        .averageCs(mc.getGames() > 0 ? (double) mc.getTotalCs() / mc.getGames() : 0)
                         .kda(mc.getKDA())
+                        .kills(mc.getGames() > 0 ? (double) mc.getKills() / mc.getGames() : 0)
+                        .deaths(mc.getGames() > 0 ? (double) mc.getDeaths() / mc.getGames() : 0)
+                        .assists(mc.getGames() > 0 ? (double) mc.getAssists() / mc.getGames() : 0)
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardUpdateResponse.java
@@ -37,25 +37,7 @@ public class BoardUpdateResponse {
                 .map(bgs -> bgs.getGameStyle().getId())
                 .collect(Collectors.toList());
 
-        if (member == null) {
-            return BoardUpdateResponse.builder()
-                    .boardId(board.getId())
-                    .memberId(0L)
-                    .profileImage(board.getBoardProfileImage())
-                    .gameName(board.getGameName())
-                    .tag(board.getTag())
-                    .tier(null)
-                    .rank(0)
-                    .gameMode(board.getGameMode())
-                    .mainP(board.getMainP())
-                    .subP(board.getSubP())
-                    .wantP(board.getWantP())
-                    .mike(board.getMike())
-                    .gameStyles(gameStyleIds)
-                    .contents(board.getContent())
-                    .build();
-        }
-
+        // 임시 멤버든 정식 멤버든 항상 Member가 존재함
         Tier tier;
         int rank;
         if (board.getGameMode() == GameMode.FREE) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/service/BoardService.java
@@ -68,14 +68,13 @@ public class BoardService {
      * 게스트 게시글 엔티티 생성 및 저장
      */
     @Transactional
-    public Board createAndSaveGuestBoard(BoardInsertRequest request, String gameName, String tag, String password) {
+    public Board createAndSaveGuestBoard(BoardInsertRequest request, Member tmpMember, String password) {
         int boardProfileImage = (request.getBoardProfileImage() != null)
                 ? request.getBoardProfileImage()
-                : 1; // 기본 이미지
+                : tmpMember.getProfileImage();
 
         Board board = Board.createForGuest(
-                gameName,
-                tag,
+                tmpMember,
                 request.getGameMode(),
                 request.getMainP(),
                 request.getSubP(),

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
@@ -214,11 +214,11 @@ public class RiotRecordService {
                 .recTotalLosses(totalLosses)
                 .recWinRate(recWinRate)
                 .recAvgKDA(recAvgKDA)
-                .recAvgKills((double) totalKills / totalGames)
-                .recAvgDeaths((double) totalDeaths / totalGames)
-                .recAvgAssists((double) totalAssists / totalGames)
+                .recAvgKills(totalGames > 0 ? (double) totalKills / totalGames : 0.0)
+                .recAvgDeaths(totalGames > 0 ? (double) totalDeaths / totalGames : 0.0)
+                .recAvgAssists(totalGames > 0 ? (double) totalAssists / totalGames : 0.0)
                 .recAvgCsPerMinute(recAvgCsPerMinute)
-                .recTotalCs(totalCs/(totalWins+totalLosses))
+                .recTotalCs((totalWins + totalLosses) > 0 ? totalCs / (totalWins + totalLosses) : 0)
                 .build();
     }
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 비회원 게시물 라이엇 정보 주입 및 임시 멤버 생성

## ⏳ 작업 상세 내용

- [x] 비회원 게시물 작성 시 라이엇 API 호출하여 최신 챔피언 통계 및 전적 정보 자동 업데이트
- [x] MemberRecentStats 업데이트 로직 개선
- [x]  Board 응답 DTO에서 누락된 챔피언 통계 필드 추가 (kills, deaths, assists, averageCs)

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->
비회원의 경우 글을 등록할때만 전적을 새로 고침을 하도록 하였습니다!
- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
