### PR TITLE
[Refactor/390] 채팅방 목록 조회 쿼리 개선

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/ChatResponseFactory.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/ChatResponseFactory.java
@@ -2,7 +2,6 @@ package com.gamegoo.gamegoo_v2.chat.dto;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.chat.domain.Chat;
-import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
 import com.gamegoo.gamegoo_v2.chat.dto.data.ChatroomSummaryDTO;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageListResponse;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatMessageResponse;
@@ -116,40 +115,6 @@ public class ChatResponseFactory {
                 .build();
     }
 
-    public ChatroomResponse toChatroomResponse(Chatroom chatroom, Member targetMember, boolean isFriend,
-                                               boolean isBlocked, Long friendRequestMemberId, Chat lastChat,
-                                               int unreadCnt) {
-        String gameName = targetMember.getBlind()
-                ? "(탈퇴한 사용자)"
-                : targetMember.getGameName();
-
-        String lastMsg = null;
-        String lastMsgAt = null;
-        Long lastMsgTimestamp = null;
-
-        if (lastChat != null) {
-            lastMsg = lastChat.getContents();
-            lastMsgAt = DateTimeUtil.toKSTString(lastChat.getCreatedAt());
-            lastMsgTimestamp = lastChat.getTimestamp();
-        }
-
-        return ChatroomResponse.builder()
-                .chatroomId(chatroom.getId())
-                .uuid(chatroom.getUuid())
-                .targetMemberId(targetMember.getId())
-                .targetMemberImg(targetMember.getProfileImage())
-                .targetMemberName(gameName)
-                .friend(isFriend)
-                .blocked(isBlocked)
-                .blind(targetMember.getBlind())
-                .friendRequestMemberId(friendRequestMemberId)
-                .lastMsg(lastMsg)
-                .lastMsgAt(lastMsgAt)
-                .notReadMsgCnt(unreadCnt)
-                .lastMsgTimestamp(lastMsgTimestamp)
-                .build();
-    }
-
     public ChatroomResponse toChatroomResponse(Member targetMember, boolean isFriend, boolean isBlocked,
                                                Long friendRequestMemberId,
                                                ChatroomSummaryDTO chatroomSummaryDTO) {
@@ -172,6 +137,37 @@ public class ChatResponseFactory {
                 .friend(isFriend)
                 .blocked(isBlocked)
                 .blind(targetMember.getBlind())
+                .friendRequestMemberId(friendRequestMemberId)
+                .lastMsg(chatroomSummaryDTO.getLastChat())
+                .lastMsgAt(lastMsgAt)
+                .notReadMsgCnt(chatroomSummaryDTO.getUnreadCnt())
+                .lastMsgTimestamp(chatroomSummaryDTO.getLastChatTimestamp())
+                .build();
+    }
+
+
+    public ChatroomResponse toChatroomResponse(boolean isFriend, boolean isBlocked,
+                                               Long friendRequestMemberId,
+                                               ChatroomSummaryDTO chatroomSummaryDTO) {
+        String gameName = chatroomSummaryDTO.getBlind()
+                ? "(탈퇴한 사용자)"
+                : chatroomSummaryDTO.getTargetMemberName();
+
+        String lastMsgAt = null;
+
+        if (chatroomSummaryDTO.getLastChatAt() != null) {
+            lastMsgAt = DateTimeUtil.toKSTString(chatroomSummaryDTO.getLastChatAt());
+        }
+
+        return ChatroomResponse.builder()
+                .chatroomId(chatroomSummaryDTO.getChatroomId())
+                .uuid(chatroomSummaryDTO.getChatroomUuid())
+                .targetMemberId(chatroomSummaryDTO.getTargetMemberId())
+                .targetMemberImg(chatroomSummaryDTO.getTargetMemberImg())
+                .targetMemberName(gameName)
+                .friend(isFriend)
+                .blocked(isBlocked)
+                .blind(chatroomSummaryDTO.getBlind())
                 .friendRequestMemberId(friendRequestMemberId)
                 .lastMsg(chatroomSummaryDTO.getLastChat())
                 .lastMsgAt(lastMsgAt)

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/data/ChatroomSummaryDTO.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/data/ChatroomSummaryDTO.java
@@ -18,6 +18,10 @@ public interface ChatroomSummaryDTO {
 
     Long getTargetMemberId();
 
-    boolean getBlind();
+    String getTargetMemberName();
+
+    Integer getTargetMemberImg();
+
+    Boolean getBlind();
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/data/ChatroomTargetDTO.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/dto/data/ChatroomTargetDTO.java
@@ -1,0 +1,13 @@
+package com.gamegoo.gamegoo_v2.chat.dto.data;
+
+public interface ChatroomTargetDTO {
+
+    Long getTargetMemberId();
+
+    Integer getIsFriend();
+
+    Integer getIsBlocked();
+
+    Long getFriendRequestMemberId();
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/repository/ChatroomRepository.java
@@ -2,6 +2,7 @@ package com.gamegoo.gamegoo_v2.chat.repository;
 
 import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
 import com.gamegoo.gamegoo_v2.chat.dto.data.ChatroomSummaryDTO;
+import com.gamegoo.gamegoo_v2.chat.dto.data.ChatroomTargetDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,16 +22,18 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long>, Chatr
                 c.contents AS lastChat,
                 cr.last_chat_at AS lastChatAt,
                 c.timestamp AS lastChatTimestamp,
-                (
-                    SELECT mc2.member_id
-                    FROM member_chatroom mc2
-                    WHERE mc2.chatroom_id = cr.chatroom_id
-                      AND mc2.member_id != mc.member_id
-                    LIMIT 1
-                ) AS targetMemberId
+                MIN(m_other.member_id) AS targetMemberId,
+                m_other.game_name AS targetMemberName,
+                m_other.profile_image AS targetMemberImg,
+                m_other.blind AS blind
             FROM chatroom cr
             JOIN member_chatroom mc
               ON cr.chatroom_id = mc.chatroom_id
+            LEFT JOIN member_chatroom mc_other
+              ON mc_other.chatroom_id = cr.chatroom_id
+             AND mc_other.member_id != mc.member_id
+            LEFT JOIN member m_other
+              ON m_other.member_id = mc_other.member_id
             LEFT JOIN chat c
               ON cr.last_chat_id = c.chat_id
             LEFT JOIN (
@@ -41,12 +44,31 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long>, Chatr
                   AND c.created_at >= IFNULL(mcx.last_view_date, mcx.created_at)
                   AND c.created_at >= mcx.last_join_date
                   AND IFNULL(c.to_member_id, :memberId) = :memberId
+                  AND c.from_member_id != :memberId
             ) uc ON uc.chatroom_id = cr.chatroom_id
             WHERE mc.member_id = :memberId
               AND mc.last_join_date IS NOT NULL
-            GROUP BY cr.chatroom_id
+            GROUP BY cr.chatroom_id, m_other.game_name, m_other.profile_image
             ORDER BY IFNULL(MAX(cr.last_chat_at), MAX(mc.last_join_date)) DESC;
             """, nativeQuery = true)
     List<ChatroomSummaryDTO> findChatroomSummariedByMemberId(@Param("memberId") Long memberId);
+
+    @Query(value = """
+            select
+                m.member_id AS targetMemberId,
+                IF(f.from_member_id IS NOT NULL, TRUE, FALSE) AS isFriend,
+                IF(b.blocker_id IS NOT NULL, TRUE, FALSE) AS isBlocked,
+                fr.from_member_id as friendRequestMemberId
+            from member m
+            left join friend f
+            on m.member_id = f.from_member_id and f.to_member_id = :memberId
+            left join block b
+            on m.member_id = b.blocker_id and b.blocked_id = :memberId and b.deleted = false
+            left join friend_request fr
+            on ((m.member_id = fr.from_member_id and fr.to_member_id = :memberId) or (m.member_id = fr.to_member_id and fr.from_member_id = :memberId)) and fr.status ='PENDING'
+            where m.member_id in :targetMemberIds
+            """, nativeQuery = true)
+    List<ChatroomTargetDTO> findChatroomTargetsByMemberId(@Param("memberId") Long memberId,
+                                                          @Param("targetMemberIds") List<Long> targetMemberIds);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatQueryService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/service/ChatQueryService.java
@@ -4,6 +4,7 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.chat.domain.Chat;
 import com.gamegoo.gamegoo_v2.chat.domain.Chatroom;
 import com.gamegoo.gamegoo_v2.chat.dto.data.ChatroomSummaryDTO;
+import com.gamegoo.gamegoo_v2.chat.dto.data.ChatroomTargetDTO;
 import com.gamegoo.gamegoo_v2.chat.repository.ChatRepository;
 import com.gamegoo.gamegoo_v2.chat.repository.ChatroomRepository;
 import com.gamegoo.gamegoo_v2.chat.repository.MemberChatroomRepository;
@@ -16,7 +17,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -131,6 +135,20 @@ public class ChatQueryService {
      */
     public List<ChatroomSummaryDTO> getChatroomSummaryList(Long memberId) {
         return chatroomRepository.findChatroomSummariedByMemberId(memberId);
+    }
+
+    /**
+     * 채팅방 목록에 보여줄 상대 회원 관련 정보 DTO 맵 반환
+     * 상대 회원 id: 친구 여부, 차단 당함 여부, 친구요청 보낸 회원 id
+     *
+     * @param memberId
+     * @param targetMemberIds
+     * @return
+     */
+    public Map<Long, ChatroomTargetDTO> getChatroomTargetMap(Long memberId, List<Long> targetMemberIds) {
+        List<ChatroomTargetDTO> list = chatroomRepository.findChatroomTargetsByMemberId(memberId, targetMemberIds);
+        return list.stream()
+                .collect(Collectors.toMap(ChatroomTargetDTO::getTargetMemberId, Function.identity()));
     }
 
 }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 채팅방 목록 조회 쿼리 개선

## ⏳ 작업 상세 내용

- [x] findChatroomSummariedByMemberId 메소드에서 join으로 targetMember 정보까지 함께 조회해 targetMember 정보 조회를 위한 별도 select 쿼리 절감
- [x] findChatroomTargetsByMemberId 메소드로 상대 회원과의 친구 여부, 차단 여부, 친구 요청 전송한 회원 id 정보를 단건 쿼리로 조회하도록 수정
- [x] 채팅방 목록 조회 시 안읽은 메시지 개수에 자신이 보낸 메시지 개수가 포함되어 집계되는 오류 수정

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
