### PR TITLE
[Ci/399] QA 전용 서버 배포 설정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main  # main 브랜치에 직접 푸시될 때도 실행
-      - ci/399
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main  # main 브랜치에 직접 푸시될 때도 실행
+      - ci/399
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - qa
-      - ci/399
   workflow_dispatch: # 수동 실행 가능
 
 jobs:

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -1,0 +1,115 @@
+name: Gamegoo v2 API QA CI/CD
+on:
+  push:
+    branches:
+      - qa
+      - ci/399
+  workflow_dispatch: # 수동 실행 가능
+
+jobs:
+  build-and-deploy: # Job 이름
+    runs-on: ubuntu-latest # 실행 환경 - 가장 최신 버전 Ubuntu 환경
+
+    env: # 전체 job에서 사용할 환경 변수 설정
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      QA_DB_HOST: ${{ secrets.QA_DB_HOST }}
+      RDS_PORT: ${{ secrets.RDS_PORT }}
+      QA_DB_SCHEMA_NAME: ${{ secrets.QA_DB_SCHEMA_NAME }}
+      DB_USERNAME: ${{ secrets.DB_USERNAME }}
+      QA_DB_PASSWORD: ${{ secrets.QA_DB_PASSWORD }}
+      GMAIL_PWD: ${{ secrets.GMAIL_PWD }}
+      RIOT_API: ${{ secrets.RIOT_API }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SOCKET_SERVER_URL: ${{ secrets.SOCKET_SERVER_URL }}
+      FRONT_URL: ${{ secrets.FRONT_URL }}
+      CLIENT_ID: ${{ secrets.CLIENT_ID }}
+      CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+      RSO_REDIRECT_URI: ${{ secrets.RSO_REDIRECT_URI }}
+
+    steps:
+      # 1. GitHub Repository 파일 불러오기
+      - name: Github Repository 파일 불러오기
+        uses: actions/checkout@v4
+
+      # 2. 권한 설정
+      - name: gradlew 권한 설정
+        run: chmod +x ./gradlew
+        shell: bash
+
+      # 3. JDK 17 설치
+      - name: JDK 17 설치
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 4. Docker 확장 기능 추가
+      - name: Docker 확장 기능 추가
+        uses: docker/setup-buildx-action@v3
+
+      # 5. Docker Hub 로그인
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # 6. Docker 이미지 생성 및 Push
+      - name: Docker 이미지 생성 및 push
+        uses: docker/build-push-action@v6
+        with:
+          context: . # Dockerfile-qa 위치
+          file: ./Dockerfile-qa # Dockerfile-qa 경로
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2-qa:${{ github.sha }} # 이미지 태그
+          platforms: linux/amd64
+
+      ## CD (Continuous Deployment) 파트
+      # 7. EC2에 SSH로 접속하여 Docker 컨테이너 실행
+      - name: EC2에 배포
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.QA_EC2_HOST }} # EC2 퍼블릭 IP
+          username: ubuntu # EC2 사용자 (기본은 ubuntu)
+          key: ${{ secrets.EC2_SSH_KEY }} # EC2 SSH Private Key
+          script_stop: true # SSH 명령어 실행 중 에러가 발생하면 워크플로 중단
+          script: |
+            sudo fuser -k -n tcp 8080 || true
+
+            docker rm -f gamegoo-api-v2-qa
+
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2-qa:${{ github.sha }}
+
+            docker run -d \
+            -p 8080:8080 \
+            --name gamegoo-api-v2-qa \
+            -v ${{ secrets.EC2_LOG_PATH }}:/app/logs \
+            -e SPRING_PROFILES_ACTIVE=qa \
+            -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
+            -e QA_DB_HOST=${{ secrets.QA_DB_HOST }} \
+            -e RDS_PORT=${{ secrets.RDS_PORT }} \
+            -e QA_DB_SCHEMA_NAME=${{ secrets.QA_DB_SCHEMA_NAME }} \
+            -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+            -e QA_DB_PASSWORD=${{ secrets.QA_DB_PASSWORD }} \
+            -e GMAIL_PWD=${{ secrets.GMAIL_PWD }} \
+            -e RIOT_API=${{ secrets.RIOT_API }} \
+            -e SOCKET_SERVER_URL=${{ secrets.SOCKET_SERVER_URL }} \
+            -e FRONT_URL=${{ secrets.FRONT_URL }} \
+            -e CLIENT_ID=${{ secrets.CLIENT_ID }} \
+            -e CLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
+            -e RSO_REDIRECT_URI=${{ secrets.RSO_REDIRECT_URI }} \
+            -e DISCORD_MONITORING_WEBHOOK_URL_DEV=${{ secrets.DISCORD_MONITORING_WEBHOOK_URL_DEV }} \
+            -e DISCORD_SCHEDULER_WEBHOOK=${{ secrets.DISCORD_SCHEDULER_WEBHOOK }} \
+            ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2-dev:${{ github.sha }}
+
+      # 실패 시 디스코드에 알림 보내기
+      - name: 배포 실패 시 디스코드 알림 전송
+        if: failure() # 이전 스텝이 실패한 경우에만 실행
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          curl -X POST -H "Content-Type: application/json" \
+          -d "{\"content\": \"🚨 **Gamegoo v2 API QA 서버 배포 실패** 🚨\nPR 번호: ${PR_NUMBER}\nPR 제목: ${PR_TITLE}\nPR 작성자: ${PR_AUTHOR}\n[PR 보기](${PR_URL})\"}" \
+          $DISCORD_WEBHOOK_URL

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -100,7 +100,7 @@ jobs:
             -e RSO_REDIRECT_URI=${{ secrets.RSO_REDIRECT_URI }} \
             -e DISCORD_MONITORING_WEBHOOK_URL_DEV=${{ secrets.DISCORD_MONITORING_WEBHOOK_URL_DEV }} \
             -e DISCORD_SCHEDULER_WEBHOOK=${{ secrets.DISCORD_SCHEDULER_WEBHOOK }} \
