### PR TITLE
[Feat/362] 비회원 신고 등록 API 구현

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/AuthMember.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/AuthMember.java
@@ -12,4 +12,6 @@ import java.lang.annotation.Target;
 @Parameter(hidden = true)
 public @interface AuthMember {
 
+    boolean required() default true;
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
@@ -37,13 +37,20 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
     public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   @NonNull NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
+        AuthMember authMember = parameter.getParameterAnnotation(AuthMember.class);
+        boolean required = authMember == null || authMember.required(); // 기본값 true
+
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
         if (currentMemberId != null) {
             return memberRepository.findById(currentMemberId)
                     .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-        } else {
+        }
+
+        if (required) {
             throw new AuthException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }
+
+        return null; // 비회원 요청인 경우 null 객체 리턴
 
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
@@ -89,17 +89,11 @@ public class JwtProvider {
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
 
-        if (!StringUtils.hasText(bearerToken)) {
-            // Authorization 헤더가 없는 경우
-            throw new JwtAuthException(ErrorCode.MISSING_AUTH_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
         }
 
-        if (!bearerToken.startsWith(BEARER_PREFIX)) {
-            // Authorization 헤더 형식이 잘못된 경우
-            throw new JwtAuthException(ErrorCode.INVALID_AUTH_HEADER);
-        }
-
-        return bearerToken.substring(7);
+        return null;
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/EntryPointHandler.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/EntryPointHandler.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.account.auth.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +11,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.io.PrintWriter;
-
-import static com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode._INTERNAL_SERVER_ERROR;
 
 
 @Slf4j
@@ -25,8 +25,7 @@ public class EntryPointHandler implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) {
-
-        var errorCode = _INTERNAL_SERVER_ERROR;
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED_EXCEPTION;
 
         ApiResponse<Object> apiResponse = ApiResponse.builder()
                 .code(errorCode.getCode())
@@ -36,14 +35,12 @@ public class EntryPointHandler implements AuthenticationEntryPoint {
                 .build();
 
         response.setContentType("application/json; charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
 
         try (PrintWriter writer = response.getWriter()) {
-            String jsonResponse = objectMapper.writeValueAsString(apiResponse);
-            writer.write(jsonResponse);
-            writer.flush();
-        } catch (Exception e) {
-            log.error("Security Filter EntryPoint 응답 메시지 작성 에러", e);
+            writer.write(objectMapper.writeValueAsString(apiResponse));
+        } catch (IOException e) {
+            log.error("EntryPoint 응답 실패", e);
         }
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
@@ -37,20 +37,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
             Long memberId = jwtProvider.getMemberId(jwt);
-
-            // 유저와 토큰 일치 시 userDetails 생성
             UserDetails userDetails = customUserDetailsService.loadUserByMemberId(memberId);
-
-            // UserDetails, Password, Role -> 접근권한 인증 Token 생성
-            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                    new UsernamePasswordAuthenticationToken(
-                            userDetails, null,
-                            userDetails.getAuthorities());
-
-            //현재 Request의 Security Context에 접근권한 설정
-            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         } else {
-            SecurityContextHolder.getContext().setAuthentication(null);
+            // 토큰이 없으면 인증 없이 진행 (비회원)
+            SecurityContextHolder.clearContext(); // 또는 유지
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
@@ -1,13 +1,16 @@
 package com.gamegoo.gamegoo_v2.content.report.controller;
 
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
-import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportRequest;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportPath;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportSortOrder;
 import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportProcessRequest;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportRequest;
+import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportInsertResponse;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportPageResponse;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportProcessResponse;
-import com.gamegoo.gamegoo_v2.content.report.dto.request.ReportSearchRequest;
 import com.gamegoo.gamegoo_v2.content.report.service.ReportFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,22 +18,19 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.data.domain.Pageable;
-import com.gamegoo.gamegoo_v2.content.report.domain.ReportPath;
-import com.gamegoo.gamegoo_v2.content.report.domain.ReportSortOrder;
-import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
-import java.time.LocalDateTime;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Tag(name = "Report", description = "Report 관련 API")
@@ -46,31 +46,31 @@ public class ReportController {
     @PostMapping("/{memberId}")
     public ApiResponse<ReportInsertResponse> addReport(@PathVariable("memberId") Long targetMemberId,
                                                        @Valid @RequestBody ReportRequest request,
-                                                       @AuthMember Member member) {
+                                                       @AuthMember(required = false) Member member) {
         return ApiResponse.ok(reportFacadeService.addReport(member, targetMemberId, request));
     }
 
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "신고 목록 조회 (관리자 전용)",
-               description = """
-                   관리자만 접근 가능한 신고 목록 고급 필터링 조회 API입니다.
+            description = """
+                    관리자만 접근 가능한 신고 목록 고급 필터링 조회 API입니다.
 
-                   **필터링 옵션:**
-                   - reportedMemberKeyword: 피신고자 검색 (게임명, 태그, 게임명#태그 형식 지원)
-                   - reporterKeyword: 신고자 검색 (게임명, 태그, 게임명#태그 형식 지원)
-                   - contentKeyword: 신고 내용으로 검색
-                   - reportPaths: 신고 경로 (BOARD=게시판, CHAT=채팅, PROFILE=프로필)
-                   - reportTypes: 신고 사유 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)
-                   - startDate/endDate: 신고 날짜 범위 (yyyy-MM-dd'T'HH:mm:ss)
-                   - reportCountMin/Max/Exact: 누적 신고 횟수 필터
-                   - isDeleted: 게시물 삭제 여부 (true/false)
-                   - banTypes: 제재 상태 (NONE, WARNING, BAN_1D, BAN_3D, BAN_5D, BAN_1W, BAN_2W, BAN_1M, PERMANENT)
-                   - sortOrder: 정렬 순서 (LATEST: 최신순, OLDEST: 오래된순) - 기본값: LATEST
-                   - page/size: 페이징 (예: page=0&size=10)
+                    **필터링 옵션:**
+                    - reportedMemberKeyword: 피신고자 검색 (게임명, 태그, 게임명#태그 형식 지원)
+                    - reporterKeyword: 신고자 검색 (게임명, 태그, 게임명#태그 형식 지원)
+                    - contentKeyword: 신고 내용으로 검색
+                    - reportPaths: 신고 경로 (BOARD=게시판, CHAT=채팅, PROFILE=프로필)
+                    - reportTypes: 신고 사유 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)
+                    - startDate/endDate: 신고 날짜 범위 (yyyy-MM-dd'T'HH:mm:ss)
+                    - reportCountMin/Max/Exact: 누적 신고 횟수 필터
+                    - isDeleted: 게시물 삭제 여부 (true/false)
+                    - banTypes: 제재 상태 (NONE, WARNING, BAN_1D, BAN_3D, BAN_5D, BAN_1W, BAN_2W, BAN_1M, PERMANENT)
+                    - sortOrder: 정렬 순서 (LATEST: 최신순, OLDEST: 오래된순) - 기본값: LATEST
+                    - page/size: 페이징 (예: page=0&size=10)
 
-                   **사용 예시:**
-                   /api/v2/report/list?reportedMemberKeyword=홍길동#KR1&reportTypes=1,4&startDate=2024-01-01T00:00:00&banTypes=WARNING&page=0&size=10
-                   """)
+                    **사용 예시:**
+                    /api/v2/report/list?reportedMemberKeyword=홍길동#KR1&reportTypes=1,4&startDate=2024-01-01T00:00:00&banTypes=WARNING&page=0&size=10
+                    """)
     @GetMapping("/list")
     public ApiResponse<ReportPageResponse> getReportList(
             @RequestParam(required = false) String reportedMemberKeyword,
@@ -109,41 +109,41 @@ public class ReportController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "신고 처리 (관리자 전용)",
-               description = """
-                   관리자가 신고를 처리하여 제재를 적용하는 API입니다.
+            description = """
+                    관리자가 신고를 처리하여 제재를 적용하는 API입니다.
 
-                   **Request Body:**
-                   - banType: 적용할 제재 유형 (필수)
-                     - NONE: 제재 없음
-                     - WARNING: 경고
-                     - BAN_1D: 1일 정지
-                     - BAN_3D: 3일 정지
-                     - BAN_5D: 5일 정지
-                     - BAN_1W: 1주 정지
-                     - BAN_2W: 2주 정지
-                     - BAN_1M: 1개월 정지
-                     - PERMANENT: 영구 정지
-                   - processReason: 제재 사유 (선택사항)
-                   """)
+                    **Request Body:**
+                    - banType: 적용할 제재 유형 (필수)
+                      - NONE: 제재 없음
+                      - WARNING: 경고
+                      - BAN_1D: 1일 정지
+                      - BAN_3D: 3일 정지
+                      - BAN_5D: 5일 정지
+                      - BAN_1W: 1주 정지
+                      - BAN_2W: 2주 정지
+                      - BAN_1M: 1개월 정지
+                      - PERMANENT: 영구 정지
+                    - processReason: 제재 사유 (선택사항)
+                    """)
     @Parameter(name = "reportId", description = "처리할 신고의 ID입니다.")
     @PutMapping("/{reportId}/process")
     public ApiResponse<ReportProcessResponse> processReport(@PathVariable("reportId") Long reportId,
-                                                           @Valid @RequestBody ReportProcessRequest request) {
+                                                            @Valid @RequestBody ReportProcessRequest request) {
         return ApiResponse.ok(reportFacadeService.processReport(reportId, request));
     }
 
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "신고된 게시글 삭제 (관리자 전용)",
-               description = """
-                   관리자가 신고된 게시글을 삭제하는 API입니다.
+            description = """
+                    관리자가 신고된 게시글을 삭제하는 API입니다.
 
-                   해당 신고와 연관된 게시글이 있는 경우 삭제 처리되며,
-                   게시글이 없는 경우 적절한 메시지가 반환됩니다.
+                    해당 신고와 연관된 게시글이 있는 경우 삭제 처리되며,
+                    게시글이 없는 경우 적절한 메시지가 반환됩니다.
 
-                   **반환 메시지:**
-                   - 성공: "신고된 게시글 삭제가 완료되었습니다"
-                   - 게시글 없음: "삭제할 게시글이 존재하지 않습니다"
-                   """)
+                    **반환 메시지:**
+                    - 성공: "신고된 게시글 삭제가 완료되었습니다"
+                    - 게시글 없음: "삭제할 게시글이 존재하지 않습니다"
+                    """)
     @Parameter(name = "reportId", description = "삭제할 게시글과 연관된 신고의 ID입니다.")
     @DeleteMapping("/{reportId}/post")
     public ApiResponse<String> deleteReportedPost(@PathVariable("reportId") Long reportId) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/domain/Report.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/domain/Report.java
@@ -37,7 +37,7 @@ public class Report extends BaseDateTimeEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "from_member_id", nullable = false)
+    @JoinColumn(name = "from_member_id")
     private Member fromMember;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.gamegoo.gamegoo_v2.core.log.LoggingFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -82,7 +83,8 @@ public class SecurityConfig {
                 .requestMatchers("/api/v2/riot/verify",
                         "/api/v2/riot/oauth/callback",
                         "/api/v2/riot/join").permitAll() // riot
-                .requestMatchers("/api/v2/posts/list/**", "/api/v2/posts/cursor", "/api/v2/posts/guest").permitAll() // board
+                .requestMatchers("/api/v2/posts/list/**", "/api/v2/posts/cursor",
+                        "/api/v2/posts/guest").permitAll() // board
                 .requestMatchers("/api/v2/posts/guest/**").permitAll() // guest board
                 .requestMatchers(
                         "/api/v2/auth/token/**",
@@ -95,6 +97,7 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/api/v2/manner/keyword/*",
                         "/api/v2/manner/level/*").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v2/report/*").permitAll()
                 .requestMatchers(
                         "/swagger-ui/**",
                         "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/event/listener/EmailEventListener.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/event/listener/EmailEventListener.java
@@ -38,10 +38,15 @@ public class EmailEventListener {
             String subject = String.format(REPORT_EMAIL_SUBJECT, event.getFromMemberGameName(),
                     event.getFromMemberTag());
 
+            String fromMemberId = "비회원";
+            if (event.getFromMemberId() != null) {
+                fromMemberId = event.getFromMemberId().toString();
+            }
+
             Map<String, String> placeholders = new HashMap<>();
             placeholders.put("TITLE", subject);
             placeholders.put("REPORT_ID", report.getId().toString());
-            placeholders.put("REPORT_FROM_MEMBER_ID", event.getFromMemberId().toString());
+            placeholders.put("REPORT_FROM_MEMBER_ID", fromMemberId);
             placeholders.put("REPORT_TO_MEMBER_ID", event.getToMemberId().toString());
             placeholders.put("REPORT_PATH", report.getPath().name());
             placeholders.put("REPORT_TYPE", reportService.getReportTypeString(event.getReportId()));

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ExceptionAdvice.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ExceptionAdvice.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -112,6 +113,20 @@ public class ExceptionAdvice {
 
         String errorMessage = String.format("%s 파라미터의 값은 %s 타입이어야 합니다.", parameterName, expectedType);
         return ResponseEntity.badRequest().body(ApiResponse.of(BAD_REQUEST, errorMessage));
+    }
+
+    // 서버 내부 에러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleAll(Exception e) {
+        ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
+
+        ApiResponse<Object> apiResponse = ApiResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .status(errorCode.getStatus())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(apiResponse);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ socket:
     url: ${SOCKET_SERVER_URL}
 
 email:
-  report_email_to: gamegoo2025@gmail.com
+  report_email_to: report@gamegoo.co.kr
   report_email_template_path: templates/new-report.html
 
 logging:


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 비회원 신고 등록 API 구현 및 에러 핸들링 리팩토링

## ⏳ 작업 상세 내용

- [x] `@AuthMember` 어노테이션에 `required` 옵션을 추가해 비회원 요청(jwt 토큰이 없는 요청)의 경우 Member 객체를 null로 주입받도록 확장
- [x] EntryPointHandler에서는 인증 실패 에러(401) 응답을 반환하도록 수정
- [x] RestControllerService에 서버 내부 에러(500) 핸들링 로직 추가
- [x] 신고 등록 API 비회원 요청 가능하도록 확장
- [x] 신고 등록 시 이메일 발송 대상 계정 수정 (report@gamegoo.co.kr로 메일 전송되도록)

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 기존에 서버 내부에서 발생한 에러에 대해서도 401 응답이 가는 문제로 인해 EntryPointHandler에서 500 에러 응답을 주도록 수정했었는데, 이 부분이 EntryPointHandler의 목적과 맞지 않아서 다시 401 응답을 주도록 수정했습니다. 서버 내부 에러는 별도로 RestControllerService에서 핸들링하도록 수정했습니다.
- [ ] 회원 + 비회원 통합 api endpoint의 경우, 컨트롤러에서 `@AuthMember(required=false)`로 사용하면 비회원 요청의 경우 Member 객체를 null로 주입받을 수 있습니다. (동일한 기능을 하는 api에 대해 회원용 endpoint, 비회원용 endpoint를 분리할 필요 없습니다.)

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 
