### PR TITLE
[Fix/382] 채팅방 목록 조회 Native Query 수정

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatroomRepository.java
@@ -16,11 +16,11 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long>, Chatr
     @Query(value = """
             SELECT
                 cr.chatroom_id AS chatroomId,
-                cr.uuid as chatroomUuid,
-                SUM(IF(IFNULL(c.to_member_id, :memberId) = :memberId, 1, 0)) AS unreadCnt,
-                MAX(IF(cr.last_chat_id = c.chat_id, c.contents, NULL)) AS lastChat,
-                MAX(cr.last_chat_at) AS lastChatAt,
-                MAX(IF(cr.last_chat_id = c.chat_id,c.timestamp,NULL)) AS lastChatTimestamp,
+                cr.uuid AS chatroomUuid,
+                COUNT(uc.chat_id) AS unreadCnt,
+                c.contents AS lastChat,
+                cr.last_chat_at AS lastChatAt,
+                c.timestamp AS lastChatTimestamp,
                 (
                     SELECT mc2.member_id
                     FROM member_chatroom mc2
@@ -29,14 +29,23 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long>, Chatr
                     LIMIT 1
                 ) AS targetMemberId
             FROM chatroom cr
-            JOIN member_chatroom mc ON cr.chatroom_id = mc.chatroom_id
-            JOIN chat c ON c.chatroom_id = cr.chatroom_id
+            JOIN member_chatroom mc
+              ON cr.chatroom_id = mc.chatroom_id
+            LEFT JOIN chat c
+              ON cr.last_chat_id = c.chat_id
+            LEFT JOIN (
+                SELECT c.chat_id, c.chatroom_id
+                FROM chat c
+                JOIN member_chatroom mcx ON mcx.chatroom_id = c.chatroom_id
+                WHERE mcx.member_id = :memberId
+                  AND c.created_at >= IFNULL(mcx.last_view_date, mcx.created_at)
+                  AND c.created_at >= mcx.last_join_date
+                  AND IFNULL(c.to_member_id, :memberId) = :memberId
+            ) uc ON uc.chatroom_id = cr.chatroom_id
             WHERE mc.member_id = :memberId
               AND mc.last_join_date IS NOT NULL
-              AND c.created_at > IFNULL(mc.last_view_date, cr.created_at)
-              AND c.created_at >= mc.last_join_date
             GROUP BY cr.chatroom_id
-            ORDER BY IFNULL(MAX(cr.last_chat_at), MAX(mc.last_join_date)) DESC
+            ORDER BY IFNULL(MAX(cr.last_chat_at), MAX(mc.last_join_date)) DESC;
             """, nativeQuery = true)
     List<ChatroomSummaryDTO> findChatroomSummariedByMemberId(@Param("memberId") Long memberId);
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 채팅방 목록 조회 Native Query 수정(기존 쿼리는 "안읽은 메시지가 하나도 없는 채팅방"을 채팅방 목록 조회 결과에서 누락하는 잘못된 쿼리 였음)

## ⏳ 작업 상세 내용

- [x] 채팅방 목록 조회 Native Query 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
