### PR TITLE
[Fix/386] 신고 목록 조회 및 처리 로직에 비회원 신고 건 반영

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/response/ReportListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/dto/response/ReportListResponse.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 @Getter
 @Builder
 public class ReportListResponse {
+
     private Long reportId;
     private Long fromMemberId;
     private String fromMemberName;
@@ -32,16 +33,25 @@ public class ReportListResponse {
             postId = report.getSourceBoard().getId();
             isPostDeleted = report.getSourceBoard().isDeleted();
         }
-        
+
+        Long fromMemberId = null;
+        String fromMemberName = "비회원";
+        String fromMemberTag = "#";
+        if (report.getFromMember() != null) {
+            fromMemberId = report.getFromMember().getId();
+            fromMemberName = report.getFromMember().getGameName();
+            fromMemberTag = report.getFromMember().getTag();
+        }
+
         String reportType = report.getReportTypeMappingList().stream()
                 .map(mapping -> ReportType.of(mapping.getCode()).getDescription())
                 .collect(Collectors.joining(", "));
-        
+
         return ReportListResponse.builder()
                 .reportId(report.getId())
-                .fromMemberId(report.getFromMember().getId())
-                .fromMemberName(report.getFromMember().getGameName())
-                .fromMemberTag(report.getFromMember().getTag())
+                .fromMemberId(fromMemberId)
+                .fromMemberName(fromMemberName)
+                .fromMemberTag(fromMemberTag)
                 .toMemberId(report.getToMember().getId())
                 .toMemberName(report.getToMember().getGameName())
                 .toMemberTag(report.getToMember().getTag())
@@ -53,4 +63,5 @@ public class ReportListResponse {
                 .isPostDeleted(isPostDeleted)
                 .build();
     }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/service/ReportFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/service/ReportFacadeService.java
@@ -81,7 +81,6 @@ public class ReportFacadeService {
     public ReportProcessResponse processReport(Long reportId, ReportProcessRequest request) {
         Report report = reportService.findById(reportId);
         Member targetMember = report.getToMember();
-        Member reporter = report.getFromMember();
 
         // 제재 적용
         banService.applyBan(targetMember, request.getBanType());
@@ -91,9 +90,12 @@ public class ReportFacadeService {
         String banDescription = banService.getBanReasonMessage(request.getBanType());
 
         // 신고자에게 알림 전송
-        notificationService.createReportProcessedNotificationForReporter(
-                reporter, reportTypeString, banDescription
-        );
+        Member reporter = report.getFromMember();
+        if (reporter != null) {
+            notificationService.createReportProcessedNotificationForReporter(
+                    reporter, reportTypeString, banDescription
+            );
+        }
 
         // 신고 당한 회원에게 알림 전송 (제재가 있는 경우에만)
         if (request.getBanType() != null && request.getBanType() != BanType.NONE) {


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 신고 목록 조회 및 처리 로직에 비회원 신고 건 반영

## ⏳ 작업 상세 내용

- [ ] 신고 목록 조회 API에서 비회원 신고 건의 경우 memberId null, 소환사명과 태그를 "비회원#"으로 응답하도록 수정
- [ ] 신고 처리 시 신고자에게 알림 발송 로직을 비회원 신고 건의 경우 적용하지 않도록 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