-            ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2-dev:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2-qa:${{ github.sha }}
 
       # 실패 시 디스코드에 알림 보내기
       - name: 배포 실패 시 디스코드 알림 전송

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -98,7 +98,7 @@ jobs:
             -e CLIENT_ID=${{ secrets.CLIENT_ID }} \
             -e CLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
             -e RSO_REDIRECT_URI=${{ secrets.RSO_REDIRECT_URI }} \
-            -e DISCORD_MONITORING_WEBHOOK_URL_DEV=${{ secrets.DISCORD_MONITORING_WEBHOOK_URL_DEV }} \
+            -e DISCORD_MONITORING_WEBHOOK_URL_QA=${{ secrets.DISCORD_MONITORING_WEBHOOK_URL_QA }} \
             -e DISCORD_SCHEDULER_WEBHOOK=${{ secrets.DISCORD_SCHEDULER_WEBHOOK }} \
             ${{ secrets.DOCKERHUB_USERNAME }}/gamegoo-api-v2-qa:${{ github.sha }}
 

--- a/Dockerfile-qa
+++ b/Dockerfile-qa
@@ -1,0 +1,30 @@
+# [1] 빌드 스테이지
+FROM gradle:8.11.1-jdk17 AS build
+
+WORKDIR /app
+
+# Gradle 라이브러리 설치를 위한 초기 세팅
+COPY build.gradle settings.gradle ./
+RUN gradle dependencies --no-daemon
+
+# 소스코드 복사 후 빌드
+COPY . /app
+RUN gradle clean build --no-daemon
+
+# [2] 런타임 스테이지
+FROM eclipse-temurin:17-jre
+
+WORKDIR /app
+
+# 1) 컨테이너 시간대 KST 설정
+ENV TZ=Asia/Seoul
+RUN apt-get update && apt-get install -y tzdata \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 2) 빌드 결과 JAR 복사
+COPY --from=build /app/build/libs/*SNAPSHOT.jar /app/gamegoov2.jar
+
+# 3) 실행
+CMD ["java", "-Dspring.profiles.active=qa", "-jar", "gamegoov2.jar"]

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/CorsProperties.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/CorsProperties.java
@@ -1,0 +1,18 @@
+package com.gamegoo.gamegoo_v2.core.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins;
+
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
     private final JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler;
     private final LoggingFilter loggingFilter;
     private final SecurityJwtProperties securityJwtProperties;
+    private final CorsProperties corsProperties;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -125,11 +126,11 @@ public class SecurityConfig {
 
         config.setAllowCredentials(true);
         config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedOrigin("http://local.mydomain.com");
-        config.addAllowedOrigin("https://api.gamegoo.co.kr");
-        config.addAllowedOrigin("https://dev.gamegoo.co.kr");
-        config.addAllowedOrigin("https://socket.gamegoo.co.kr");
-        config.addAllowedOrigin("https://www.gamegoo.co.kr");
+
+        for (String origin : corsProperties.getAllowedOrigins()) {
+            config.addAllowedOrigin(origin);
+        }
+
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**", config);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,10 @@ logging:
   discord:
     webhook: ${DISCORD_SCHEDULER_WEBHOOK}
 
+cors:
+  allowed-origins:
+    - http://local.mydomain.com
+
 ---
 # 개발 환경
 server:
@@ -125,6 +129,11 @@ decorator:
     p6spy:
       enable-logging: false
 
+cors:
+  allowed-origins:
+    - https://dev.gamegoo.co.kr
+    - https://devsocket.gamegoo.co.kr
+
 ---
 # 운영 환경
 server:
@@ -153,6 +162,12 @@ decorator:
     p6spy:
       enable-logging: false
 
+cors:
+  allowed-origins:
+    - https://api.gamegoo.co.kr
+    - https://socket.gamegoo.co.kr
+    - https://www.gamegoo.co.kr
+
 ---
 # QA 환경
 server:
@@ -164,7 +179,7 @@ spring:
       on-profile: qa
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
   datasource:
     url: jdbc:mysql://${QA_DB_HOST}:${RDS_PORT}/${QA_DB_SCHEMA_NAME}?useSSL=true
@@ -180,3 +195,9 @@ decorator:
   datasource:
     p6spy:
       enable-logging: false
+
+cors:
+  allowed-origins:
+    - https://qaapi.gamegoo.co.kr
+    - https://qasocket.gamegoo.co.kr
+    - https://test.gamegoo.co.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -174,7 +174,7 @@ spring:
 
 logging:
   discord:
-    webhook: ${DISCORD_MONITORING_WEBHOOK_URL_PROD}
+    webhook: ${DISCORD_MONITORING_WEBHOOK_URL_QA}
 
 decorator:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,7 +170,7 @@ spring:
     url: jdbc:mysql://${QA_DB_HOST}:${RDS_PORT}/${QA_DB_SCHEMA_NAME}?useSSL=true
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    password: ${QA_DB_PASSWORD}
 
 logging:
   discord:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -136,10 +136,38 @@ spring:
       on-profile: prod
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
   datasource:
     url: jdbc:mysql://${RDS_PRIVATE_IP}:${RDS_PORT}/${PROD_DB_SCHEMA_NAME}?useSSL=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+logging:
+  discord:
+    webhook: ${DISCORD_MONITORING_WEBHOOK_URL_PROD}
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false
+
+---
+# QA 환경
+server:
+  port: 8080
+
+spring:
+  config:
+    activate:
+      on-profile: qa
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: false
+  datasource:
+    url: jdbc:mysql://${QA_DB_HOST}:${RDS_PORT}/${QA_DB_SCHEMA_NAME}?useSSL=true
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -136,7 +136,7 @@ spring:
       on-profile: prod
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
   datasource:
     url: jdbc:mysql://${RDS_PRIVATE_IP}:${RDS_PORT}/${PROD_DB_SCHEMA_NAME}?useSSL=true

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -101,5 +101,15 @@
             <appender-ref ref="ASYNC_DISCORD"/>
         </root>
     </springProfile>
+    <!-- qa Profile에서의 로그 설정 -->
+    <springProfile name="qa">
+        <root level="INFO">
+            <!-- CONSOLE, FILE_INFO, FILE_ERROR 등록-->
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE_INFO"/>
+            <appender-ref ref="FILE_ERROR"/>
+            <appender-ref ref="ASYNC_DISCORD"/>
+        </root>
+    </springProfile>
 
 </configuration>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -51,3 +51,6 @@ email:
 logging:
   discord:
     webhook: aaa
+
+cors:
+  allowed-origins: [ ]


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> QA 전용 서버 배포 설정 및 CORS 설정

## ⏳ 작업 상세 내용

- [x] deploy-qa.yml 파일 작성
- [x] qa 서버 환경변수 설정
- [x] Dockerfile-qa 작성
- [x] CorsProperties를 이용한 환경별 CORS 허용 도메인 설정 분리

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] prod, dev, qa 환경 정리입니다.
각 환경별 cicd 스크립트 실행 조건
- prod: main 브랜치에 push 또는 main 브랜치에 pr merge
- dev: develop 브랜치에 pr merge
- qa: qa 브랜치에 push

각 환경별 로그 저장 범위
- prod
  - 콘솔 출력
  - aws s3 `gamegoo/log/api_server`, `gamegoo/log/socket_server` 경로에 로그 파일 일별 저장
- dev: 콘솔에만 출력
- qa
  - 콘솔 출력
  - aws s3 `gamegoo/log/qa_api_server`, `gamegoo/log/qa_socket_server` 경로에 로그 파일 일별 저장
