### PR TITLE
[Refactor/392] JWT 검증 filter에서 DB 조회 로직 제외

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/annotation/resolver/AuthMemberArgumentResolver.java
@@ -43,6 +43,12 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
         if (currentMemberId != null) {
             return memberRepository.findById(currentMemberId)
+                    .map(member -> {
+                        if (member.getBlind()) {
+                            throw new MemberException(ErrorCode.INACTIVE_MEMBER); // 탈퇴 여부 검증
+                        }
+                        return member;
+                    })
                     .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
         }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/controller/AuthController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.gamegoo.gamegoo_v2.account.auth.dto.request.LoginRequest;
 import com.gamegoo.gamegoo_v2.account.auth.dto.request.RefreshTokenRequest;
 import com.gamegoo.gamegoo_v2.account.auth.dto.response.LoginResponse;
 import com.gamegoo.gamegoo_v2.account.auth.dto.response.RefreshTokenResponse;
-import com.gamegoo.gamegoo_v2.account.auth.jwt.JwtProvider;
 import com.gamegoo.gamegoo_v2.account.auth.service.AuthFacadeService;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
@@ -26,13 +25,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v2/auth")
 public class AuthController {
 
-    private final JwtProvider jwtProvider;
     private final AuthFacadeService authFacadeService;
 
     @GetMapping("/token/{memberId}")
     @Operation(summary = "임시 access token 발급 API", description = "테스트용으로 access token을 발급받을 수 있는 API 입니다.")
     public ApiResponse<String> getTestAccessToken(@PathVariable(name = "memberId") Long memberId) {
-        return ApiResponse.ok(jwtProvider.createAccessToken(memberId));
+        return ApiResponse.ok(authFacadeService.createTestAccessToken(memberId));
     }
 
     @PostMapping("/join")
@@ -64,4 +62,5 @@ public class AuthController {
     public ApiResponse<String> blindMember(@AuthMember Member member) {
         return ApiResponse.ok(authFacadeService.blindMember(member));
     }
+
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
@@ -88,8 +88,12 @@ public class JwtProvider {
      * @return
      */
     public Role getRole(String token) {
-        String roleStr = parseClaims(token).get("role", String.class);
-        return Role.valueOf(roleStr);
+        try {
+            String roleStr = parseClaims(token).get("role", String.class);
+            return Role.valueOf(roleStr);
+        } catch (Exception e) {
+            throw new JwtAuthException(ErrorCode.INVALID_CLAIMS);
+        }
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
@@ -88,7 +88,8 @@ public class JwtProvider {
      * @return
      */
     public Role getRole(String token) {
-        return parseClaims(token).get("role", Role.class);
+        String roleStr = parseClaims(token).get("role", String.class);
+        return Role.valueOf(roleStr);
     }
 
     /**

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.gamegoo.gamegoo_v2.account.auth.jwt;
 
+import com.gamegoo.gamegoo_v2.account.auth.domain.Role;
 import com.gamegoo.gamegoo_v2.core.exception.JwtAuthException;
 import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.jsonwebtoken.Claims;
@@ -43,8 +44,8 @@ public class JwtProvider {
      * @param memberId
      * @return
      */
-    public String createAccessToken(Long memberId) {
-        return createToken(memberId, accessTokenExpTime);
+    public String createAccessToken(Long memberId, Role role) {
+        return createToken(memberId, role, accessTokenExpTime);
     }
 
     /**
@@ -53,11 +54,11 @@ public class JwtProvider {
      * @param memberId
      * @return
      */
-    public String createRefreshToken(Long memberId) {
+    public String createRefreshToken(Long memberId, Role role) {
         // refreshExpireDay를 밀리초 단위로 변환
         long refreshExpireTimeInMillis = refreshExpireDay * 24 * 60 * 60 * 1000;
 
-        return createToken(memberId, refreshExpireTimeInMillis);
+        return createToken(memberId, role, refreshExpireTimeInMillis);
     }
 
     /**
@@ -78,6 +79,16 @@ public class JwtProvider {
      */
     public Long getMemberId(String token) {
         return parseClaims(token).get("memberId", Long.class);
+    }
+
+    /**
+     * token claim에서 role 추출 메소드
+     *
+     * @param token
+     * @return
+     */
+    public Role getRole(String token) {
+        return parseClaims(token).get("role", Role.class);
     }
 
     /**
@@ -126,16 +137,18 @@ public class JwtProvider {
      * token 생성 메소드
      *
      * @param memberId
+     * @param role
      * @param expireTime
      * @return
      */
-    private String createToken(Long memberId, Long expireTime) {
+    private String createToken(Long memberId, Role role, Long expireTime) {
 
         long now = (new Date()).getTime();
         Date validity = new Date(now + expireTime);
 
         return Jwts.builder()
                 .claim("memberId", memberId)
+                .claim("role", role)
                 .issuedAt(new Date(now))
                 .expiration(validity)
                 .signWith(key)

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/CustomUserDetails.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 public class CustomUserDetails implements UserDetails {
 
     Long memberId;
-    Role role;    // Member, Admin
+    Role role;    // MEMBER, ADMIN
 
     public CustomUserDetails(Long memberId, Role role) {
         this.memberId = memberId;

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/security/JwtAuthFilter.java
@@ -1,5 +1,6 @@
 package com.gamegoo.gamegoo_v2.account.auth.security;
 
+import com.gamegoo.gamegoo_v2.account.auth.domain.Role;
 import com.gamegoo.gamegoo_v2.account.auth.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,7 +10,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -20,7 +20,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
 
-    private final CustomUserDetailsService customUserDetailsService;
     private final List<RequestMatcher> excludedRequestMatchers;
     private final JwtProvider jwtProvider;
 
@@ -37,7 +36,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
             Long memberId = jwtProvider.getMemberId(jwt);
-            UserDetails userDetails = customUserDetailsService.loadUserByMemberId(memberId);
+            Role role = jwtProvider.getRole(jwt);
+
+            CustomUserDetails userDetails = new CustomUserDetails(memberId, role);
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.gamegoo.gamegoo_v2.core.config;
 
 import com.gamegoo.gamegoo_v2.account.auth.jwt.JwtProvider;
 import com.gamegoo.gamegoo_v2.account.auth.security.CustomAccessDeniedHandler;
-import com.gamegoo.gamegoo_v2.account.auth.security.CustomUserDetailsService;
 import com.gamegoo.gamegoo_v2.account.auth.security.EntryPointHandler;
 import com.gamegoo.gamegoo_v2.account.auth.security.JwtAuthFilter;
 import com.gamegoo.gamegoo_v2.account.auth.security.JwtAuthenticationExceptionHandler;
@@ -39,7 +38,6 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
-    private final CustomUserDetailsService customUserDetailsService;
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final EntryPointHandler unauthorizedHandler;
     private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler;
@@ -57,7 +55,7 @@ public class SecurityConfig {
                 .map(e -> new AntPathRequestMatcher(e.getPattern(), e.getMethod()))
                 .collect(Collectors.toList());
 
-        return new JwtAuthFilter(customUserDetailsService, excludedRequestMatchers, jwtProvider);
+        return new JwtAuthFilter(excludedRequestMatchers, jwtProvider);
     }
 
     @Bean

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ExceptionAdvice.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/exception/common/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -124,6 +125,20 @@ public class ExceptionAdvice {
                 .body(ApiResponse.of(HttpStatus.NOT_FOUND, e.getMessage()));
     }
 
+    // @PreAuthorize 인가 실패
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ApiResponse<?>> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+        ErrorCode errorCode = ErrorCode._FORBIDDEN;
+
+        ApiResponse<Object> apiResponse = ApiResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .status(errorCode.getStatus())
+                .build();
+
+        return ResponseEntity.status(ErrorCode._FORBIDDEN.getStatus()).body(apiResponse);
+    }
+
     // 서버 내부 에러
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Object>> handleAll(Exception e) {
@@ -136,7 +151,7 @@ public class ExceptionAdvice {
                 .status(errorCode.getStatus())
                 .build();
 
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(apiResponse);
+        return ResponseEntity.status(ErrorCode._INTERNAL_SERVER_ERROR.getStatus()).body(apiResponse);
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotFacadeService.java
@@ -8,9 +8,9 @@ import com.gamegoo.gamegoo_v2.account.member.service.MemberService;
 import com.gamegoo.gamegoo_v2.external.riot.domain.ChampionStats;
 import com.gamegoo.gamegoo_v2.external.riot.dto.TierDetails;
 import com.gamegoo.gamegoo_v2.external.riot.dto.request.RiotJoinRequest;
-import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotAuthTokenResponse;
-import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotAccountIdResponse;
 import com.gamegoo.gamegoo_v2.external.riot.dto.request.RiotVerifyExistUserRequest;
+import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotAccountIdResponse;
+import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotAuthTokenResponse;
 import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotPuuidGameNameResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -109,8 +109,8 @@ public class RiotFacadeService {
 
         // 사용자가 있을 경우, 로그인 진행
         Member member = memberList.get(0);
-        String accessToken = jwtProvider.createAccessToken(member.getId());
-        String refreshToken = jwtProvider.createRefreshToken(member.getId());
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getRole());
 
         // refresh token DB에 저장
         authService.updateRefreshToken(member, refreshToken);

--- a/src/test/java/com/gamegoo/gamegoo_v2/integration/auth/AuthFacadeServiceTest.java
+++ b/src/test/java/com/gamegoo/gamegoo_v2/integration/auth/AuthFacadeServiceTest.java
@@ -158,7 +158,7 @@ class AuthFacadeServiceTest {
         @Test
         void updateToken() {
             // given
-            String token = jwtProvider.createRefreshToken(member.getId());
+            String token = jwtProvider.createRefreshToken(member.getId(), member.getRole());
             RefreshToken refreshToken = RefreshToken.builder()
                     .refreshToken(token)
                     .member(member)
@@ -190,7 +190,7 @@ class AuthFacadeServiceTest {
         @Test
         void updateTokenWithInvalidRefreshToken() {
             // given
-            String token = jwtProvider.createRefreshToken(member.getId());
+            String token = jwtProvider.createRefreshToken(member.getId(), member.getRole());
             RefreshToken refreshToken = RefreshToken.builder()
                     .refreshToken(token)
                     .member(member)


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> JWT 검증 filter에서 DB 조회 로직 제외
기존에는 security filter 단에서 db 조회 로직이 포함되어 있어서 매 요청마다 db 조회를 위해 connection을 가져야했습니다. 이 부분에서 성능 상 병목이 발생해서 db 조회 로직을 제거하고 @AuthMember ArgumentResolver에서 member 엔티티를 조회해올 때 탈퇴 여부도 검증하도록 로직을 수정했습니다.

## ⏳ 작업 상세 내용

- [x] JWT 검증 filter에서 DB 조회 로직 제외
- [x] memberId, role을 클레임으로 갖는 jwt 토큰 생성하도록 수정
- [x] @AuthMember 어노테이션 리졸버에 탈퇴한 회원 검증 로직 추가

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 앞으로 특정 회원의 role을 어드민으로 변경 시, 해당 회원은 access token을 재발급 받아야만 어드민 관련 기능 이용 가능합니다.

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
