### PR TITLE
[Refactor/381] shared enum 설정 및 optional = false 재추가

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/dto/response/LoginResponse.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.account.auth.dto.response;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ public class LoginResponse {
     int profileImage;
     String accessToken;
     String refreshToken;
+    @Schema(ref = "#/components/schemas/BanType")
     BanType banType;
     LocalDateTime banExpireAt;
     String banMessage;

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -130,7 +130,7 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberGameStyle> memberGameStyleList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
     private MemberRecentStats memberRecentStats;
 
     @Enumerated(EnumType.STRING)
@@ -205,7 +205,7 @@ public class Member extends BaseDateTimeEntity {
     }
 
     // 임시 멤버 전용
-    public static Member createForTmp(String gameName, String tag, Tier soloTier, int soloRank, double soloWinRate, 
+    public static Member createForTmp(String gameName, String tag, Tier soloTier, int soloRank, double soloWinRate,
                                       Tier freeTier, int freeRank, double freeWinRate, int soloGameCount, int freeGameCount) {
         // 임시 멤버 랜덤 프로필 사진 설정
         int randomProfileImage = ThreadLocalRandom.current().nextInt(1, 9);

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/request/IsMikeRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/request/IsMikeRequest.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.account.member.dto.request;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.Getter;
 @Getter
 public class IsMikeRequest {
 
+    @Schema(ref = "#/components/schemas/Mike")
     @NotNull(message = "mike 값은 비워둘 수 없습니다.")
     Mike mike;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/request/PositionRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/request/PositionRequest.java
@@ -1,6 +1,8 @@
 package com.gamegoo.gamegoo_v2.account.member.dto.request;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,13 +13,16 @@ import java.util.List;
 @Builder
 public class PositionRequest {
 
+    @Schema(ref = "#/components/schemas/Position")
     @NotNull(message = "메인 포지션은 null일 수 없습니다.")
-    private Position mainP; // 메인 포지션
+    private Position mainP;
 
+    @Schema(ref = "#/components/schemas/Position")
     @NotNull(message = "서브 포지션은 null일 수 없습니다.")
-    private Position subP; // 서브 포지션
+    private Position subP;
 
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     @NotNull(message = "원하는 포지션은 null일 수 없습니다.")
-    private List<Position> wantP; // 원하는 포지션
+    private List<Position> wantP;
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
@@ -1,11 +1,14 @@
 package com.gamegoo.gamegoo_v2.account.member.dto.response;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.game.dto.response.GameStyleResponse;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.ChampionStatsResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,23 +20,30 @@ public class MyProfileResponse {
 
     Long id;
     Integer profileImg;
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
     String email;
     String gameName;
     String tag;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier soloTier;
     Integer soloRank;
     Double soloWinrate;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier freeTier;
     Integer freeRank;
     Double freeWinrate;
     String updatedAt;
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
     Boolean isAgree;
     Boolean isBlind;
-    String loginType;
+    @Schema(ref = "#/components/schemas/LoginType")
+    LoginType loginType;
     List<GameStyleResponse> gameStyleResponseList;
     List<ChampionStatsResponse> championStatsResponseList;
     MemberRecentStatsResponse memberRecentStats;
@@ -65,7 +75,7 @@ public class MyProfileResponse {
                 .wantP(member.getWantP())
                 .isAgree(member.isAgree())
                 .isBlind(member.getBlind())
-                .loginType(String.valueOf(member.getLoginType()))
+                .loginType(member.getLoginType())
                 .updatedAt(String.valueOf(member.getUpdatedAt()))
                 .gameStyleResponseList(gameStyleResponseList)
                 .championStatsResponseList(championStatsResponseList)

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
@@ -1,11 +1,14 @@
 package com.gamegoo.gamegoo_v2.account.member.dto.response;
 
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.game.dto.response.GameStyleResponse;
 import com.gamegoo.gamegoo_v2.content.board.dto.response.ChampionStatsResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,22 +20,29 @@ public class OtherProfileResponse {
 
     Long id;
     Integer profileImg;
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
     String gameName;
     String tag;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier soloTier;
     Integer soloRank;
     Double soloWinrate;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier freeTier;
     Integer freeRank;
     Double freeWinrate;
     String updatedAt;
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
     Boolean isAgree;
     Boolean isBlind;
-    String loginType;
+    @Schema(ref = "#/components/schemas/LoginType")
+    LoginType loginType;
     Boolean blocked; // 해당 회원을 차단했는지 여부
     Boolean friend; // 해당 회원과의 친구 여부
     Long friendRequestMemberId; // 해당 회원과의 친구 요청 상태
@@ -67,7 +77,7 @@ public class OtherProfileResponse {
                 .subP(targetMember.getSubP())
                 .isAgree(targetMember.isAgree())
                 .isBlind(targetMember.getBlind())
-                .loginType(String.valueOf(targetMember.getLoginType()))
+                .loginType(targetMember.getLoginType())
                 .updatedAt(String.valueOf(targetMember.getUpdatedAt()))
                 .blocked(isBlocked)
                 .friend(isFriend)

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -19,6 +19,7 @@ import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -91,10 +92,15 @@ public class BoardController {
     })
     public ApiResponse<BoardResponse> boardList(
             @ValidPage @RequestParam(name = "page") Integer page,
+            @Parameter(description = "게임 모드", schema = @Schema(ref = "#/components/schemas/GameMode"))
             @RequestParam(required = false) GameMode gameMode,
+            @Parameter(description = "티어", schema = @Schema(ref = "#/components/schemas/Tier"))
             @RequestParam(required = false) Tier tier,
+            @Parameter(description = "메인 포지션", schema = @Schema(ref = "#/components/schemas/Position"))
             @RequestParam(required = false) Position mainP,
+            @Parameter(description = "서브 포지션", schema = @Schema(ref = "#/components/schemas/Position"))
             @RequestParam(required = false) Position subP,
+            @Parameter(description = "마이크 사용 여부", schema = @Schema(ref = "#/components/schemas/Mike"))
             @RequestParam(required = false) Mike mike) {
 
         return ApiResponse.ok(boardFacadeService.getBoardList(gameMode, tier, mainP, subP, mike, page));
@@ -179,9 +185,13 @@ public class BoardController {
     public ResponseEntity<ApiResponse<BoardCursorResponse>> getBoardsWithCursor(
             @RequestParam(required = false) LocalDateTime cursor,
             @RequestParam(required = false) Long cursorId,
+            @Parameter(description = "게임 모드", schema = @Schema(ref = "#/components/schemas/GameMode"))
             @RequestParam(required = false) GameMode gameMode,
+            @Parameter(description = "티어", schema = @Schema(ref = "#/components/schemas/Tier"))
             @RequestParam(required = false) Tier tier,
+            @Parameter(description = "주 포지션", schema = @Schema(ref = "#/components/schemas/Position"))
             @RequestParam(required = false) Position position1,
+            @Parameter(description = "부 포지션", schema = @Schema(ref = "#/components/schemas/Position"))
             @RequestParam(required = false) Position position2) {
         BoardCursorResponse response = boardFacadeService.getAllBoardsWithCursor(cursor, cursorId, gameMode, tier, position1, position2);
         return ResponseEntity.ok(ApiResponse.ok(response));

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/request/BoardInsertRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/request/BoardInsertRequest.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.content.board.dto.request;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -20,20 +21,24 @@ public class BoardInsertRequest {
     @NotNull(message = "boardProfileImage 값은 비워둘 수 없습니다.")
     Integer boardProfileImage;
 
+    @Schema(ref = "#/components/schemas/GameMode")
     @NotNull(message = "게임 모드는 필수 값입니다.")
     GameMode gameMode;
 
+    @Schema(ref = "#/components/schemas/Position")
     @NotNull(message = "주 포지션은 필수 값입니다.")
     Position mainP;
 
+    @Schema(ref = "#/components/schemas/Position")
     @NotNull(message = "부 포지션은 필수 값입니다.")
     Position subP;
 
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     @NotNull(message = "희망 포지션은 필수 값입니다.")
     @Size(min = 1, message = "최소 하나 이상의 희망 포지션을 선택해야 합니다.")
     List<Position> wantP;
 
-    @Schema(description = "마이크 사용 여부", defaultValue = "UNAVAILABLE")
+    @Schema(ref = "#/components/schemas/Mike", defaultValue = "UNAVAILABLE")
     Mike mike = Mike.UNAVAILABLE;
 
     @NotNull(message = "게임 스타일 리스트는 필수 값입니다.")

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/request/BoardUpdateRequest.java
@@ -3,6 +3,7 @@ package com.gamegoo.gamegoo_v2.content.board.dto.request;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -20,20 +21,24 @@ public class BoardUpdateRequest {
     @Max(value = 8, message = "프로필 이미지의 값은 8이하이어야 합니다.")
     Integer boardProfileImage;
 
+    @Schema(ref = "#/components/schemas/GameMode")
     @NotNull(message = "게임 모드는 필수 값입니다.")
     GameMode gameMode;
 
+    @Schema(ref = "#/components/schemas/Position")
     @NotNull(message = "주 포지션은 필수 값입니다.")
     Position mainP;
 
+    @Schema(ref = "#/components/schemas/Position")
     @NotNull(message = "부 포지션은 필수 값입니다.")
     Position subP;
 
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     @NotNull(message = "희망 포지션은 필수 값입니다.")
     @Size(min = 1, message = "최소 하나 이상의 희망 포지션을 선택해야 합니다.")
     List<Position> wantP;
 
-    @Schema(description = "마이크 사용 여부 (선택)")
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
 
     @NotNull(message = "게임 스타일 리스트는 필수 값입니다.")

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponse.java
@@ -7,6 +7,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.account.member.dto.response.MemberRecentStatsResponse;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -25,16 +27,23 @@ public class BoardByIdResponse {
     String gameName;
     String tag;
     Integer mannerLevel;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier soloTier;
     int soloRank;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier freeTier;
     int freeRank;
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
     List<ChampionStatsResponse> championStatsResponseList;
     MemberRecentStatsResponse memberRecentStats;
+    @Schema(ref = "#/components/schemas/GameMode")
     GameMode gameMode;
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
     Integer recentGameCount;
     Double winRate;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardByIdResponseForMember.java
@@ -8,6 +8,8 @@ import com.gamegoo.gamegoo_v2.account.member.dto.response.MemberRecentStatsRespo
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.social.manner.service.MannerService;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -32,16 +34,23 @@ public class BoardByIdResponseForMember {
     Integer mannerLevel;
     Double mannerRank;
     Integer mannerRatingCount;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier soloTier;
     int soloRank;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier freeTier;
     int freeRank;
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
     List<ChampionStatsResponse> championStatsResponseList;
     MemberRecentStatsResponse memberRecentStats;
+    @Schema(ref = "#/components/schemas/GameMode")
     GameMode gameMode;
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
     Integer recentGameCount;
     Double winRate;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardInsertResponse.java
@@ -6,6 +6,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,12 +22,18 @@ public class BoardInsertResponse {
     private Integer profileImage;
     private String gameName;
     private String tag;
+    @Schema(ref = "#/components/schemas/Tier")
     private Tier tier;
     private int rank;
+    @Schema(ref = "#/components/schemas/GameMode")
     private GameMode gameMode;
+    @Schema(ref = "#/components/schemas/Position")
     private Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     private Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     private List<Position> wantP;
+    @Schema(ref = "#/components/schemas/Mike")
     private Mike mike;
     private List<Long> gameStyles;
     private String contents;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -7,6 +7,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.account.member.dto.response.MemberRecentStatsResponse;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,24 +25,32 @@ public class BoardListResponse {
     private Long memberId;
     private String gameName;
     private String tag;
+    @Schema(ref = "#/components/schemas/Position")
     private Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     private Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     private List<Position> wantP;
+    @Schema(ref = "#/components/schemas/Mike")
     private Mike mike;
     private String contents;
     private Integer boardProfileImage;
     private LocalDateTime createdAt;
     private Integer profileImage;
     private Integer mannerLevel;
+    @Schema(ref = "#/components/schemas/Tier")
     private Tier tier;
     private int rank;
+    @Schema(ref = "#/components/schemas/GameMode")
     private GameMode gameMode;
     private Double winRate;
     private LocalDateTime bumpTime;
     private List<ChampionStatsResponse> championStatsResponseList;
     private MemberRecentStatsResponse memberRecentStats;
+    @Schema(ref = "#/components/schemas/Tier")
     private Tier freeTier;
     private int freeRank;
+    @Schema(ref = "#/components/schemas/Tier")
     private Tier soloTier;
     private int soloRank;
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardUpdateResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardUpdateResponse.java
@@ -6,6 +6,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,12 +23,18 @@ public class BoardUpdateResponse {
     Integer profileImage;
     String gameName;
     String tag;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier tier;
     Integer rank;
+    @Schema(ref = "#/components/schemas/GameMode")
     GameMode gameMode;
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
     List<Long> gameStyles;
     String contents;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/MyBoardListResponse.java
@@ -4,6 +4,7 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.content.board.domain.Board;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,6 +19,7 @@ public class MyBoardListResponse {
     Integer profileImage;
     String gameName;
     String tag;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier tier;
     int rank;
     String contents;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
@@ -15,6 +15,7 @@ import com.gamegoo.gamegoo_v2.content.report.service.ReportFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -76,7 +77,9 @@ public class ReportController {
             @RequestParam(required = false) String reportedMemberKeyword,
             @RequestParam(required = false) String reporterKeyword,
             @RequestParam(required = false) String contentKeyword,
+            @Parameter(description = "신고 경로", schema = @Schema(ref = "#/components/schemas/ReportPath"))
             @RequestParam(required = false) List<ReportPath> reportPaths,
+            @Parameter(description = "신고 유형 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)", schema = @Schema(ref = "#/components/schemas/ReportType"))
             @RequestParam(required = false) List<Integer> reportTypes,
             @RequestParam(required = false) LocalDateTime startDate,
             @RequestParam(required = false) LocalDateTime endDate,
@@ -84,7 +87,9 @@ public class ReportController {
             @RequestParam(required = false) Integer reportCountMax,
             @RequestParam(required = false) Integer reportCountExact,
             @RequestParam(required = false) Boolean isDeleted,
+            @Parameter(description = "제재 상태", schema = @Schema(ref = "#/components/schemas/BanType"))
             @RequestParam(required = false) List<BanType> banTypes,
+            @Parameter(description = "정렬 순서", schema = @Schema(ref = "#/components/schemas/ReportSortOrder"))
             @RequestParam(required = false) ReportSortOrder sortOrder,
             Pageable pageable) {
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/BanRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/BanRequest.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.content.report.dto.request;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class BanRequest {
+    @Schema(ref = "#/components/schemas/BanType")
     private BanType banType;
     private LocalDateTime banExpireAt;
     private String banScope;

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportProcessRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportProcessRequest.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.content.report.dto.request;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ReportProcessRequest {
     
+    @Schema(ref = "#/components/schemas/BanType")
     @NotNull(message = "제재 유형은 필수입니다.")
     private BanType banType;
     

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportRequest.java
@@ -10,6 +10,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
@@ -17,6 +19,7 @@ import java.util.List;
 @Builder
 public class ReportRequest {
 
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/ReportType"))
     @NotDuplicated
     @NotEmpty(message = "신고 코드 리스트는 비워둘 수 없습니다.")
     @EachMin(value = 1, message = "report code는 1 이상의 값이어야 합니다.")

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportSearchRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/request/ReportSearchRequest.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
 import com.gamegoo.gamegoo_v2.content.report.domain.ReportSortOrder;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @NoArgsConstructor
@@ -18,6 +20,7 @@ public class ReportSearchRequest {
     private String reportedMemberKeyword;
     private String reporterKeyword;
     private String contentKeyword;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/ReportPath"))
     private List<ReportPath> reportPaths;
     private List<Integer> reportTypes;
     private LocalDateTime startDate;
@@ -26,6 +29,8 @@ public class ReportSearchRequest {
     private Integer reportCountMax;
     private Integer reportCountExact;
     private Boolean isDeleted;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/BanType"))
     private List<BanType> banTypes;
+    @Schema(ref = "#/components/schemas/ReportSortOrder")
     private ReportSortOrder sortOrder;
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/response/ReportProcessResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/response/ReportProcessResponse.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.content.report.dto.response;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,7 @@ public class ReportProcessResponse {
     
     private Long reportId;
     private Long targetMemberId;
+    @Schema(ref = "#/components/schemas/BanType")
     private BanType appliedBanType;
     private LocalDateTime banExpireAt;
     private String message;

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
@@ -1,6 +1,5 @@
 package com.gamegoo.gamegoo_v2.core.config;
 
-import com.gamegoo.gamegoo_v2.account.auth.domain.Role;
 import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
 import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
 import com.gamegoo.gamegoo_v2.account.member.domain.Mike;

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
@@ -1,0 +1,177 @@
+package com.gamegoo.gamegoo_v2.core.config;
+
+import com.gamegoo.gamegoo_v2.account.auth.domain.Role;
+import com.gamegoo.gamegoo_v2.account.member.domain.BanType;
+import com.gamegoo.gamegoo_v2.account.member.domain.LoginType;
+import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
+import com.gamegoo.gamegoo_v2.account.member.domain.Position;
+import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportPath;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportSortOrder;
+import com.gamegoo.gamegoo_v2.content.report.domain.ReportType;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import com.gamegoo.gamegoo_v2.matching.domain.MatchingStatus;
+import com.gamegoo.gamegoo_v2.matching.domain.MatchingType;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenApiCustomizer openApiCustomizer() {
+        return openApi -> {
+            Components components = openApi.getComponents();
+            if (components == null) {
+                components = new Components();
+                openApi.setComponents(components);
+            }
+
+            // Tier enum 등록
+            Schema<String> tierSchema = new Schema<String>()
+                    .type("string")
+                    .description("리그오브레전드 티어");
+            tierSchema.setEnum(Arrays.asList(
+                    Tier.UNRANKED.name(),
+                    Tier.IRON.name(),
+                    Tier.BRONZE.name(),
+                    Tier.SILVER.name(),
+                    Tier.GOLD.name(),
+                    Tier.PLATINUM.name(),
+                    Tier.EMERALD.name(),
+                    Tier.DIAMOND.name(),
+                    Tier.MASTER.name(),
+                    Tier.GRANDMASTER.name(),
+                    Tier.CHALLENGER.name()
+            ));
+            components.addSchemas("Tier", tierSchema);
+
+            // Position enum 등록
+            Schema<String> positionSchema = new Schema<String>()
+                    .type("string")
+                    .description("게임 포지션");
+            positionSchema.setEnum(Arrays.asList(
+                    Position.ANY.name(),
+                    Position.TOP.name(),
+                    Position.JUNGLE.name(),
+                    Position.MID.name(),
+                    Position.ADC.name(),
+                    Position.SUP.name()
+            ));
+            components.addSchemas("Position", positionSchema);
+
+            // Mike enum 등록
+            Schema<String> mikeSchema = new Schema<String>()
+                    .type("string")
+                    .description("마이크 사용 가능 여부");
+            mikeSchema.setEnum(Arrays.asList(
+                    Mike.UNAVAILABLE.name(),
+                    Mike.AVAILABLE.name()
+            ));
+            components.addSchemas("Mike", mikeSchema);
+
+            // GameMode enum 등록
+            Schema<String> gameModeSchema = new Schema<String>()
+                    .type("string")
+                    .description("게임 모드");
+            gameModeSchema.setEnum(Arrays.asList(
+                    GameMode.FAST.name(),
+                    GameMode.SOLO.name(),
+                    GameMode.FREE.name(),
+                    GameMode.ARAM.name()
+            ));
+            components.addSchemas("GameMode", gameModeSchema);
+
+            // LoginType enum 등록
+            Schema<String> loginTypeSchema = new Schema<String>()
+                    .type("string")
+                    .description("로그인 유형");
+            loginTypeSchema.setEnum(Arrays.asList(
+                    LoginType.GENERAL.name(),
+                    LoginType.RSO.name()
+            ));
+            components.addSchemas("LoginType", loginTypeSchema);
+
+            // BanType enum 등록
+            Schema<String> banTypeSchema = new Schema<String>()
+                    .type("string")
+                    .description("차단 유형");
+            banTypeSchema.setEnum(Arrays.asList(
+                    BanType.NONE.name(),
+                    BanType.WARNING.name(),
+                    BanType.BAN_1D.name(),
+                    BanType.BAN_3D.name(),
+                    BanType.BAN_5D.name(),
+                    BanType.BAN_1W.name(),
+                    BanType.BAN_2W.name(),
+                    BanType.BAN_1M.name(),
+                    BanType.PERMANENT.name()
+            ));
+            components.addSchemas("BanType", banTypeSchema);
+
+            // MatchingType enum 등록
+            Schema<String> matchingTypeSchema = new Schema<String>()
+                    .type("string")
+                    .description("매칭 타입");
+            matchingTypeSchema.setEnum(Arrays.asList(
+                    MatchingType.BASIC.name(),
+                    MatchingType.PRECISE.name()
+            ));
+            components.addSchemas("MatchingType", matchingTypeSchema);
+
+            // ReportSortOrder enum 등록
+            Schema<String> reportSortOrderSchema = new Schema<String>()
+                    .type("string")
+                    .description("신고 정렬 순서");
+            reportSortOrderSchema.setEnum(Arrays.asList(
+                    ReportSortOrder.LATEST.name(),
+                    ReportSortOrder.OLDEST.name()
+            ));
+            components.addSchemas("ReportSortOrder", reportSortOrderSchema);
+
+            // ReportType enum 등록 (ID 기반)
+            Schema<Integer> reportTypeSchema = new Schema<Integer>()
+                    .type("integer")
+                    .description("신고 유형 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)");
+            reportTypeSchema.setEnum(Arrays.asList(
+                    ReportType.SPAM.getId(),
+                    ReportType.ILLEGAL_CONTENT.getId(),
+                    ReportType.HARASSMENT.getId(),
+                    ReportType.HATE_SPEECH.getId(),
+                    ReportType.PRIVACY_VIOLATION.getId(),
+                    ReportType.OFFENSIVE.getId()
+            ));
+            components.addSchemas("ReportType", reportTypeSchema);
+
+            // ReportPath enum 등록
+            Schema<String> reportPathSchema = new Schema<String>()
+                    .type("string")
+                    .description("신고 경로");
+            reportPathSchema.setEnum(Arrays.asList(
+                    ReportPath.BOARD.name(),
+                    ReportPath.CHAT.name(),
+                    ReportPath.PROFILE.name()
+            ));
+            components.addSchemas("ReportPath", reportPathSchema);
+
+            // MatchingStatus enum 등록
+            Schema<String> matchingStatusSchema = new Schema<String>()
+                    .type("string")
+                    .description("매칭 상태");
+            matchingStatusSchema.setEnum(Arrays.asList(
+                    MatchingStatus.FAIL.name(),
+                    MatchingStatus.SUCCESS.name(),
+                    MatchingStatus.PENDING.name(),
+                    MatchingStatus.FOUND.name(),
+                    MatchingStatus.QUIT.name()
+            ));
+            components.addSchemas("MatchingStatus", matchingStatusSchema);
+        };
+    }
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -32,145 +33,53 @@ public class OpenApiConfig {
                 openApi.setComponents(components);
             }
 
-            // Tier enum 등록
-            Schema<String> tierSchema = new Schema<String>()
-                    .type("string")
-                    .description("리그오브레전드 티어");
-            tierSchema.setEnum(Arrays.asList(
-                    Tier.UNRANKED.name(),
-                    Tier.IRON.name(),
-                    Tier.BRONZE.name(),
-                    Tier.SILVER.name(),
-                    Tier.GOLD.name(),
-                    Tier.PLATINUM.name(),
-                    Tier.EMERALD.name(),
-                    Tier.DIAMOND.name(),
-                    Tier.MASTER.name(),
-                    Tier.GRANDMASTER.name(),
-                    Tier.CHALLENGER.name()
-            ));
-            components.addSchemas("Tier", tierSchema);
+            // 일반 String enum들 등록
+            addStringEnumSchema(components, "Tier", Tier.class, "리그오브레전드 티어");
+            addStringEnumSchema(components, "Position", Position.class, "게임 포지션");
+            addStringEnumSchema(components, "Mike", Mike.class, "마이크 사용 가능 여부");
+            addStringEnumSchema(components, "GameMode", GameMode.class, "게임 모드");
+            addStringEnumSchema(components, "LoginType", LoginType.class, "로그인 유형");
+            addStringEnumSchema(components, "BanType", BanType.class, "차단 유형");
+            addStringEnumSchema(components, "MatchingType", MatchingType.class, "매칭 타입");
+            addStringEnumSchema(components, "ReportSortOrder", ReportSortOrder.class, "신고 정렬 순서");
+            addStringEnumSchema(components, "ReportPath", ReportPath.class, "신고 경로");
+            addStringEnumSchema(components, "MatchingStatus", MatchingStatus.class, "매칭 상태");
 
-            // Position enum 등록
-            Schema<String> positionSchema = new Schema<String>()
-                    .type("string")
-                    .description("게임 포지션");
-            positionSchema.setEnum(Arrays.asList(
-                    Position.ANY.name(),
-                    Position.TOP.name(),
-                    Position.JUNGLE.name(),
-                    Position.MID.name(),
-                    Position.ADC.name(),
-                    Position.SUP.name()
-            ));
-            components.addSchemas("Position", positionSchema);
-
-            // Mike enum 등록
-            Schema<String> mikeSchema = new Schema<String>()
-                    .type("string")
-                    .description("마이크 사용 가능 여부");
-            mikeSchema.setEnum(Arrays.asList(
-                    Mike.UNAVAILABLE.name(),
-                    Mike.AVAILABLE.name()
-            ));
-            components.addSchemas("Mike", mikeSchema);
-
-            // GameMode enum 등록
-            Schema<String> gameModeSchema = new Schema<String>()
-                    .type("string")
-                    .description("게임 모드");
-            gameModeSchema.setEnum(Arrays.asList(
-                    GameMode.FAST.name(),
-                    GameMode.SOLO.name(),
-                    GameMode.FREE.name(),
-                    GameMode.ARAM.name()
-            ));
-            components.addSchemas("GameMode", gameModeSchema);
-
-            // LoginType enum 등록
-            Schema<String> loginTypeSchema = new Schema<String>()
-                    .type("string")
-                    .description("로그인 유형");
-            loginTypeSchema.setEnum(Arrays.asList(
-                    LoginType.GENERAL.name(),
-                    LoginType.RSO.name()
-            ));
-            components.addSchemas("LoginType", loginTypeSchema);
-
-            // BanType enum 등록
-            Schema<String> banTypeSchema = new Schema<String>()
-                    .type("string")
-                    .description("차단 유형");
-            banTypeSchema.setEnum(Arrays.asList(
-                    BanType.NONE.name(),
-                    BanType.WARNING.name(),
-                    BanType.BAN_1D.name(),
-                    BanType.BAN_3D.name(),
-                    BanType.BAN_5D.name(),
-                    BanType.BAN_1W.name(),
-                    BanType.BAN_2W.name(),
-                    BanType.BAN_1M.name(),
-                    BanType.PERMANENT.name()
-            ));
-            components.addSchemas("BanType", banTypeSchema);
-
-            // MatchingType enum 등록
-            Schema<String> matchingTypeSchema = new Schema<String>()
-                    .type("string")
-                    .description("매칭 타입");
-            matchingTypeSchema.setEnum(Arrays.asList(
-                    MatchingType.BASIC.name(),
-                    MatchingType.PRECISE.name()
-            ));
-            components.addSchemas("MatchingType", matchingTypeSchema);
-
-            // ReportSortOrder enum 등록
-            Schema<String> reportSortOrderSchema = new Schema<String>()
-                    .type("string")
-                    .description("신고 정렬 순서");
-            reportSortOrderSchema.setEnum(Arrays.asList(
-                    ReportSortOrder.LATEST.name(),
-                    ReportSortOrder.OLDEST.name()
-            ));
-            components.addSchemas("ReportSortOrder", reportSortOrderSchema);
-
-            // ReportType enum 등록 (ID 기반)
-            Schema<Integer> reportTypeSchema = new Schema<Integer>()
-                    .type("integer")
-                    .description("신고 유형 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)");
-            reportTypeSchema.setEnum(Arrays.asList(
-                    ReportType.SPAM.getId(),
-                    ReportType.ILLEGAL_CONTENT.getId(),
-                    ReportType.HARASSMENT.getId(),
-                    ReportType.HATE_SPEECH.getId(),
-                    ReportType.PRIVACY_VIOLATION.getId(),
-                    ReportType.OFFENSIVE.getId()
-            ));
-            components.addSchemas("ReportType", reportTypeSchema);
-
-            // ReportPath enum 등록
-            Schema<String> reportPathSchema = new Schema<String>()
-                    .type("string")
-                    .description("신고 경로");
-            reportPathSchema.setEnum(Arrays.asList(
-                    ReportPath.BOARD.name(),
-                    ReportPath.CHAT.name(),
-                    ReportPath.PROFILE.name()
-            ));
-            components.addSchemas("ReportPath", reportPathSchema);
-
-            // MatchingStatus enum 등록
-            Schema<String> matchingStatusSchema = new Schema<String>()
-                    .type("string")
-                    .description("매칭 상태");
-            matchingStatusSchema.setEnum(Arrays.asList(
-                    MatchingStatus.FAIL.name(),
-                    MatchingStatus.SUCCESS.name(),
-                    MatchingStatus.PENDING.name(),
-                    MatchingStatus.FOUND.name(),
-                    MatchingStatus.QUIT.name()
-            ));
-            components.addSchemas("MatchingStatus", matchingStatusSchema);
+            // ReportType은 특별 처리 (ID 기반)
+            addReportTypeSchema(components);
         };
+    }
+
+    /**
+     * 일반적인 String enum 스키마를 등록하는 헬퍼 메서드
+     */
+    private <T extends Enum<T>> void addStringEnumSchema(Components components, String schemaName, 
+                                                        Class<T> enumClass, String description) {
+        Schema<String> schema = new Schema<String>()
+                .type("string")
+                .description(description);
+        
+        List<String> enumValues = Arrays.stream(enumClass.getEnumConstants())
+                .map(Enum::name)
+                .toList();
+        
+        schema.setEnum(enumValues);
+        components.addSchemas(schemaName, schema);
+    }
+
+    /**
+     * ReportType 전용 스키마 등록 (ID 기반)
+     */
+    private void addReportTypeSchema(Components components) {
+        Schema<Integer> reportTypeSchema = new Schema<Integer>()
+                .type("integer")
+                .description("신고 유형 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)");
+        
+        List<Integer> enumValues = Arrays.stream(ReportType.values())
+                .map(ReportType::getId)
+                .toList();
+        
+        reportTypeSchema.setEnum(enumValues);
+        components.addSchemas("ReportType", reportTypeSchema);
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/TierDetails.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/dto/TierDetails.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.external.riot.dto;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,7 +10,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TierDetails {
 
+    @Schema(ref = "#/components/schemas/GameMode")
     GameMode gameMode;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier tier;
     double winrate;
     int rank;

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/controller/MatchingController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/controller/MatchingController.java
@@ -7,6 +7,8 @@ import com.gamegoo.gamegoo_v2.matching.dto.response.MatchingFoundResponse;
 import com.gamegoo.gamegoo_v2.matching.dto.response.PriorityListResponse;
 import com.gamegoo.gamegoo_v2.matching.service.MatchingFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,7 @@ public class MatchingController {
     @PatchMapping("/matching/status/{matchingUuid}/{status}")
     public ApiResponse<String> UpdateMatchingStatus(
             @PathVariable(name = "matchingUuid") String matchingUuid,
+            @Parameter(description = "매칭 상태", schema = @Schema(ref = "#/components/schemas/MatchingStatus"))
             @PathVariable(name = "status") MatchingStatus status
     ) {
         return ApiResponse.ok(matchingFacadeService.modifyMyMatchingStatus(matchingUuid, status));
@@ -47,6 +50,7 @@ public class MatchingController {
     @PatchMapping("/matching/status/target/{matchingUuid}/{status}")
     public ApiResponse<String> UpdateBothMatchingStatus(
             @PathVariable(name = "matchingUuid") String matchingUuid,
+            @Parameter(description = "매칭 상태", schema = @Schema(ref = "#/components/schemas/MatchingStatus"))
             @PathVariable(name = "status") MatchingStatus status
     ) {
         return ApiResponse.ok(matchingFacadeService.modifyBothMatchingStatus(matchingUuid, status));

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/dto/request/InitializingMatchingRequest.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/dto/request/InitializingMatchingRequest.java
@@ -4,6 +4,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Mike;
 import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.matching.domain.MatchingType;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,19 +16,25 @@ import java.util.List;
 @Builder
 public class InitializingMatchingRequest {
 
+    @Schema(ref = "#/components/schemas/GameMode")
     @NotNull(message = "gameMode 는 비워둘 수 없습니다.")
     GameMode gameMode;
 
+    @Schema(ref = "#/components/schemas/Mike")
     @NotNull(message = "mike 는 비워둘 수 없습니다.")
     Mike mike;
 
+    @Schema(ref = "#/components/schemas/MatchingType")
     @NotNull(message = "matchingType은 비워둘 수 없습니다.")
     MatchingType matchingType;
 
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
 
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
 
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
 
     List<Long> gameStyleIdList;

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/dto/response/MatchingMemberInfoResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/dto/response/MatchingMemberInfoResponse.java
@@ -6,6 +6,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Position;
 import com.gamegoo.gamegoo_v2.account.member.domain.Tier;
 import com.gamegoo.gamegoo_v2.game.dto.response.GameStyleResponse;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,16 +23,23 @@ public class MatchingMemberInfoResponse {
     String matchingUuid;
     String gameName;
     String tag;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier soloTier;
     Integer soloRank;
+    @Schema(ref = "#/components/schemas/Tier")
     Tier freeTier;
     Integer freeRank;
     Integer mannerLevel;
     Integer profileImg;
+    @Schema(ref = "#/components/schemas/GameMode")
     GameMode gameMode;
+    @Schema(ref = "#/components/schemas/Position")
     Position mainP;
+    @Schema(ref = "#/components/schemas/Position")
     Position subP;
+    @ArraySchema(schema = @Schema(ref = "#/components/schemas/Position"))
     List<Position> wantP;
+    @Schema(ref = "#/components/schemas/Mike")
     Mike mike;
     List<GameStyleResponse> gameStyleResponseList;
 

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/member/MemberServiceFacadeTest.java
@@ -156,7 +156,7 @@ class MemberServiceFacadeTest {
         assertThat(response.getWantP()).isEqualTo(freshMember.getWantP());
         assertThat(response.getIsAgree()).isEqualTo(freshMember.isAgree());
         assertThat(response.getIsBlind()).isEqualTo(freshMember.getBlind());
-        assertThat(response.getLoginType()).isEqualTo(freshMember.getLoginType().name());
+        assertThat(response.getLoginType()).isEqualTo(freshMember.getLoginType());
         assertThat(response.getChampionStatsResponseList()).isNotNull();
 
         // MemberRecentStats 검증 - null인 경우를 확인
@@ -231,7 +231,7 @@ class MemberServiceFacadeTest {
         assertThat(response.getWantP()).isEqualTo(targetMember.getWantP());
         assertThat(response.getIsAgree()).isEqualTo(targetMember.isAgree());
         assertThat(response.getIsBlind()).isEqualTo(targetMember.getBlind());
-        assertThat(response.getLoginType()).isEqualTo(String.valueOf(targetMember.getLoginType()));
+        assertThat(response.getLoginType()).isEqualTo(targetMember.getLoginType());
         assertThat(response.getChampionStatsResponseList()).isNotNull();
 
         // MemberRecentStats 검증 - null인 경우를 확인


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> openapi 관련 프론트 측 요구 사항으로 shared enum 설정 및 운영 서버의 MemberRecentStats 테이블 데이터 정합성 문제 해결로 optional = false 재추가 입니다.

## ⏳ 작업 상세 내용

- [x] shared enum 관련 작업
- [x] optional = false 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
