### PR TITLE
[Feat/397] 라이엇 전적 정보 게시물 반영 시 타입 별 반영

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/Member.java
@@ -95,6 +95,9 @@ public class Member extends BaseDateTimeEntity {
     @Column(nullable = false)
     private double freeWinRate = 0.0;
 
+    @Column(nullable = false, columnDefinition = "double default 0.0")
+    private double aramWinRate = 0.0;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private Position mainP = Position.ANY;
@@ -376,5 +379,9 @@ public class Member extends BaseDateTimeEntity {
     public void updateRiotBasicInfo(String gameName, String tag) {
         this.gameName = gameName;
         this.tag = tag;
+    }
+
+    public void updateAramWinRate(double aramWinRate) {
+        this.aramWinRate = aramWinRate;
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberChampion.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberChampion.java
@@ -33,6 +33,7 @@ public class MemberChampion extends BaseDateTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    // 기존 필드들 (프로필용 - 솔로+자유 합친 통계)
     @Column(nullable = false)
     private int wins;
 
@@ -54,11 +55,98 @@ public class MemberChampion extends BaseDateTimeEntity {
     @Column(nullable = false)
     private int assists;
 
+    // 솔로랭크 전용 통계 (게시판용)
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int soloWins;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int soloGames;
+
+    @Column(nullable = false, columnDefinition = "double default 0.0")
+    private double soloCsPerMinute;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int soloTotalCs;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int soloKills;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int soloDeaths;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int soloAssists;
+
+    // 자유랭크 전용 통계 (게시판용)
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int freeWins;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int freeGames;
+
+    @Column(nullable = false, columnDefinition = "double default 0.0")
+    private double freeCsPerMinute;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int freeTotalCs;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int freeKills;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int freeDeaths;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int freeAssists;
+
+    // 칼바람 전용 통계 (게시판용)
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int aramWins;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int aramGames;
+
+    @Column(nullable = false, columnDefinition = "double default 0.0")
+    private double aramCsPerMinute;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int aramTotalCs;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int aramKills;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int aramDeaths;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int aramAssists;
+
     public double getKDA() {
         if (deaths == 0) {
             return kills + assists > 0 ? kills + assists : 0;
         }
         return (double) (kills + assists) / deaths;
+    }
+
+    public double getSoloKDA() {
+        if (soloDeaths == 0) {
+            return soloKills + soloAssists > 0 ? soloKills + soloAssists : 0;
+        }
+        return (double) (soloKills + soloAssists) / soloDeaths;
+    }
+
+    public double getFreeKDA() {
+        if (freeDeaths == 0) {
+            return freeKills + freeAssists > 0 ? freeKills + freeAssists : 0;
+        }
+        return (double) (freeKills + freeAssists) / freeDeaths;
+    }
+
+    public double getAramKDA() {
+        if (aramDeaths == 0) {
+            return aramKills + aramAssists > 0 ? aramKills + aramAssists : 0;
+        }
+        return (double) (aramKills + aramAssists) / aramDeaths;
     }
 
     public static MemberChampion create(Champion champion, Member member, int wins, int games, double csPerMinute, int totalCs, int kills, int deaths, int assists) {
@@ -95,6 +183,36 @@ public class MemberChampion extends BaseDateTimeEntity {
         }
         this.member = member;
         member.getMemberChampionList().add(this);
+    }
+
+    public void updateSoloStats(int wins, int games, double csPerMinute, int totalCs, int kills, int deaths, int assists) {
+        this.soloWins = wins;
+        this.soloGames = games;
+        this.soloCsPerMinute = csPerMinute;
+        this.soloTotalCs = totalCs;
+        this.soloKills = kills;
+        this.soloDeaths = deaths;
+        this.soloAssists = assists;
+    }
+
+    public void updateFreeStats(int wins, int games, double csPerMinute, int totalCs, int kills, int deaths, int assists) {
+        this.freeWins = wins;
+        this.freeGames = games;
+        this.freeCsPerMinute = csPerMinute;
+        this.freeTotalCs = totalCs;
+        this.freeKills = kills;
+        this.freeDeaths = deaths;
+        this.freeAssists = assists;
+    }
+
+    public void updateAramStats(int wins, int games, double csPerMinute, int totalCs, int kills, int deaths, int assists) {
+        this.aramWins = wins;
+        this.aramGames = games;
+        this.aramCsPerMinute = csPerMinute;
+        this.aramTotalCs = totalCs;
+        this.aramKills = kills;
+        this.aramDeaths = deaths;
+        this.aramAssists = assists;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberRecentStats.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/domain/MemberRecentStats.java
@@ -27,6 +27,7 @@ public class MemberRecentStats {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    // 기존 필드들 (프로필용 - 솔로+자유 합친 통계)
     private int recTotalWins;
     private int recTotalLosses;
     private double recWinRate;
@@ -36,6 +37,39 @@ public class MemberRecentStats {
     private double recAvgAssists;
     private double recAvgCsPerMinute;
     private int recTotalCs;
+
+    // 솔로랭크 전용 통계 (게시판용)
+    private int soloRecTotalWins;
+    private int soloRecTotalLosses;
+    private double soloRecWinRate;
+    private double soloRecAvgKDA;
+    private double soloRecAvgKills;
+    private double soloRecAvgDeaths;
+    private double soloRecAvgAssists;
+    private double soloRecAvgCsPerMinute;
+    private int soloRecTotalCs;
+
+    // 자유랭크 전용 통계 (게시판용)
+    private int freeRecTotalWins;
+    private int freeRecTotalLosses;
+    private double freeRecWinRate;
+    private double freeRecAvgKDA;
+    private double freeRecAvgKills;
+    private double freeRecAvgDeaths;
+    private double freeRecAvgAssists;
+    private double freeRecAvgCsPerMinute;
+    private int freeRecTotalCs;
+
+    // 칼바람 전용 통계 (게시판용)
+    private int aramRecTotalWins;
+    private int aramRecTotalLosses;
+    private double aramRecWinRate;
+    private double aramRecAvgKDA;
+    private double aramRecAvgKills;
+    private double aramRecAvgDeaths;
+    private double aramRecAvgAssists;
+    private double aramRecAvgCsPerMinute;
+    private int aramRecTotalCs;
 
     public void setMember(Member member) {
         this.member = member;
@@ -55,6 +89,45 @@ public class MemberRecentStats {
         this.recAvgAssists = recAvgAssists;
         this.recAvgCsPerMinute = recAvgCsPerMinute;
         this.recTotalCs = recTotalCs;
+    }
+
+    public void updateSoloStats(int wins, int losses, double winRate, double avgKDA, double avgKills,
+                               double avgDeaths, double avgAssists, double avgCsPerMinute, int totalCs) {
+        this.soloRecTotalWins = wins;
+        this.soloRecTotalLosses = losses;
+        this.soloRecWinRate = winRate;
+        this.soloRecAvgKDA = avgKDA;
+        this.soloRecAvgKills = avgKills;
+        this.soloRecAvgDeaths = avgDeaths;
+        this.soloRecAvgAssists = avgAssists;
+        this.soloRecAvgCsPerMinute = avgCsPerMinute;
+        this.soloRecTotalCs = totalCs;
+    }
+
+    public void updateFreeStats(int wins, int losses, double winRate, double avgKDA, double avgKills,
+                               double avgDeaths, double avgAssists, double avgCsPerMinute, int totalCs) {
+        this.freeRecTotalWins = wins;
+        this.freeRecTotalLosses = losses;
+        this.freeRecWinRate = winRate;
+        this.freeRecAvgKDA = avgKDA;
+        this.freeRecAvgKills = avgKills;
+        this.freeRecAvgDeaths = avgDeaths;
+        this.freeRecAvgAssists = avgAssists;
+        this.freeRecAvgCsPerMinute = avgCsPerMinute;
+        this.freeRecTotalCs = totalCs;
+    }
+
+    public void updateAramStats(int wins, int losses, double winRate, double avgKDA, double avgKills,
+                               double avgDeaths, double avgAssists, double avgCsPerMinute, int totalCs) {
+        this.aramRecTotalWins = wins;
+        this.aramRecTotalLosses = losses;
+        this.aramRecWinRate = winRate;
+        this.aramRecAvgKDA = avgKDA;
+        this.aramRecAvgKills = avgKills;
+        this.aramRecAvgDeaths = avgDeaths;
+        this.aramRecAvgAssists = avgAssists;
+        this.aramRecAvgCsPerMinute = avgCsPerMinute;
+        this.aramRecTotalCs = totalCs;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponse.java
@@ -44,45 +44,40 @@ public class MemberRecentStatsResponse {
         if (memberRecentStats == null) {
             return null;
         }
-
-        try {
-            return switch (gameMode) {
-                case SOLO, FAST -> new MemberRecentStatsResponse(
-                        memberRecentStats.getSoloRecTotalWins(),
-                        memberRecentStats.getSoloRecTotalLosses(),
-                        memberRecentStats.getSoloRecWinRate(),
-                        memberRecentStats.getSoloRecAvgKDA(),
-                        memberRecentStats.getSoloRecAvgKills(),
-                        memberRecentStats.getSoloRecAvgDeaths(),
-                        memberRecentStats.getSoloRecAvgAssists(),
-                        memberRecentStats.getSoloRecAvgCsPerMinute(),
-                        memberRecentStats.getSoloRecTotalCs()
-                );
-                case FREE -> new MemberRecentStatsResponse(
-                        memberRecentStats.getFreeRecTotalWins(),
-                        memberRecentStats.getFreeRecTotalLosses(),
-                        memberRecentStats.getFreeRecWinRate(),
-                        memberRecentStats.getFreeRecAvgKDA(),
-                        memberRecentStats.getFreeRecAvgKills(),
-                        memberRecentStats.getFreeRecAvgDeaths(),
-                        memberRecentStats.getFreeRecAvgAssists(),
-                        memberRecentStats.getFreeRecAvgCsPerMinute(),
-                        memberRecentStats.getFreeRecTotalCs()
-                );
-                case ARAM -> new MemberRecentStatsResponse(
-                        memberRecentStats.getAramRecTotalWins(),
-                        memberRecentStats.getAramRecTotalLosses(),
-                        memberRecentStats.getAramRecWinRate(),
-                        memberRecentStats.getAramRecAvgKDA(),
-                        memberRecentStats.getAramRecAvgKills(),
-                        memberRecentStats.getAramRecAvgDeaths(),
-                        memberRecentStats.getAramRecAvgAssists(),
-                        memberRecentStats.getAramRecAvgCsPerMinute(),
-                        memberRecentStats.getAramRecTotalCs()
-                );
-            };
-        } catch (jakarta.persistence.EntityNotFoundException e) {
-            return null;
-        }
+        return switch (gameMode) {
+            case SOLO, FAST -> new MemberRecentStatsResponse(
+                    memberRecentStats.getSoloRecTotalWins(),
+                    memberRecentStats.getSoloRecTotalLosses(),
+                    memberRecentStats.getSoloRecWinRate(),
+                    memberRecentStats.getSoloRecAvgKDA(),
+                    memberRecentStats.getSoloRecAvgKills(),
+                    memberRecentStats.getSoloRecAvgDeaths(),
+                    memberRecentStats.getSoloRecAvgAssists(),
+                    memberRecentStats.getSoloRecAvgCsPerMinute(),
+                    memberRecentStats.getSoloRecTotalCs()
+            );
+            case FREE -> new MemberRecentStatsResponse(
+                    memberRecentStats.getFreeRecTotalWins(),
+                    memberRecentStats.getFreeRecTotalLosses(),
+                    memberRecentStats.getFreeRecWinRate(),
+                    memberRecentStats.getFreeRecAvgKDA(),
+                    memberRecentStats.getFreeRecAvgKills(),
+                    memberRecentStats.getFreeRecAvgDeaths(),
+                    memberRecentStats.getFreeRecAvgAssists(),
+                    memberRecentStats.getFreeRecAvgCsPerMinute(),
+                    memberRecentStats.getFreeRecTotalCs()
+            );
+            case ARAM -> new MemberRecentStatsResponse(
+                    memberRecentStats.getAramRecTotalWins(),
+                    memberRecentStats.getAramRecTotalLosses(),
+                    memberRecentStats.getAramRecWinRate(),
+                    memberRecentStats.getAramRecAvgKDA(),
+                    memberRecentStats.getAramRecAvgKills(),
+                    memberRecentStats.getAramRecAvgDeaths(),
+                    memberRecentStats.getAramRecAvgAssists(),
+                    memberRecentStats.getAramRecAvgCsPerMinute(),
+                    memberRecentStats.getAramRecTotalCs()
+            );
+        };
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MemberRecentStatsResponse.java
@@ -1,6 +1,7 @@
 package com.gamegoo.gamegoo_v2.account.member.dto.response;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.MemberRecentStats;
+import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -21,7 +22,7 @@ public class MemberRecentStatsResponse {
         if (memberRecentStats == null) {
             return null;
         }
-        
+
         try {
             return new MemberRecentStatsResponse(
                     memberRecentStats.getRecTotalWins(),
@@ -34,6 +35,52 @@ public class MemberRecentStatsResponse {
                     memberRecentStats.getRecAvgCsPerMinute(),
                     memberRecentStats.getRecTotalCs()
             );
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return null;
+        }
+    }
+
+    public static MemberRecentStatsResponse fromGameMode(MemberRecentStats memberRecentStats, GameMode gameMode) {
+        if (memberRecentStats == null) {
+            return null;
+        }
+
+        try {
+            return switch (gameMode) {
+                case SOLO, FAST -> new MemberRecentStatsResponse(
+                        memberRecentStats.getSoloRecTotalWins(),
+                        memberRecentStats.getSoloRecTotalLosses(),
+                        memberRecentStats.getSoloRecWinRate(),
+                        memberRecentStats.getSoloRecAvgKDA(),
+                        memberRecentStats.getSoloRecAvgKills(),
+                        memberRecentStats.getSoloRecAvgDeaths(),
+                        memberRecentStats.getSoloRecAvgAssists(),
+                        memberRecentStats.getSoloRecAvgCsPerMinute(),
+                        memberRecentStats.getSoloRecTotalCs()
+                );
+                case FREE -> new MemberRecentStatsResponse(
+                        memberRecentStats.getFreeRecTotalWins(),
+                        memberRecentStats.getFreeRecTotalLosses(),
+                        memberRecentStats.getFreeRecWinRate(),
+                        memberRecentStats.getFreeRecAvgKDA(),
+                        memberRecentStats.getFreeRecAvgKills(),
+                        memberRecentStats.getFreeRecAvgDeaths(),
+                        memberRecentStats.getFreeRecAvgAssists(),
+                        memberRecentStats.getFreeRecAvgCsPerMinute(),
+                        memberRecentStats.getFreeRecTotalCs()
+                );
+                case ARAM -> new MemberRecentStatsResponse(
+                        memberRecentStats.getAramRecTotalWins(),
+                        memberRecentStats.getAramRecTotalLosses(),
+                        memberRecentStats.getAramRecWinRate(),
+                        memberRecentStats.getAramRecAvgKDA(),
+                        memberRecentStats.getAramRecAvgKills(),
+                        memberRecentStats.getAramRecAvgDeaths(),
+                        memberRecentStats.getAramRecAvgAssists(),
+                        memberRecentStats.getAramRecAvgCsPerMinute(),
+                        memberRecentStats.getAramRecTotalCs()
+                );
+            };
         } catch (jakarta.persistence.EntityNotFoundException e) {
             return null;
         }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/MyProfileResponse.java
@@ -55,9 +55,7 @@ public class MyProfileResponse {
                 .map(memberGameStyle -> GameStyleResponse.of(memberGameStyle.getGameStyle()))
                 .toList();
 
-        List<ChampionStatsResponse> championStatsResponseList = member.getMemberChampionList().stream()
-                .map(ChampionStatsResponse::from)
-                .toList();
+        List<ChampionStatsResponse> championStatsResponseList = getProfileChampionStats(member);
 
         // 3일 기준으로 갱신 가능 여부 체크
         boolean canRefresh = member.canRefreshChampionStats();
@@ -90,5 +88,14 @@ public class MyProfileResponse {
                 .build();
     }
 
+    /**
+     * 프로필용 챔피언 통계 조회 (솔랭+자유 통합 통계가 있는 챔피언만)
+     */
+    public static List<ChampionStatsResponse> getProfileChampionStats(Member member) {
+        return member.getMemberChampionList().stream()
+                .filter(memberChampion -> memberChampion.getGames() > 0) // 통합 통계가 있는 챔피언만
+                .map(ChampionStatsResponse::from)
+                .toList();
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/dto/response/OtherProfileResponse.java
@@ -57,9 +57,7 @@ public class OtherProfileResponse {
                 .map(memberGameStyle -> GameStyleResponse.of(memberGameStyle.getGameStyle()))
                 .toList();
 
-        List<ChampionStatsResponse> championStatsResponseList = targetMember.getMemberChampionList().stream()
-                .map(ChampionStatsResponse::from)
-                .toList();
+        List<ChampionStatsResponse> championStatsResponseList = MyProfileResponse.getProfileChampionStats(targetMember);
 
         // 3일 기준으로 갱신 가능 여부 체크
         boolean canRefresh = targetMember.canRefreshChampionStats();

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberChampionRepository.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/repository/MemberChampionRepository.java
@@ -2,11 +2,15 @@ package com.gamegoo.gamegoo_v2.account.member.repository;
 
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.account.member.domain.MemberChampion;
+import com.gamegoo.gamegoo_v2.game.domain.Champion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 
 public interface MemberChampionRepository extends JpaRepository<MemberChampion, Long> {
 
     void deleteByMember(Member member);
+    
+    Optional<MemberChampion> findByMemberAndChampion(Member member, Champion champion);
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/ChampionStatsRefreshService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/ChampionStatsRefreshService.java
@@ -13,7 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,15 +41,57 @@ public class ChampionStatsRefreshService {
         try {
             // 먼저 새로운 데이터 조회
             var accountInfo = riotAuthService.getAccountByPuuid(puuid);
-            List<ChampionStats> preferChampionStats = riotRecordService.getPreferChampionfromMatch(gameName, puuid);
-            var recStats = riotRecordService.getRecent30GameStats(gameName, puuid);
+            
+            // 최적화된 한 번의 API 호출로 모든 모드 통계 조회
+            var allModeStats = riotRecordService.getAllModeStatsOptimized(gameName, puuid);
+            
+            // 프로필용 통합 데이터 (솔로+자유만)
+            var recStats = allModeStats.getCombinedStats();
+            List<ChampionStats> preferChampionStats = allModeStats.getCombinedChampionStats().values().stream()
+                    .filter(stats -> stats.getGames() > 0)
+                    .sorted(Comparator.comparingInt(ChampionStats::getGames).reversed())
+                    .limit(4)
+                    .collect(Collectors.toList());
+            
+            // 모드별 분리 데이터 (게시판용)
+            var soloRecStats = allModeStats.getSoloStats();
+            var freeRecStats = allModeStats.getFreeStats();
+            var aramRecStats = allModeStats.getAramStats();
+            
+            List<ChampionStats> soloChampionStats = allModeStats.getSoloChampionStats().values().stream()
+                    .filter(stats -> stats.getGames() > 0)
+                    .sorted(Comparator.comparingInt(ChampionStats::getGames).reversed())
+                    .limit(4)
+                    .collect(Collectors.toList());
+            
+            List<ChampionStats> freeChampionStats = allModeStats.getFreeChampionStats().values().stream()
+                    .filter(stats -> stats.getGames() > 0)
+                    .sorted(Comparator.comparingInt(ChampionStats::getGames).reversed())
+                    .limit(4)
+                    .collect(Collectors.toList());
+            
+            List<ChampionStats> aramChampionStats = allModeStats.getAramChampionStats().values().stream()
+                    .filter(stats -> stats.getGames() > 0)
+                    .sorted(Comparator.comparingInt(ChampionStats::getGames).reversed())
+                    .limit(4)
+                    .collect(Collectors.toList());
+            
             List<TierDetails> tierWinrateRank = riotInfoService.getTierWinrateRank(puuid);
 
             // API 호출이 성공한 경우에만 기존 데이터 삭제 후 새로 저장
             memberChampionRepository.deleteByMember(freshMember);
+            
+            // 1. 먼저 프로필용 통합 챔피언 통계 저장 (솔랭+자유 플레이한 챔피언만)
             memberChampionService.saveMemberChampions(freshMember, preferChampionStats);
+            
+            // 2. 그 다음 모든 모드별 챔피언들을 저장하고 모드별 통계 추가
+            memberChampionService.saveMemberChampionsByMode(freshMember, soloChampionStats, freeChampionStats, aramChampionStats);
+            
             freshMember.updateRiotBasicInfo(accountInfo.getGameName(), accountInfo.getTagLine());
             freshMember.updateRiotStats(tierWinrateRank);
+            
+            // 칼바람 승률 업데이트
+            freshMember.updateAramWinRate(aramRecStats.getRecWinRate());
 
             // 갱신 시간도 함께 업데이트
             freshMember.updateChampionStatsRefreshedAt();
@@ -55,6 +99,8 @@ public class ChampionStatsRefreshService {
             // 최근 30게임 통계 계산 및 저장
             MemberRecentStats memberRecentStats = memberRecentStatsRepository.findById(memberId)
                     .orElse(MemberRecentStats.builder().member(freshMember).build());
+            
+            // 기존 통합 통계 업데이트 (프로필용)
             memberRecentStats.update(
                     recStats.getRecTotalWins(),
                     recStats.getRecTotalLosses(),
@@ -66,9 +112,47 @@ public class ChampionStatsRefreshService {
                     recStats.getRecAvgCsPerMinute(),
                     recStats.getRecTotalCs()
             );
+            
+            // 모드별 통계 업데이트 (게시판용)
+            memberRecentStats.updateSoloStats(
+                    soloRecStats.getRecTotalWins(),
+                    soloRecStats.getRecTotalLosses(),
+                    soloRecStats.getRecWinRate(),
+                    soloRecStats.getRecAvgKDA(),
+                    soloRecStats.getRecAvgKills(),
+                    soloRecStats.getRecAvgDeaths(),
+                    soloRecStats.getRecAvgAssists(),
+                    soloRecStats.getRecAvgCsPerMinute(),
+                    soloRecStats.getRecTotalCs()
+            );
+            
+            memberRecentStats.updateFreeStats(
+                    freeRecStats.getRecTotalWins(),
+                    freeRecStats.getRecTotalLosses(),
+                    freeRecStats.getRecWinRate(),
+                    freeRecStats.getRecAvgKDA(),
+                    freeRecStats.getRecAvgKills(),
+                    freeRecStats.getRecAvgDeaths(),
+                    freeRecStats.getRecAvgAssists(),
+                    freeRecStats.getRecAvgCsPerMinute(),
+                    freeRecStats.getRecTotalCs()
+            );
+            
+            memberRecentStats.updateAramStats(
+                    aramRecStats.getRecTotalWins(),
+                    aramRecStats.getRecTotalLosses(),
+                    aramRecStats.getRecWinRate(),
+                    aramRecStats.getRecAvgKDA(),
+                    aramRecStats.getRecAvgKills(),
+                    aramRecStats.getRecAvgDeaths(),
+                    aramRecStats.getRecAvgAssists(),
+                    aramRecStats.getRecAvgCsPerMinute(),
+                    aramRecStats.getRecTotalCs()
+            );
+            
             memberRecentStatsRepository.save(memberRecentStats);
         } catch (Exception e) {
-            // Riot API 호출 실패 시 기존 데이터 유지 (롤백)
+            // API 호출 실패 시 예외 던지기
             throw new RuntimeException("Riot API 호출 실패로 인한 챔피언 통계 업데이트 실패", e);
         }
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/service/MemberChampionService.java
@@ -16,6 +16,10 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class MemberChampionService {
 
+    private enum ChampionStatsMode {
+        SOLO, FREE, ARAM
+    }
+
     private final MemberChampionRepository memberChampionRepository;
     private final ChampionRepository championRepository;
 
@@ -28,10 +32,7 @@ public class MemberChampionService {
      */
     @Transactional
     public void saveMemberChampions(Member member, List<ChampionStats> championStats) {
-        // 기존 챔피언 데이터 삭제
-        memberChampionRepository.deleteByMember(member);
-        
-        // 새로운 챔피언 데이터 저장
+        // 새로운 챔피언 데이터 저장 (기존 데이터는 호출하는 쪽에서 삭제)
         championStats.forEach(stats -> {
             Long championId = stats.getChampionId();
             // 챔피언이 존재하지 않으면 스킵
@@ -43,5 +44,78 @@ public class MemberChampionService {
         });
     }
 
+    @Transactional
+    public void saveMemberChampionsByMode(Member member, List<ChampionStats> soloStats, 
+                                         List<ChampionStats> freeStats, List<ChampionStats> aramStats) {
+        // 솔로랭크 통계 업데이트
+        updateChampionStatsByMode(member, soloStats, ChampionStatsMode.SOLO);
+        
+        // 자유랭크 통계 업데이트
+        updateChampionStatsByMode(member, freeStats, ChampionStatsMode.FREE);
+        
+        // 칼바람 통계 업데이트
+        updateChampionStatsByMode(member, aramStats, ChampionStatsMode.ARAM);
+    }
+
+    /**
+     * 기존 MemberChampion 레코드에만 모드별 통계를 업데이트 (새로운 챔피언 생성하지 않음)
+     */
+    @Transactional
+    public void updateMemberChampionsByMode(Member member, List<ChampionStats> soloStats, 
+                                           List<ChampionStats> freeStats, List<ChampionStats> aramStats) {
+        // 솔로랭크 통계 업데이트 (기존 레코드만)
+        updateExistingChampionStatsByMode(member, soloStats, ChampionStatsMode.SOLO);
+        
+        // 자유랭크 통계 업데이트 (기존 레코드만)
+        updateExistingChampionStatsByMode(member, freeStats, ChampionStatsMode.FREE);
+        
+        // 칼바람 통계 업데이트 (기존 레코드만)
+        updateExistingChampionStatsByMode(member, aramStats, ChampionStatsMode.ARAM);
+    }
+
+    /**
+     * 모드별 챔피언 통계 업데이트 공통 메서드
+     */
+    private void updateChampionStatsByMode(Member member, List<ChampionStats> championStatsList, ChampionStatsMode mode) {
+        championStatsList.forEach(stats -> {
+            Long championId = stats.getChampionId();
+            championRepository.findById(championId).ifPresent(champion -> {
+                MemberChampion memberChampion = memberChampionRepository.findByMemberAndChampion(member, champion)
+                        .orElseGet(() -> {
+                            MemberChampion newMc = MemberChampion.create(champion, member, 0, 0, 0.0, 0, 0, 0, 0);
+                            return memberChampionRepository.save(newMc);
+                        });
+                
+                updateStatsByMode(memberChampion, stats, mode);
+            });
+        });
+    }
+
+    /**
+     * 기존 레코드에만 모드별 챔피언 통계 업데이트 (새로운 챔피언 생성하지 않음)
+     */
+    private void updateExistingChampionStatsByMode(Member member, List<ChampionStats> championStatsList, ChampionStatsMode mode) {
+        championStatsList.forEach(stats -> {
+            Long championId = stats.getChampionId();
+            championRepository.findById(championId).ifPresent(champion -> {
+                memberChampionRepository.findByMemberAndChampion(member, champion)
+                        .ifPresent(memberChampion -> updateStatsByMode(memberChampion, stats, mode));
+            });
+        });
+    }
+
+    /**
+     * 모드에 따라 적절한 업데이트 메서드 호출
+     */
+    private void updateStatsByMode(MemberChampion memberChampion, ChampionStats stats, ChampionStatsMode mode) {
+        switch (mode) {
+            case SOLO -> memberChampion.updateSoloStats(stats.getWins(), stats.getGames(), stats.getCsPerMinute(), 
+                    stats.getTotalCs(), stats.getKills(), stats.getDeaths(), stats.getAssists());
+            case FREE -> memberChampion.updateFreeStats(stats.getWins(), stats.getGames(), stats.getCsPerMinute(), 
+                    stats.getTotalCs(), stats.getKills(), stats.getDeaths(), stats.getAssists());
+            case ARAM -> memberChampion.updateAramStats(stats.getWins(), stats.getGames(), stats.getCsPerMinute(), 
+                    stats.getTotalCs(), stats.getKills(), stats.getDeaths(), stats.getAssists());
+        }
+    }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/dto/response/BoardListResponse.java
@@ -61,33 +61,25 @@ public class BoardListResponse {
         Tier tier;
         int rank;
         Double winRate;
-        if (board.getGameMode() == GameMode.FREE) {
-            tier = member.getFreeTier();
-            rank = member.getFreeRank();
-            winRate = member.getFreeWinRate();
-        } else {
-            tier = member.getSoloTier();
-            rank = member.getSoloRank();
-            winRate = member.getSoloWinRate();
+        switch (board.getGameMode()) {
+            case FREE:
+                tier = member.getFreeTier();
+                rank = member.getFreeRank();
+                winRate = member.getFreeWinRate();
+                break;
+            case ARAM:
+                tier = member.getSoloTier(); // 칼바람은 티어가 없으므로 솔로 티어 사용
+                rank = member.getSoloRank();
+                winRate = member.getAramWinRate();
+                break;
+            default: // SOLO, FAST
+                tier = member.getSoloTier();
+                rank = member.getSoloRank();
+                winRate = member.getSoloWinRate();
+                break;
         }
 
-        List<ChampionStatsResponse> championStatsResponseList = member.getMemberChampionList() == null
-                ? List.of()
-                : member.getMemberChampionList().stream()
-                .map(mc -> ChampionStatsResponse.builder()
-                        .championId(mc.getChampion().getId())
-                        .championName(mc.getChampion().getName())
-                        .wins(mc.getWins())
-                        .games(mc.getGames())
-                        .winRate(mc.getGames() > 0 ? (double) mc.getWins() / mc.getGames() : 0)
-                        .csPerMinute(mc.getCsPerMinute())
-                        .averageCs(mc.getGames() > 0 ? (double) mc.getTotalCs() / mc.getGames() : 0)
-                        .kda(mc.getKDA())
-                        .kills(mc.getGames() > 0 ? (double) mc.getKills() / mc.getGames() : 0)
-                        .deaths(mc.getGames() > 0 ? (double) mc.getDeaths() / mc.getGames() : 0)
-                        .assists(mc.getGames() > 0 ? (double) mc.getAssists() / mc.getGames() : 0)
-                        .build())
-                .collect(Collectors.toList());
+        List<ChampionStatsResponse> championStatsResponseList = getChampionStatsByGameMode(member, board.getGameMode());
 
         return BoardListResponse.builder()
                 .boardId(board.getId())
@@ -109,12 +101,65 @@ public class BoardListResponse {
                 .winRate(winRate)
                 .bumpTime(board.getBumpTime())
                 .championStatsResponseList(championStatsResponseList)
-                .memberRecentStats(MemberRecentStatsResponse.from(member.getMemberRecentStats()))
+                .memberRecentStats(MemberRecentStatsResponse.fromGameMode(member.getMemberRecentStats(), board.getGameMode()))
                 .freeTier(member.getFreeTier())
                 .freeRank(member.getFreeRank())
                 .soloTier(member.getSoloTier())
                 .soloRank(member.getSoloRank())
                 .build();
+    }
+
+    private static List<ChampionStatsResponse> getChampionStatsByGameMode(Member member, GameMode gameMode) {
+        if (member.getMemberChampionList() == null) {
+            return List.of();
+        }
+
+        return member.getMemberChampionList().stream()
+                .map(mc -> {
+                    return switch (gameMode) {
+                        case SOLO, FAST -> ChampionStatsResponse.builder()
+                                .championId(mc.getChampion().getId())
+                                .championName(mc.getChampion().getName())
+                                .wins(mc.getSoloWins())
+                                .games(mc.getSoloGames())
+                                .winRate(mc.getSoloGames() > 0 ? (double) mc.getSoloWins() / mc.getSoloGames() : 0)
+                                .csPerMinute(mc.getSoloCsPerMinute())
+                                .averageCs(mc.getSoloGames() > 0 ? (double) mc.getSoloTotalCs() / mc.getSoloGames() : 0)
+                                .kda(mc.getSoloKDA())
+                                .kills(mc.getSoloGames() > 0 ? (double) mc.getSoloKills() / mc.getSoloGames() : 0)
+                                .deaths(mc.getSoloGames() > 0 ? (double) mc.getSoloDeaths() / mc.getSoloGames() : 0)
+                                .assists(mc.getSoloGames() > 0 ? (double) mc.getSoloAssists() / mc.getSoloGames() : 0)
+                                .build();
+                        case FREE -> ChampionStatsResponse.builder()
+                                .championId(mc.getChampion().getId())
+                                .championName(mc.getChampion().getName())
+                                .wins(mc.getFreeWins())
+                                .games(mc.getFreeGames())
+                                .winRate(mc.getFreeGames() > 0 ? (double) mc.getFreeWins() / mc.getFreeGames() : 0)
+                                .csPerMinute(mc.getFreeCsPerMinute())
+                                .averageCs(mc.getFreeGames() > 0 ? (double) mc.getFreeTotalCs() / mc.getFreeGames() : 0)
+                                .kda(mc.getFreeKDA())
+                                .kills(mc.getFreeGames() > 0 ? (double) mc.getFreeKills() / mc.getFreeGames() : 0)
+                                .deaths(mc.getFreeGames() > 0 ? (double) mc.getFreeDeaths() / mc.getFreeGames() : 0)
+                                .assists(mc.getFreeGames() > 0 ? (double) mc.getFreeAssists() / mc.getFreeGames() : 0)
+                                .build();
+                        case ARAM -> ChampionStatsResponse.builder()
+                                .championId(mc.getChampion().getId())
+                                .championName(mc.getChampion().getName())
+                                .wins(mc.getAramWins())
+                                .games(mc.getAramGames())
+                                .winRate(mc.getAramGames() > 0 ? (double) mc.getAramWins() / mc.getAramGames() : 0)
+                                .csPerMinute(mc.getAramCsPerMinute())
+                                .averageCs(mc.getAramGames() > 0 ? (double) mc.getAramTotalCs() / mc.getAramGames() : 0)
+                                .kda(mc.getAramKDA())
+                                .kills(mc.getAramGames() > 0 ? (double) mc.getAramKills() / mc.getAramGames() : 0)
+                                .deaths(mc.getAramGames() > 0 ? (double) mc.getAramDeaths() / mc.getAramGames() : 0)
+                                .assists(mc.getAramGames() > 0 ? (double) mc.getAramAssists() / mc.getAramGames() : 0)
+                                .build();
+                    };
+                })
+                .filter(response -> response.getGames() > 0) // 게임이 있는 챔피언만 포함
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/domain/ChampionStats.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/domain/ChampionStats.java
@@ -13,6 +13,7 @@ public class ChampionStats {
     private int kills; // 킬
     private int deaths; // 데스
     private int assists; // 어시스트
+    private int queueId; // 큐 ID (420: 솔로, 440: 자유, 450: 칼바람)
 
     /**
      * 한 경기의 결과로 객체를 생성
@@ -148,6 +149,14 @@ public class ChampionStats {
 
     public void setAssists(int assists) {
         this.assists = assists;
+    }
+
+    public int getQueueId() {
+        return queueId;
+    }
+
+    public void setQueueId(int queueId) {
+        this.queueId = queueId;
     }
 
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/service/RiotRecordService.java
@@ -42,6 +42,11 @@ public class RiotRecordService {
 
     private static final int INITIAL_MATCH_COUNT = 30;
     private static final int MAX_CHAMPIONS_REQUIRED = 4;
+    
+    // 큐 ID 상수
+    private static final int QUEUE_ID_SOLO_RANK = 420;
+    private static final int QUEUE_ID_FREE_RANK = 440;
+    private static final int QUEUE_ID_ARAM = 450;
 
     @Getter
     @Builder
@@ -77,6 +82,26 @@ public class RiotRecordService {
     }
 
     /**
+     * Riot API: 특정 큐 ID의 최근 선호 챔피언 4개 리스트 조회
+     *
+     * @param gameName 게임 이름
+     * @param puuid    Riot PUUID
+     * @param targetQueueId 대상 큐 ID (420: 솔로, 440: 자유, 450: 칼바람)
+     * @return 선호 챔피언 ID 리스트
+     */
+    public List<ChampionStats> getPreferChampionFromMatchByQueueId(String gameName, String puuid, int targetQueueId) {
+        // 1. 특정 큐 ID의 최근 플레이한 챔피언 통계 가져오기
+        Map<Long, ChampionStats> championStatsMap = fetchRecentChampionStatsByQueueId(gameName, puuid, targetQueueId);
+
+        // 2. 많이 사용한 챔피언 상위 최대 4개 계산
+        return championStatsMap.values().stream()
+                .filter(stats -> stats.getGames() > 0)
+                .sorted(Comparator.comparingInt(ChampionStats::getGames).reversed())
+                .limit(MAX_CHAMPIONS_REQUIRED)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * 최근 플레이한 챔피언 ID 리스트를 Riot API에서 가져오는 메서드
      *
      * @param gameName 게임 이름
@@ -93,6 +118,36 @@ public class RiotRecordService {
             Optional<ChampionStats> championStatsOpt = fetchChampionStatsFromMatch(matchId, gameName);
             championStatsOpt.ifPresent(stats -> {
                 if (ChampionIdStore.contains(stats.getChampionId())) {
+                    championStatsMap.merge(stats.getChampionId(), stats, (oldStats, newStats) -> {
+                        oldStats.merge(newStats);
+                        return oldStats;
+                    });
+                }
+            });
+        }
+
+        return championStatsMap;
+    }
+
+    /**
+     * 특정 큐 ID의 최근 플레이한 챔피언 통계를 Riot API에서 가져오는 메서드
+     *
+     * @param gameName 게임 이름
+     * @param puuid    Riot PUUID
+     * @param targetQueueId 대상 큐 ID
+     * @return 큐 ID별 챔피언 통계 맵
+     */
+    private Map<Long, ChampionStats> fetchRecentChampionStatsByQueueId(String gameName, String puuid, int targetQueueId) {
+        Map<Long, ChampionStats> championStatsMap = new HashMap<>();
+
+        List<String> matchIds = Optional.ofNullable(fetchMatchIds(puuid, 0, INITIAL_MATCH_COUNT))
+                .orElseGet(Collections::emptyList);
+
+        for (String matchId : matchIds) {
+            Optional<ChampionStats> championStatsOpt = fetchChampionStatsFromMatch(matchId, gameName);
+            championStatsOpt.ifPresent(stats -> {
+                // 특정 큐 ID의 게임만 포함
+                if (stats.getQueueId() == targetQueueId && ChampionIdStore.contains(stats.getChampionId())) {
                     championStatsMap.merge(stats.getChampionId(), stats, (oldStats, newStats) -> {
                         oldStats.merge(newStats);
                         return oldStats;
@@ -140,9 +195,9 @@ public class RiotRecordService {
                 return Optional.empty();
             }
 
-            // 솔로 랭크(420)와 자유 랭크(440)가 아니면 통계에 포함하지 않음
+            // 솔로 랭크, 자유 랭크, 칼바람이 아니면 통계에 포함하지 않음
             int queueId = response.getInfo().getQueueId();
-            if (queueId != 420 && queueId != 440) {
+            if (queueId != QUEUE_ID_SOLO_RANK && queueId != QUEUE_ID_FREE_RANK && queueId != QUEUE_ID_ARAM) {
                 return Optional.empty();
             }
 
@@ -160,6 +215,7 @@ public class RiotRecordService {
                     .map(participant -> {
                         ChampionStats stats = new ChampionStats(participant.getChampionId(), participant.isWin());
                         stats.setGameTime(finalGameDuration);
+                        stats.setQueueId(queueId); // Queue ID 설정 추가
                         // CS가 음수인 경우 0으로 설정 (미니언 + 정글몹)
                         int totalCs = Math.max(0, participant.getTotalMinionsKilled() + participant.getNeutralMinionsKilled());
                         stats.setTotalMinionsKilled(totalCs);
@@ -174,6 +230,55 @@ public class RiotRecordService {
             riotApiHelper.handleApiError(e);
             return Optional.empty();
         }
+    }
+
+    public Recent30GameStatsResponse getRecent30GameStatsByQueueId(String gameName, String puuid, int targetQueueId) {
+        List<String> matchIds = Optional.ofNullable(fetchMatchIds(puuid, 0, INITIAL_MATCH_COUNT))
+                .orElseGet(Collections::emptyList);
+
+        int totalWins = 0;
+        int totalLosses = 0;
+        int totalKills = 0;
+        int totalDeaths = 0;
+        int totalAssists = 0;
+        int totalCs = 0;
+        double totalCsPerMinute = 0.0;
+        int totalGames = 0;
+
+        for (String matchId : matchIds) {
+            Optional<ChampionStats> championStatsOpt = fetchChampionStatsFromMatch(matchId, gameName);
+            if (championStatsOpt.isPresent()) {
+                ChampionStats stats = championStatsOpt.get();
+                // 특정 큐 ID의 게임만 포함
+                if (stats.getQueueId() == targetQueueId) {
+                    totalGames++;
+                    if (stats.getWins() > 0) totalWins++;
+                    else totalLosses++;
+                    totalKills += stats.getKills();
+                    totalDeaths += stats.getDeaths();
+                    totalAssists += stats.getAssists();
+                    totalCs += stats.getTotalMinionsKilled();
+                    double gameMinutes = stats.getGameTime() / 60.0;
+                    if (gameMinutes > 0) {
+                        totalCsPerMinute += stats.getTotalMinionsKilled() / gameMinutes;
+                    }
+                }
+            }
+        }
+        double recWinRate = totalGames > 0 ? (double) totalWins / totalGames * 100 : 0.0;
+        double recAvgKDA = totalGames > 0 ? (double) (totalKills + totalAssists) / Math.max(1, totalDeaths) : 0.0;
+        double recAvgCsPerMinute = totalGames > 0 ? totalCsPerMinute / totalGames : 0.0;
+        return Recent30GameStatsResponse.builder()
+                .recTotalWins(totalWins)
+                .recTotalLosses(totalLosses)
+                .recWinRate(recWinRate)
+                .recAvgKDA(recAvgKDA)
+                .recAvgKills(totalGames > 0 ? (double) totalKills / totalGames : 0.0)
+                .recAvgDeaths(totalGames > 0 ? (double) totalDeaths / totalGames : 0.0)
+                .recAvgAssists(totalGames > 0 ? (double) totalAssists / totalGames : 0.0)
+                .recAvgCsPerMinute(recAvgCsPerMinute)
+                .recTotalCs((totalWins + totalLosses) > 0 ? totalCs / (totalWins + totalLosses) : 0)
+                .build();
     }
 
     public Recent30GameStatsResponse getRecent30GameStats(String gameName, String puuid) {
@@ -193,22 +298,179 @@ public class RiotRecordService {
             Optional<ChampionStats> championStatsOpt = fetchChampionStatsFromMatch(matchId, gameName);
             if (championStatsOpt.isPresent()) {
                 ChampionStats stats = championStatsOpt.get();
-                totalGames++;
-                if (stats.getWins() > 0) totalWins++;
-                else totalLosses++;
-                totalKills += stats.getKills();
-                totalDeaths += stats.getDeaths();
-                totalAssists += stats.getAssists();
-                totalCs += stats.getTotalMinionsKilled();
-                double gameMinutes = stats.getGameTime() / 60.0;
-                if (gameMinutes > 0) {
-                    totalCsPerMinute += stats.getTotalMinionsKilled() / gameMinutes;
+                // 프로필용: 솔로와 자유만 포함, 칼바람 제외
+                if (stats.getQueueId() == QUEUE_ID_SOLO_RANK || stats.getQueueId() == QUEUE_ID_FREE_RANK) {
+                    totalGames++;
+                    if (stats.getWins() > 0) totalWins++;
+                    else totalLosses++;
+                    totalKills += stats.getKills();
+                    totalDeaths += stats.getDeaths();
+                    totalAssists += stats.getAssists();
+                    totalCs += stats.getTotalMinionsKilled();
+                    double gameMinutes = stats.getGameTime() / 60.0;
+                    if (gameMinutes > 0) {
+                        totalCsPerMinute += stats.getTotalMinionsKilled() / gameMinutes;
+                    }
                 }
             }
         }
         double recWinRate = totalGames > 0 ? (double) totalWins / totalGames * 100 : 0.0;
         double recAvgKDA = totalGames > 0 ? (double) (totalKills + totalAssists) / Math.max(1, totalDeaths) : 0.0;
         double recAvgCsPerMinute = totalGames > 0 ? totalCsPerMinute / totalGames : 0.0;
+        return Recent30GameStatsResponse.builder()
+                .recTotalWins(totalWins)
+                .recTotalLosses(totalLosses)
+                .recWinRate(recWinRate)
+                .recAvgKDA(recAvgKDA)
+                .recAvgKills(totalGames > 0 ? (double) totalKills / totalGames : 0.0)
+                .recAvgDeaths(totalGames > 0 ? (double) totalDeaths / totalGames : 0.0)
+                .recAvgAssists(totalGames > 0 ? (double) totalAssists / totalGames : 0.0)
+                .recAvgCsPerMinute(recAvgCsPerMinute)
+                .recTotalCs((totalWins + totalLosses) > 0 ? totalCs / (totalWins + totalLosses) : 0)
+                .build();
+    }
+
+    /**
+     * 한 번의 API 호출로 모든 모드의 통계를 계산하는 최적화된 메서드
+     */
+    @Getter
+    @Builder
+    public static class AllModeStatsResponse {
+        private Recent30GameStatsResponse combinedStats;  // 프로필용 (솔로+자유)
+        private Recent30GameStatsResponse soloStats;      // 솔로 전용
+        private Recent30GameStatsResponse freeStats;      // 자유 전용  
+        private Recent30GameStatsResponse aramStats;      // 칼바람 전용
+        private Map<Long, ChampionStats> combinedChampionStats;  // 프로필용 챔피언 통계
+        private Map<Long, ChampionStats> soloChampionStats;      // 솔로 챔피언 통계
+        private Map<Long, ChampionStats> freeChampionStats;      // 자유 챔피언 통계
+        private Map<Long, ChampionStats> aramChampionStats;      // 칼바람 챔피언 통계
+    }
+
+    /**
+     * 최적화된 메서드: 한 번의 API 호출로 모든 모드별 통계를 계산
+     */
+    public AllModeStatsResponse getAllModeStatsOptimized(String gameName, String puuid) {
+        List<String> matchIds = Optional.ofNullable(fetchMatchIds(puuid, 0, INITIAL_MATCH_COUNT))
+                .orElseGet(Collections::emptyList);
+
+        AllModeStatsCollector collector = new AllModeStatsCollector();
+        
+        // 한 번의 루프로 모든 매치 데이터 처리
+        for (String matchId : matchIds) {
+            Optional<ChampionStats> championStatsOpt = fetchChampionStatsFromMatch(matchId, gameName);
+            championStatsOpt.ifPresent(collector::processChampionStats);
+        }
+
+        return collector.buildResponse();
+    }
+
+    /**
+     * 모든 모드의 통계를 수집하는 헬퍼 클래스
+     */
+    private class AllModeStatsCollector {
+        private final int[] totalWins = new int[4];      // [combined, solo, free, aram]
+        private final int[] totalLosses = new int[4];
+        private final int[] totalKills = new int[4];
+        private final int[] totalDeaths = new int[4];
+        private final int[] totalAssists = new int[4];
+        private final int[] totalCs = new int[4];
+        private final double[] totalCsPerMinute = new double[4];
+        private final int[] totalGames = new int[4];
+
+        private final Map<Long, ChampionStats> combinedChampionStats = new HashMap<>();
+        private final Map<Long, ChampionStats> soloChampionStats = new HashMap<>();
+        private final Map<Long, ChampionStats> freeChampionStats = new HashMap<>();
+        private final Map<Long, ChampionStats> aramChampionStats = new HashMap<>();
+
+        public void processChampionStats(ChampionStats stats) {
+            int queueId = stats.getQueueId();
+            
+            // 챔피언 통계 업데이트
+            if (ChampionIdStore.contains(stats.getChampionId())) {
+                updateChampionStatsByMode(stats, queueId);
+            }
+
+            // 게임 통계 업데이트
+            updateGameStatsByMode(stats, queueId);
+        }
+
+        private void updateChampionStatsByMode(ChampionStats stats, int queueId) {
+            // 모드별 챔피언 통계 저장
+            switch (queueId) {
+                case QUEUE_ID_SOLO_RANK -> soloChampionStats.merge(stats.getChampionId(), stats, this::mergeChampionStats);
+                case QUEUE_ID_FREE_RANK -> freeChampionStats.merge(stats.getChampionId(), stats, this::mergeChampionStats);
+                case QUEUE_ID_ARAM -> aramChampionStats.merge(stats.getChampionId(), stats, this::mergeChampionStats);
+            }
+            
+            // 프로필용 통합 챔피언 통계 (솔로+자유만)
+            if (queueId == QUEUE_ID_SOLO_RANK || queueId == QUEUE_ID_FREE_RANK) {
+                combinedChampionStats.merge(stats.getChampionId(), stats, this::mergeChampionStats);
+            }
+        }
+
+        private void updateGameStatsByMode(ChampionStats stats, int queueId) {
+            double gameMinutes = stats.getGameTime() / 60.0;
+            double csPerMinute = gameMinutes > 0 ? stats.getTotalMinionsKilled() / gameMinutes : 0.0;
+
+            // 프로필용 통합 통계 (솔로+자유)
+            if (queueId == QUEUE_ID_SOLO_RANK || queueId == QUEUE_ID_FREE_RANK) {
+                updateStatsArray(0, stats, csPerMinute);
+            }
+
+            // 각 모드별 통계
+            switch (queueId) {
+                case QUEUE_ID_SOLO_RANK -> updateStatsArray(1, stats, csPerMinute); // 솔로
+                case QUEUE_ID_FREE_RANK -> updateStatsArray(2, stats, csPerMinute); // 자유
+                case QUEUE_ID_ARAM -> updateStatsArray(3, stats, csPerMinute); // 칼바람
+            }
+        }
+
+        private void updateStatsArray(int index, ChampionStats stats, double csPerMinute) {
+            totalGames[index]++;
+            if (stats.getWins() > 0) totalWins[index]++;
+            else totalLosses[index]++;
+            totalKills[index] += stats.getKills();
+            totalDeaths[index] += stats.getDeaths();
+            totalAssists[index] += stats.getAssists();
+            totalCs[index] += stats.getTotalMinionsKilled();
+            totalCsPerMinute[index] += csPerMinute;
+        }
+
+        private ChampionStats mergeChampionStats(ChampionStats oldStats, ChampionStats newStats) {
+            oldStats.merge(newStats);
+            return oldStats;
+        }
+
+        public AllModeStatsResponse buildResponse() {
+            Recent30GameStatsResponse combinedStats = buildStatsResponse(totalWins[0], totalLosses[0], 
+                    totalKills[0], totalDeaths[0], totalAssists[0], totalCs[0], totalCsPerMinute[0], totalGames[0]);
+            Recent30GameStatsResponse soloStats = buildStatsResponse(totalWins[1], totalLosses[1], 
+                    totalKills[1], totalDeaths[1], totalAssists[1], totalCs[1], totalCsPerMinute[1], totalGames[1]);
+            Recent30GameStatsResponse freeStats = buildStatsResponse(totalWins[2], totalLosses[2], 
+                    totalKills[2], totalDeaths[2], totalAssists[2], totalCs[2], totalCsPerMinute[2], totalGames[2]);
+            Recent30GameStatsResponse aramStats = buildStatsResponse(totalWins[3], totalLosses[3], 
+                    totalKills[3], totalDeaths[3], totalAssists[3], totalCs[3], totalCsPerMinute[3], totalGames[3]);
+
+            return AllModeStatsResponse.builder()
+                    .combinedStats(combinedStats)
+                    .soloStats(soloStats)
+                    .freeStats(freeStats)
+                    .aramStats(aramStats)
+                    .combinedChampionStats(combinedChampionStats)
+                    .soloChampionStats(soloChampionStats)
+                    .freeChampionStats(freeChampionStats)
+                    .aramChampionStats(aramChampionStats)
+                    .build();
+        }
+    }
+
+    private Recent30GameStatsResponse buildStatsResponse(int totalWins, int totalLosses, int totalKills, 
+                                                        int totalDeaths, int totalAssists, int totalCs, 
+                                                        double totalCsPerMinute, int totalGames) {
+        double recWinRate = totalGames > 0 ? (double) totalWins / totalGames * 100 : 0.0;
+        double recAvgKDA = totalGames > 0 ? (double) (totalKills + totalAssists) / Math.max(1, totalDeaths) : 0.0;
+        double recAvgCsPerMinute = totalGames > 0 ? totalCsPerMinute / totalGames : 0.0;
+        
         return Recent30GameStatsResponse.builder()
                 .recTotalWins(totalWins)
                 .recTotalLosses(totalLosses)

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/domain/MatchingRecord.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/domain/MatchingRecord.java
@@ -122,10 +122,11 @@ public class MatchingRecord extends BaseDateTimeEntity {
     }
 
     private static double getWinRateByGameMode(GameMode gameMode, Member member) {
-        if (gameMode == GameMode.FREE) {
-            return member.getFreeWinRate();
-        }
-        return member.getSoloWinRate();
+        return switch (gameMode) {
+            case FREE -> member.getFreeWinRate();
+            case ARAM -> member.getAramWinRate();
+            default -> member.getSoloWinRate(); // SOLO, FAST
+        };
     }
 
     // MatchingRecord Builder


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> 프로필과 마찬 가지로 솔랭 + 자유랭으로 반환하던 정보들을 게시물 성격에 맞춰 반영하도록 작업 했습니다!

## ⏳ 작업 상세 내용

- [x] MemberRecentStats에 모드별 통계 필드 추가 (solo, free, aram(칼바람))
- [x] MemberChampion에 모드별 챔피언 통계 필드 추가
- [x] 게임 모드별 통계 반환 로직 구현
- [x] Member에 aram 승률 필드 구현

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
