### PR TITLE
[Feat/438] 스웨거 문서 에러코드 관련 추가

### DIFF
--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/controller/AuthController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.gamegoo.gamegoo_v2.account.auth.dto.response.RefreshTokenResponse;
 import com.gamegoo.gamegoo_v2.account.auth.service.AuthFacadeService;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -28,6 +30,7 @@ public class AuthController {
     @GetMapping("/token/{memberId}")
     @Operation(summary = "임시 access token 발급 API", description = "테스트용으로 access token을 발급받을 수 있는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<String> getTestAccessToken(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(authFacadeService.createTestAccessToken(memberId));
     }
@@ -40,12 +43,22 @@ public class AuthController {
 
     @PostMapping("/refresh")
     @Operation(summary = "refresh   토큰을 통한 access, refresh 토큰 재발급 API 입니다.", description = "API for Refresh Token")
+    @ApiErrorCodes({
+            ErrorCode.INVALID_REFRESH_TOKEN,
+            ErrorCode.INVALID_SIGNATURE,
+            ErrorCode.MALFORMED_TOKEN,
+            ErrorCode.EXPIRED_JWT_EXCEPTION,
+            ErrorCode.UNSUPPORTED_TOKEN,
+            ErrorCode.INVALID_CLAIMS,
+            ErrorCode.MEMBER_NOT_FOUND
+    })
     public ApiResponse<RefreshTokenResponse> updateToken(@Valid @RequestBody RefreshTokenRequest request) {
         return ApiResponse.ok(authFacadeService.updateToken(request));
     }
 
     @DeleteMapping
     @Operation(summary = "탈퇴 API입니다.", description = "API for Blinding Member")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<String> blindMember(@AuthMember Member member) {
         return ApiResponse.ok(authFacadeService.blindMember(member));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/auth/controller/PasswordController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/auth/controller/PasswordController.java
@@ -8,6 +8,8 @@ import com.gamegoo.gamegoo_v2.account.auth.dto.response.PasswordCheckResponse;
 import com.gamegoo.gamegoo_v2.account.auth.service.PasswordFacadeService;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,12 @@ public class PasswordController {
 
     @PostMapping("/reset")
     @Operation(summary = "비밀번호 재설정 API 입니다. JWT X", description = "API for reseting password JWT X")
+    @ApiErrorCodes({
+            ErrorCode.EMAIL_RECORD_NOT_FOUND,
+            ErrorCode.INVALID_VERIFICATION_CODE,
+            ErrorCode.EMAIL_VERIFICATION_TIME_EXCEED,
+            ErrorCode.MEMBER_NOT_FOUND
+    })
     public ApiResponse<String> resetPassword(@Valid @RequestBody PasswordResetWithVerifyRequest request) {
         return ApiResponse.ok(passwordFacadeService.changePasswordWithVerify(request));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/email/controller/EmailController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/email/controller/EmailController.java
@@ -4,6 +4,8 @@ import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.account.email.dto.EmailCodeRequest;
 import com.gamegoo.gamegoo_v2.account.email.dto.EmailRequest;
 import com.gamegoo.gamegoo_v2.account.email.service.EmailFacadeService;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -25,6 +27,12 @@ public class EmailController {
 
     @PostMapping("/send/join")
     @Operation(summary = "회원가입용 이메일 인증코드 전송 API 입니다. 중복확인 포함", description = "API for sending email for join")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_ALREADY_EXISTS,
+            ErrorCode.EMAIL_LIMIT_EXCEEDED,
+            ErrorCode.EMAIL_CONTENT_LOAD_FAIL,
+            ErrorCode.EMAIL_SEND_FAIL
+    })
     public ApiResponse<String> sendEmailWithCheckDuplication(
             @Valid @RequestBody EmailRequest request) {
         return ApiResponse.ok(emailFacadeService.sendEmailVerificationCodeCheckDuplication(request));
@@ -32,12 +40,23 @@ public class EmailController {
 
     @PostMapping("/send/pwd")
     @Operation(summary = "비밀번호 찾기용 이메일 인증코드 전송 API 입니다.", description = "API for sending email for finding password")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.EMAIL_LIMIT_EXCEEDED,
+            ErrorCode.EMAIL_CONTENT_LOAD_FAIL,
+            ErrorCode.EMAIL_SEND_FAIL
+    })
     public ApiResponse<String> sendEmail(@Valid @RequestBody EmailRequest request) {
         return ApiResponse.ok(emailFacadeService.sendEmailVerificationCodeCheckExistence(request));
     }
 
     @PostMapping("/verify")
     @Operation(summary = "이메일 인증코드 검증 API 입니다.", description = "API for verifying email")
+    @ApiErrorCodes({
+        ErrorCode.EMAIL_RECORD_NOT_FOUND,
+        ErrorCode.INVALID_VERIFICATION_CODE,
+        ErrorCode.EMAIL_VERIFICATION_TIME_EXCEED
+    })
     public ApiResponse<String> verifyEmail(@Valid @RequestBody EmailCodeRequest request) {
         return ApiResponse.ok(emailFacadeService.verifyEmailCode(request));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/account/member/controller/MemberController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/account/member/controller/MemberController.java
@@ -11,6 +11,8 @@ import com.gamegoo.gamegoo_v2.account.member.dto.response.MyProfileResponse;
 import com.gamegoo.gamegoo_v2.account.member.dto.response.OtherProfileResponse;
 import com.gamegoo.gamegoo_v2.account.member.service.MemberFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -70,6 +72,7 @@ public class MemberController {
 
     @Operation(summary = "gamestyle 추가 및 수정 API 입니다.", description = "API for Gamestyle addition and modification ")
     @PutMapping("/gamestyle")
+    @ApiErrorCodes({ErrorCode.GAMESTYLE_NOT_FOUND})
     public ApiResponse<String> addGameStyle(@Valid @RequestBody GameStyleRequest request,
                                             @AuthMember Member member) {
         return ApiResponse.ok(memberFacadeService.setGameStyle(member, request));
@@ -77,6 +80,16 @@ public class MemberController {
 
     @Operation(summary = "챔피언 통계 새로고침 API 입니다.", description = "API for refreshing champion statistics")
     @PutMapping("/champion-stats/refresh")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.CHAMPION_REFRESH_COOLDOWN,
+            ErrorCode.RIOT_INVALID_API_KEY,
+            ErrorCode.RIOT_NOT_FOUND,
+            ErrorCode.RIOT_API_ERROR,
+            ErrorCode.RIOT_SERVER_ERROR,
+            ErrorCode.RIOT_NETWORK_ERROR,
+            ErrorCode.RIOT_UNKNOWN_ERROR
+    })
     public ApiResponse<MyProfileResponse> refreshChampionStats(
             @AuthMember Member member,
             @RequestParam(value = "memberId", required = false) Long targetMemberId) {
@@ -85,6 +98,7 @@ public class MemberController {
 
     @Operation(summary = "어드민 권한 부여 API (개발용)", description = "개발용 어드민 권한 부여 API")
     @PatchMapping("/admin/grant/{memberId}")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<String> grantAdminRole(@PathVariable Long memberId) {
 
         return ApiResponse.ok(memberFacadeService.updateMemberRole(memberId, Role.ADMIN));
@@ -92,6 +106,7 @@ public class MemberController {
 
     @Operation(summary = "일반 사용자 권한으로 변경 API (개발용)", description = "어드민 권한을 일반 사용자로 변경하는 API")
     @PatchMapping("/admin/revoke/{memberId}")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<String> revokeAdminRole(@PathVariable Long memberId) {
         return ApiResponse.ok(memberFacadeService.updateMemberRole(memberId, Role.MEMBER));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/controller/ChatController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/controller/ChatController.java
@@ -8,6 +8,8 @@ import com.gamegoo.gamegoo_v2.chat.dto.response.EnterChatroomResponse;
 import com.gamegoo.gamegoo_v2.chat.service.ChatFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidCursor;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,6 +39,14 @@ public class ChatController {
                     "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid, 상대 회원 정보 등을 반환합니다.")
     @Parameter(name = "memberId", description = "채팅방을 시작할 대상 회원의 id 입니다.")
     @GetMapping("/chat/start/member/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.CHAT_START_FAILED_TARGET_IS_BLOCKED,
+            ErrorCode.CHAT_START_FAILED_BLOCKED_BY_TARGET,
+            ErrorCode.CHAT_START_FAILED_TARGET_DEACTIVATED,
+            ErrorCode.CHATROOM_ACCESS_DENIED
+    })
     public ApiResponse<EnterChatroomResponse> startChatroomByMemberId(
             @PathVariable(name = "memberId") Long targetMemberId,
             @AuthMember Member member) {
@@ -49,6 +59,16 @@ public class ChatController {
                     "대상 회원과의 채팅방이 존재하지 않는 경우, 채팅방을 새로 생성해 해당 채팅방의 uuid, 상대 회원 정보 등을 리턴합니다.")
     @Parameter(name = "boardId", description = "말 걸어보기 버튼을 누른 게시글의 id 입니다.")
     @GetMapping("/chat/start/board/{boardId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_BANNED_FROM_CHATTING,
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.CHAT_START_FAILED_TARGET_DEACTIVATED,
+            ErrorCode.CHAT_START_FAILED_BLOCKED_BY_TARGET,
+            ErrorCode.CHAT_START_FAILED_TARGET_IS_BLOCKED,
+            ErrorCode.CHATROOM_ACCESS_DENIED
+    })
     public ApiResponse<EnterChatroomResponse> startChatroomByBoardId(@PathVariable(name = "boardId") Long boardId,
                                                                      @AuthMember Member member) {
         return ApiResponse.ok(chatFacadeService.startChatroomByBoardId(member, boardId));
@@ -57,6 +77,13 @@ public class ChatController {
     @Operation(summary = "채팅방 입장 API",
             description = "특정 채팅방에 입장하는 API 입니다. 상대 회원 정보와 채팅 메시지 내역 등을 리턴합니다.")
     @GetMapping("/chat/{chatroomUuid}/enter")
+    @ApiErrorCodes({
+            ErrorCode.CHATROOM_NOT_FOUND,
+            ErrorCode.CHATROOM_ACCESS_DENIED,
+            ErrorCode.CHAT_START_FAILED_TARGET_IS_BLOCKED,
+            ErrorCode.CHAT_START_FAILED_BLOCKED_BY_TARGET,
+            ErrorCode.CHAT_START_FAILED_TARGET_DEACTIVATED
+    })
     public ApiResponse<EnterChatroomResponse> enterChatroom(@PathVariable(name = "chatroomUuid") String chatroomUuid,
                                                             @AuthMember Member member) {
         return ApiResponse.ok(chatFacadeService.enterChatroomByUuid(member, chatroomUuid));
@@ -68,6 +95,10 @@ public class ChatController {
                     "cursor 파라미터를 보내지 않으면, 해당 채팅방의 가장 최근 메시지 내역을 조회합니다.")
     @GetMapping("/chat/{chatroomUuid}/messages")
     @Parameter(name = "cursor", description = "페이징을 위한 커서, 13자리 timestamp integer를 보내주세요. (UTC 기준)")
+    @ApiErrorCodes({
+            ErrorCode.CHATROOM_NOT_FOUND,
+            ErrorCode.CHATROOM_ACCESS_DENIED
+    })
     public ApiResponse<ChatMessageListResponse> getChatMessages(
             @PathVariable(name = "chatroomUuid") String chatroomUuid,
             @ValidCursor @RequestParam(name = "cursor", required = false) Long cursor,
@@ -84,6 +115,12 @@ public class ChatController {
     @Operation(summary = "채팅 메시지 읽음 처리 API", description = "특정 채팅방의 메시지를 읽음 처리하는 API 입니다.")
     @PatchMapping("/chat/{chatroomUuid}/read")
     @Parameter(name = "timestamp", description = "특정 메시지를 읽음 처리하는 경우, 그 메시지의 timestamp를 함께 보내주세요.")
+    @ApiErrorCodes({
+            ErrorCode.CHATROOM_NOT_FOUND,
+            ErrorCode.CHATROOM_ACCESS_DENIED,
+            ErrorCode.CHAT_READ_FAILED_NOT_ENTERED_CHATROOM,
+            ErrorCode.CHAT_MESSAGE_NOT_FOUND
+    })
     public ApiResponse<String> readChatMessage(
             @PathVariable(name = "chatroomUuid") String chatroomUuid,
             @RequestParam(name = "timestamp", required = false) Long timestamp,
@@ -93,6 +130,10 @@ public class ChatController {
 
     @Operation(summary = "채팅방 나가기 API", description = "채팅방 나가기 API 입니다.")
     @PatchMapping("/chat/{chatroomUuid}/exit")
+    @ApiErrorCodes({
+            ErrorCode.CHATROOM_NOT_FOUND,
+            ErrorCode.CHATROOM_ACCESS_DENIED
+    })
     public ApiResponse<Object> exitChatroom(@PathVariable(name = "chatroomUuid") String chatroomUuid,
                                             @AuthMember Member member) {
         return ApiResponse.ok(chatFacadeService.exitChatroom(member, chatroomUuid));

--- a/src/main/java/com/gamegoo/gamegoo_v2/chat/controller/ChatInternalController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/chat/controller/ChatInternalController.java
@@ -4,6 +4,8 @@ import com.gamegoo.gamegoo_v2.chat.dto.request.ChatCreateRequest;
 import com.gamegoo.gamegoo_v2.chat.dto.response.ChatCreateResponse;
 import com.gamegoo.gamegoo_v2.chat.service.ChatFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -27,12 +29,25 @@ public class ChatInternalController {
 
     @Operation(summary = "채팅방 uuid 조회 API", description = "회원이 속한 채팅방의 uuid를 조회하는 API 입니다.")
     @GetMapping("/{memberId}/chatroom/uuid")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<List<String>> getChatroomUuid(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(chatFacadeService.getChatroomUuids(memberId));
     }
 
     @Operation(summary = "채팅 메시지 등록 API", description = "새로운 채팅 메시지를 등록하는 API 입니다.")
     @PostMapping("/{memberId}/chat/{chatroomUuid}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.MEMBER_BANNED_FROM_CHATTING,
+            ErrorCode.CHATROOM_NOT_FOUND,
+            ErrorCode.CHATROOM_ACCESS_DENIED,
+            ErrorCode.CHAT_ADD_FAILED_TARGET_DEACTIVATED,
+            ErrorCode.CHAT_ADD_FAILED_TARGET_IS_BLOCKED,
+            ErrorCode.CHAT_ADD_FAILED_BLOCKED_BY_TARGET,
+            ErrorCode.ADD_BOARD_SYSTEM_CHAT_FAILED,
+            ErrorCode.SYSTEM_MEMBER_NOT_FOUND,
+            ErrorCode.SYSTEM_MESSAGE_TYPE_NOT_FOUND
+    })
     public ApiResponse<ChatCreateResponse> addChat(@PathVariable(name = "memberId") Long memberId,
                                                    @PathVariable(name = "chatroomUuid") String chatroomUuid,
                                                    @RequestBody @Valid ChatCreateRequest request) {

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/board/controller/BoardController.java
@@ -15,6 +15,8 @@ import com.gamegoo.gamegoo_v2.content.board.service.BoardFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -55,6 +57,12 @@ public class BoardController {
                     "나락: ARAM >, " +
                     "주 포지션, 부포지션, 희망 포지션: < TOP, JUNGLE, MID, ADC, SUP, ANY >, 마이크 여부: < AVAILABLE, UNAVAILABLE >, 게임" +
                     " 스타일 리스트: 1~3개 선택 가능")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_BANNED_FROM_POSTING,
+            ErrorCode.BOARD_FORBIDDEN_WORD,
+            ErrorCode.BOARD_CREATE_COOL_DOWN,
+            ErrorCode.BOARD_GAME_STYLE_NOT_FOUND
+    })
     public ApiResponse<BoardInsertResponse> boardInsert(
             @AuthMember Member member,
             @Valid @RequestBody BoardInsertRequest request) {
@@ -67,6 +75,17 @@ public class BoardController {
                     "나락: ARAM >, " +
                     "주 포지션, 부포지션, 희망 포지션: < TOP, JUNGLE, MID, ADC, SUP, ANY >, 마이크 여부: < AVAILABLE, UNAVAILABLE >, 게임" +
                     " 스타일 리스트: 1~3개 선택 가능")
+    @ApiErrorCodes({
+            ErrorCode.BOARD_FORBIDDEN_WORD,
+            ErrorCode.BOARD_GAME_STYLE_NOT_FOUND,
+            ErrorCode.RIOT_INVALID_API_KEY,
+            ErrorCode.RIOT_NOT_FOUND,
+            ErrorCode.RIOT_API_ERROR,
+            ErrorCode.RIOT_SERVER_ERROR,
+            ErrorCode.RIOT_NETWORK_ERROR,
+            ErrorCode.RIOT_UNKNOWN_ERROR,
+            ErrorCode.MEMBER_ALREADY_EXISTS
+    })
     public ApiResponse<BoardInsertResponse> guestBoardInsert(
             @Valid @RequestBody GuestBoardInsertRequest request) {
         return ApiResponse.ok(boardFacadeService.createGuestBoard(request, request.getGameName(), request.getTag()));
@@ -111,6 +130,7 @@ public class BoardController {
     @GetMapping("/member/list/{boardId}")
     @Operation(summary = "회원용 게시판 글 조회 API", description = "게시판에서 글을 조회하는 API 입니다.")
     @Parameter(name = "boardId", description = "조회할 게시판 글 id 입니다.")
+    @ApiErrorCodes({ErrorCode.BOARD_NOT_FOUND})
     public ApiResponse<BoardByIdResponseForMember> getBoardByIdForMember(@PathVariable Long boardId,
                                                                          @AuthMember Member member) {
         return ApiResponse.ok(boardFacadeService.getBoardByIdForMember(boardId, member));
@@ -119,6 +139,7 @@ public class BoardController {
     @GetMapping("/list/{boardId}")
     @Operation(summary = "비회원용 게시판 글 조회 API", description = "게시판에서 글을 조회하는 API 입니다.")
     @Parameter(name = "boardId", description = "조회할 게시판 글 id 입니다.")
+    @ApiErrorCodes({ErrorCode.BOARD_NOT_FOUND})
     public ApiResponse<BoardByIdResponse> getBoardById(@PathVariable Long boardId) {
         return ApiResponse.ok(boardFacadeService.getBoardById(boardId));
     }
@@ -126,6 +147,13 @@ public class BoardController {
     @PutMapping("/{boardId}")
     @Operation(summary = "게시판 글 수정 API", description = "게시판에서 글을 수정하는 API 입니다.")
     @Parameter(name = "boardId", description = "수정할 게시판 글 id 입니다.")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_BANNED_FROM_POSTING,
+            ErrorCode.BOARD_FORBIDDEN_WORD,
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.UPDATE_BOARD_ACCESS_DENIED,
+            ErrorCode.BOARD_GAME_STYLE_NOT_FOUND
+    })
     public ApiResponse<BoardUpdateResponse> boardUpdate(@PathVariable Long boardId,
                                                         @Valid @RequestBody BoardUpdateRequest request,
                                                         @AuthMember Member member) {
@@ -135,6 +163,10 @@ public class BoardController {
     @DeleteMapping("/{boardId}")
     @Operation(summary = "게시판 글 삭제 API", description = "게시판에서 글을 삭제하는 API 입니다.")
     @Parameter(name = "boardId", description = "삭제할 게시판 글 id 입니다.")
+    @ApiErrorCodes({
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.DELETE_BOARD_ACCESS_DENIED
+    })
     public ApiResponse<String> delete(@PathVariable Long boardId, @AuthMember Member member) {
         boardFacadeService.deleteBoard(member, boardId);
         return ApiResponse.ok("게시글을 삭제하였습니다.");
@@ -164,6 +196,12 @@ public class BoardController {
     @PostMapping("/{boardId}/bump")
     @Operation(summary = "게시글 끌올 API", description = "게시글을 끌올하여 상단 노출시키는 API 입니다. 마지막 끌올 후 1시간 제한이 적용됩니다.")
     @Parameter(name = "boardId", description = "끌올할 게시판 글 id 입니다.")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_BANNED_FROM_POSTING,
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.BUMP_ACCESS_DENIED,
+            ErrorCode.BUMP_TIME_LIMIT
+    })
     public ApiResponse<BoardBumpResponse> bumpBoard(@PathVariable Long boardId,
                                                     @AuthMember Member member) {
         return ApiResponse.ok(boardFacadeService.bumpBoard(boardId, member));
@@ -200,6 +238,13 @@ public class BoardController {
     @PutMapping("/guest/{boardId}")
     @Operation(summary = "비회원 게시판 글 수정 API", description = "비회원이 게시판에서 글을 수정하는 API 입니다.")
     @Parameter(name = "boardId", description = "수정할 게시판 글 id 입니다.")
+    @ApiErrorCodes({
+            ErrorCode.BOARD_FORBIDDEN_WORD,
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.GUEST_BOARD_ACCESS_DENIED,
+            ErrorCode.INVALID_GUEST_PASSWORD,
+            ErrorCode.BOARD_GAME_STYLE_NOT_FOUND
+    })
     public ApiResponse<BoardUpdateResponse> guestBoardUpdate(@PathVariable Long boardId,
                                                             @Valid @RequestBody GuestBoardUpdateRequest request) {
         return ApiResponse.ok(boardFacadeService.updateGuestBoard(request, boardId));
@@ -208,6 +253,11 @@ public class BoardController {
     @DeleteMapping("/guest/{boardId}")
     @Operation(summary = "비회원 게시판 글 삭제 API", description = "비회원이 게시판에서 글을 삭제하는 API 입니다.")
     @Parameter(name = "boardId", description = "삭제할 게시판 글 id 입니다.")
+    @ApiErrorCodes({
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.GUEST_BOARD_ACCESS_DENIED,
+            ErrorCode.INVALID_GUEST_PASSWORD
+    })
     public ApiResponse<String> deleteGuestBoard(@PathVariable Long boardId, 
                                                @Valid @RequestBody GuestBoardDeleteRequest request) {
         boardFacadeService.deleteGuestBoard(boardId, request);

--- a/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/content/report/controller/ReportController.java
@@ -13,6 +13,8 @@ import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportPageResponse;
 import com.gamegoo.gamegoo_v2.content.report.dto.response.ReportProcessResponse;
 import com.gamegoo.gamegoo_v2.content.report.service.ReportFacadeService;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -45,6 +47,14 @@ public class ReportController {
     @Operation(summary = "신고 등록 API", description = "대상 회원에 대한 신고를 등록하는 API 입니다.")
     @Parameter(name = "memberId", description = "신고할 대상 회원의 id 입니다.")
     @PostMapping("/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.REPORT_ALREADY_EXISTS,
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.REPORT_PATH_NOT_FOUND
+    })
     public ApiResponse<ReportInsertResponse> addReport(@PathVariable("memberId") Long targetMemberId,
                                                        @Valid @RequestBody ReportRequest request,
                                                        @AuthMember(required = false) Member member) {
@@ -132,6 +142,7 @@ public class ReportController {
                     """)
     @Parameter(name = "reportId", description = "처리할 신고의 ID입니다.")
     @PutMapping("/{reportId}/process")
+    @ApiErrorCodes({ErrorCode.REPORT_NOT_FOUND})
     public ApiResponse<ReportProcessResponse> processReport(@PathVariable("reportId") Long reportId,
                                                             @Valid @RequestBody ReportProcessRequest request) {
         return ApiResponse.ok(reportFacadeService.processReport(reportId, request));
@@ -151,6 +162,11 @@ public class ReportController {
                     """)
     @Parameter(name = "reportId", description = "삭제할 게시글과 연관된 신고의 ID입니다.")
     @DeleteMapping("/{reportId}/post")
+    @ApiErrorCodes({
+            ErrorCode.REPORT_NOT_FOUND,
+            ErrorCode.BOARD_NOT_FOUND,
+            ErrorCode.DELETE_BOARD_ACCESS_DENIED
+    })
     public ApiResponse<String> deleteReportedPost(@PathVariable("reportId") Long reportId) {
         return ApiResponse.ok(reportFacadeService.deleteReportedPost(reportId));
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
@@ -108,11 +108,10 @@ public class OpenApiConfig {
                 .description("비즈니스 에러 코드")
                 .example("COMMON400"));
 
-        Schema<Object> dataSchema = new Schema<>();
-        dataSchema.setType("object");
-        dataSchema.setNullable(true);
-        dataSchema.setDescription("응답 데이터 (에러 시 null)");
-        errorResponseSchema.addProperties("data", dataSchema);
+        errorResponseSchema.addProperties("data", new Schema<>()
+                .type("object")
+                .nullable(true)
+                .description("응답 데이터 (에러 시 null)"));
 
         components.addSchemas(SwaggerErrorResponseConfig.ERROR_RESPONSE_SCHEMA_NAME, errorResponseSchema);
     }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/OpenApiConfig.java
@@ -11,9 +11,13 @@ import com.gamegoo.gamegoo_v2.content.report.domain.ReportType;
 import com.gamegoo.gamegoo_v2.matching.domain.GameMode;
 import com.gamegoo.gamegoo_v2.matching.domain.MatchingStatus;
 import com.gamegoo.gamegoo_v2.matching.domain.MatchingType;
+import com.gamegoo.gamegoo_v2.core.config.swagger.SwaggerErrorResponseConfig;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,6 +51,8 @@ public class OpenApiConfig {
 
             // ReportType은 특별 처리 (ID 기반)
             addReportTypeSchema(components);
+
+            addErrorResponseSchema(components);
         };
     }
 
@@ -74,12 +80,40 @@ public class OpenApiConfig {
         Schema<Integer> reportTypeSchema = new Schema<Integer>()
                 .type("integer")
                 .description("신고 유형 (1=스팸, 2=불법정보, 3=성희롱, 4=욕설/혐오, 5=개인정보노출, 6=불쾌한표현)");
-        
+
         List<Integer> enumValues = Arrays.stream(ReportType.values())
                 .map(ReportType::getId)
                 .toList();
-        
+
         reportTypeSchema.setEnum(enumValues);
         components.addSchemas("ReportType", reportTypeSchema);
+    }
+
+    private void addErrorResponseSchema(Components components) {
+        if (components.getSchemas() != null
+                && components.getSchemas().containsKey(SwaggerErrorResponseConfig.ERROR_RESPONSE_SCHEMA_NAME)) {
+            return;
+        }
+
+        ObjectSchema errorResponseSchema = new ObjectSchema();
+        errorResponseSchema.setDescription("공통 에러 응답 포맷");
+
+        errorResponseSchema.addProperties("status", new IntegerSchema()
+                .description("HTTP 상태 코드")
+                .example(400));
+        errorResponseSchema.addProperties("message", new StringSchema()
+                .description("에러 메시지")
+                .example("잘못된 요청입니다."));
+        errorResponseSchema.addProperties("code", new StringSchema()
+                .description("비즈니스 에러 코드")
+                .example("COMMON400"));
+
+        Schema<Object> dataSchema = new Schema<>();
+        dataSchema.setType("object");
+        dataSchema.setNullable(true);
+        dataSchema.setDescription("응답 데이터 (에러 시 null)");
+        errorResponseSchema.addProperties("data", dataSchema);
+
+        components.addSchemas(SwaggerErrorResponseConfig.ERROR_RESPONSE_SCHEMA_NAME, errorResponseSchema);
     }
 }

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/swagger/ApiErrorCodes.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/swagger/ApiErrorCodes.java
@@ -1,0 +1,17 @@
+package com.gamegoo.gamegoo_v2.core.config.swagger;
+
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodes {
+
+    ErrorCode[] value();
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/core/config/swagger/SwaggerErrorResponseConfig.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/core/config/swagger/SwaggerErrorResponseConfig.java
@@ -1,0 +1,99 @@
+package com.gamegoo.gamegoo_v2.core.config.swagger;
+
+import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Configuration
+public class SwaggerErrorResponseConfig {
+
+    public static final String ERROR_RESPONSE_SCHEMA_NAME = "ApiErrorResponse";
+
+    @Bean
+    public OperationCustomizer apiErrorResponseCustomizer() {
+        return (operation, handlerMethod) -> {
+            ApiErrorCodes annotation = handlerMethod.getMethodAnnotation(ApiErrorCodes.class);
+
+            Set<ErrorCode> errorCodeSet = new LinkedHashSet<>();
+            if (annotation != null && annotation.value().length > 0) {
+                errorCodeSet.addAll(Arrays.asList(annotation.value()));
+            }
+
+            boolean hasRequiredAuthMember = Arrays.stream(handlerMethod.getMethodParameters())
+                    .anyMatch(parameter -> {
+                        AuthMember authMember = parameter.getParameterAnnotation(AuthMember.class);
+                        return authMember != null && authMember.required();
+                    });
+
+            if (hasRequiredAuthMember) {
+                errorCodeSet.add(ErrorCode.UNAUTHORIZED_EXCEPTION);
+                errorCodeSet.add(ErrorCode.MEMBER_NOT_FOUND);
+                errorCodeSet.add(ErrorCode.INACTIVE_MEMBER);
+            }
+
+            if (errorCodeSet.isEmpty()) {
+                return operation;
+            }
+
+            Map<HttpStatus, List<ErrorCode>> groupedErrorCodes = errorCodeSet.stream()
+                    .collect(Collectors.groupingBy(ErrorCode::getStatus, LinkedHashMap::new, Collectors.toList()));
+
+            ApiResponses responses = operation.getResponses();
+            if (responses == null) {
+                responses = new ApiResponses();
+                operation.setResponses(responses);
+            }
+
+            final ApiResponses apiResponses = responses;
+
+            groupedErrorCodes.forEach((status, errorCodes) -> {
+                String responseCode = String.valueOf(status.value());
+                io.swagger.v3.oas.models.responses.ApiResponse apiResponse = apiResponses.computeIfAbsent(
+                        responseCode,
+                        key -> new io.swagger.v3.oas.models.responses.ApiResponse().description(status.getReasonPhrase())
+                );
+
+                String description = errorCodes.stream()
+                        .map(errorCode -> String.format("[%s] %s", errorCode.getCode(), errorCode.getMessage()))
+                        .collect(Collectors.joining("\n"));
+
+                if (apiResponse.getDescription() == null || apiResponse.getDescription().isBlank()
+                        || status.getReasonPhrase().equals(apiResponse.getDescription())) {
+                    apiResponse.setDescription(description);
+                } else if (!apiResponse.getDescription().contains(description)) {
+                    apiResponse.setDescription(apiResponse.getDescription() + "\n" + description);
+                }
+
+                Content content = apiResponse.getContent();
+                if (content == null) {
+                    content = new Content();
+                    apiResponse.setContent(content);
+                }
+
+                MediaType mediaType = content.get(org.springframework.http.MediaType.APPLICATION_JSON_VALUE);
+                if (mediaType == null) {
+                    mediaType = new MediaType();
+                    mediaType.schema(new Schema<>().$ref("#/components/schemas/" + ERROR_RESPONSE_SCHEMA_NAME));
+                    content.addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mediaType);
+                }
+            });
+
+            return operation;
+        };
+    }
+}

--- a/src/main/java/com/gamegoo/gamegoo_v2/external/riot/controller/RiotController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/external/riot/controller/RiotController.java
@@ -1,9 +1,10 @@
 package com.gamegoo.gamegoo_v2.external.riot.controller;
 
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.external.riot.dto.request.RiotJoinRequest;
 import com.gamegoo.gamegoo_v2.external.riot.dto.request.RiotVerifyExistUserRequest;
-import com.gamegoo.gamegoo_v2.external.riot.dto.response.RiotJoinResponse;
 import com.gamegoo.gamegoo_v2.external.riot.service.RiotFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,19 +31,42 @@ public class RiotController {
 
     @PostMapping("/verify")
     @Operation(summary = "실제 존재하는 Riot 계정인지 검증하는 API", description = "API for verifying account by riot API")
+    @ApiErrorCodes({
+            ErrorCode.RIOT_INVALID_API_KEY,
+            ErrorCode.RIOT_NOT_FOUND,
+            ErrorCode.RIOT_API_ERROR,
+            ErrorCode.RIOT_SERVER_ERROR,
+            ErrorCode.RIOT_NETWORK_ERROR,
+            ErrorCode.RIOT_UNKNOWN_ERROR
+    })
     public ApiResponse<String> VerifyRiot(@RequestBody @Valid RiotVerifyExistUserRequest request) {
         return ApiResponse.ok(riotFacadeService.verifyRiotAccount(request));
     }
 
     @PostMapping("/join")
     @Operation(summary = "RSO 전용 회원가입 API", description = "API for RSO join")
-    public ApiResponse<RiotJoinResponse> joinByRSO(@RequestBody @Valid RiotJoinRequest request) {
-
-        return ApiResponse.ok(riotFacadeService.join(request));
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_ALREADY_EXISTS,
+            ErrorCode.RIOT_INVALID_API_KEY,
+            ErrorCode.RIOT_NOT_FOUND,
+            ErrorCode.RIOT_API_ERROR,
+            ErrorCode.RIOT_SERVER_ERROR,
+            ErrorCode.RIOT_NETWORK_ERROR,
+            ErrorCode.RIOT_UNKNOWN_ERROR
+    })
+    public ApiResponse<String> joinByRSO(@RequestBody @Valid RiotJoinRequest request) {
+        riotFacadeService.join(request);
+        return ApiResponse.ok("RSO 회원가입이 완료되었습니다.");
     }
 
     @GetMapping("/oauth/callback")
     @Operation(summary = "Riot OAuth 인증 코드 콜백 처리")
+    @ApiErrorCodes({
+            ErrorCode.RIOT_API_ERROR,
+            ErrorCode.RSO_NO_STATE,
+            ErrorCode.STATE_WRONG_DECODE,
+            ErrorCode.INACTIVE_MEMBER
+    })
     public ResponseEntity<Void> handleRSOCallback(@RequestParam("code") String code,
                                                   @RequestParam(required = false) String state) {
         return ResponseEntity.status(HttpStatus.FOUND)

--- a/src/main/java/com/gamegoo/gamegoo_v2/matching/controller/MatchingController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/matching/controller/MatchingController.java
@@ -1,6 +1,8 @@
 package com.gamegoo.gamegoo_v2.matching.controller;
 
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.matching.domain.MatchingStatus;
 import com.gamegoo.gamegoo_v2.matching.dto.request.InitializingMatchingRequest;
 import com.gamegoo.gamegoo_v2.matching.dto.response.MatchingFoundResponse;
@@ -31,6 +33,11 @@ public class MatchingController {
 
     @Operation(summary = "매칭 우선순위 계산 및 기록 저장 API", description = "API for calculating and recording matching")
     @PostMapping("/matching/priority/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.MEMBER_BANNED_FROM_MATCHING,
+            ErrorCode.GAMESTYLE_NOT_FOUND
+    })
     public ApiResponse<PriorityListResponse> InitializeMatching(@PathVariable(name = "memberId") Long memberId,
                                                                 @RequestBody @Valid InitializingMatchingRequest request) {
         return ApiResponse.ok(matchingFacadeService.calculatePriorityAndRecording(memberId, request));
@@ -38,6 +45,7 @@ public class MatchingController {
 
     @Operation(summary = "내 매칭 status 변경", description = "API for updating my matching status")
     @PatchMapping("/matching/status/{matchingUuid}/{status}")
+    @ApiErrorCodes({ErrorCode.MATCHING_NOT_FOUND})
     public ApiResponse<String> UpdateMatchingStatus(
             @PathVariable(name = "matchingUuid") String matchingUuid,
             @Parameter(description = "매칭 상태", schema = @Schema(ref = "#/components/schemas/MatchingStatus"))
@@ -48,6 +56,10 @@ public class MatchingController {
 
     @Operation(summary = "나와 상대방 매칭 status 변경", description = "API for updating both matching status")
     @PatchMapping("/matching/status/target/{matchingUuid}/{status}")
+    @ApiErrorCodes({
+            ErrorCode.MATCHING_NOT_FOUND,
+            ErrorCode.TARGET_MATCHING_MEMBER_NOT_FOUND
+    })
     public ApiResponse<String> UpdateBothMatchingStatus(
             @PathVariable(name = "matchingUuid") String matchingUuid,
             @Parameter(description = "매칭 상태", schema = @Schema(ref = "#/components/schemas/MatchingStatus"))
@@ -58,6 +70,18 @@ public class MatchingController {
 
     @Operation(summary = "매칭 FOUND API", description = "API triggered when a match is found")
     @PatchMapping("/matching/found/{matchingUuid}/{targetMatchingUuid}")
+    @ApiErrorCodes({
+            ErrorCode.MATCHING_NOT_FOUND,
+            ErrorCode.MATCHING_FOUND_FAILED_BY_CONFLICT_MATCHINGUUID,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.INACTIVE_MEMBER,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.MATCHING_FOUND_FAILED_TARGET_IS_BLOCKED,
+            ErrorCode.MATCHING_FOUND_FAILED_BLOCKED_BY_TARGET,
+            ErrorCode.MATCHING_STATUS_NOT_ALLOWED,
+            ErrorCode.MATCHING_TARGET_UNAVAILABLE,
+            ErrorCode.TARGET_MATCHING_MEMBER_NOT_FOUND
+    })
     public ApiResponse<MatchingFoundResponse> FindMatching(
             @PathVariable(name = "matchingUuid") String matchingUuid,
             @PathVariable(name = "targetMatchingUuid") String targetMatchingUuid
@@ -67,6 +91,18 @@ public class MatchingController {
 
     @Operation(summary = "매칭 SUCCESS API", description = "API triggered when a match is succeed")
     @PatchMapping("/matching/success/{matchingUuid}/{targetMatchingUuid}")
+    @ApiErrorCodes({
+            ErrorCode.MATCHING_NOT_FOUND,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.INACTIVE_MEMBER,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.MATCHING_FOUND_FAILED_TARGET_IS_BLOCKED,
+            ErrorCode.MATCHING_FOUND_FAILED_BLOCKED_BY_TARGET,
+            ErrorCode.MATCHING_STATUS_NOT_ALLOWED,
+            ErrorCode.MATCHING_TARGET_UNAVAILABLE,
+            ErrorCode.TARGET_MATCHING_MEMBER_NOT_FOUND,
+            ErrorCode.CHATROOM_ACCESS_DENIED
+    })
     public ApiResponse<String> SuccessMatching(
             @PathVariable(name = "matchingUuid") String matchingUuid,
             @PathVariable(name = "targetMatchingUuid") String targetMatchingUuid

--- a/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/notification/controller/NotificationController.java
@@ -5,6 +5,8 @@ import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidCursor;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationCursorListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.NotificationPageListResponse;
 import com.gamegoo.gamegoo_v2.notification.dto.ReadNotificationResponse;
@@ -33,6 +35,7 @@ public class NotificationController {
     @Operation(summary = "알림 읽음 처리 API", description = "특정 알림을 읽음 처리하는 API 입니다.")
     @Parameter(name = "notificationId", description = "읽음 처리할 알림의 id 입니다.")
     @PatchMapping("/{notificationId}")
+    @ApiErrorCodes({ErrorCode.NOTIFICATION_NOT_FOUND})
     public ApiResponse<ReadNotificationResponse> readNotification(
             @PathVariable(name = "notificationId") Long notificationId, @AuthMember Member member) {
         return ApiResponse.ok(notificationFacadeService.readNotification(member, notificationId));

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/block/controller/BlockController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/block/controller/BlockController.java
@@ -4,6 +4,8 @@ import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
 import com.gamegoo.gamegoo_v2.core.common.annotation.ValidPage;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockListResponse;
 import com.gamegoo.gamegoo_v2.social.block.dto.BlockResponse;
 import com.gamegoo.gamegoo_v2.social.block.service.BlockFacadeService;
@@ -32,6 +34,12 @@ public class BlockController {
     @Operation(summary = "회원 차단 API", description = "대상 회원을 차단하는 API 입니다.")
     @Parameter(name = "memberId", description = "차단할 대상 회원의 id 입니다.")
     @PostMapping("/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.BLOCK_MEMBER_BAD_REQUEST,
+            ErrorCode.ALREADY_BLOCKED
+    })
     public ApiResponse<BlockResponse> blockMember(@PathVariable(name = "memberId") Long targetMemberId,
                                                   @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.blockMember(member, targetMemberId));
@@ -48,6 +56,11 @@ public class BlockController {
     @Operation(summary = "회원 차단 해제 API", description = "해당 회원에 대한 차단을 해제하는 API 입니다.")
     @Parameter(name = "memberId", description = "차단을 해제할 대상 회원의 id 입니다.")
     @DeleteMapping("/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.TARGET_MEMBER_NOT_BLOCKED
+    })
     public ApiResponse<BlockResponse> unblockMember(@PathVariable(name = "memberId") Long targetMemberId,
                                                     @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.unBlockMember(member, targetMemberId));
@@ -56,6 +69,11 @@ public class BlockController {
     @Operation(summary = "차단 목록에서 탈퇴한 회원 삭제 API", description = "차단 목록에서 특정 회원이 탈퇴한 회원인 경우, 삭제하는 API 입니다. (차단 해제 아님)")
     @Parameter(name = "memberId", description = "목록에서 삭제할 대상 회원의 id 입니다.")
     @DeleteMapping("/delete/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.TARGET_MEMBER_NOT_BLOCKED,
+            ErrorCode.DELETE_BLOCKED_MEMBER_FAILED
+    })
     public ApiResponse<BlockResponse> deleteBlockMember(@PathVariable(name = "memberId") Long targetMemberId,
                                                         @AuthMember Member member) {
         return ApiResponse.ok(blockFacadeService.deleteBlock(member, targetMemberId));

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/controller/FriendController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/controller/FriendController.java
@@ -3,6 +3,8 @@ package com.gamegoo.gamegoo_v2.social.friend.controller;
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.friend.dto.DeleteFriendResponse;
 import com.gamegoo.gamegoo_v2.social.friend.dto.FriendInfoResponse;
 import com.gamegoo.gamegoo_v2.social.friend.dto.FriendListResponse;
@@ -37,6 +39,16 @@ public class FriendController {
     @Operation(summary = "친구 요청 전송 API", description = "대상 회원에게 친구 요청을 전송하는 API 입니다. 대상 회원에게 친구 요청 알림을 전송합니다.")
     @Parameter(name = "memberId", description = "친구 요청을 전송할 대상 회원의 id 입니다.")
     @PostMapping("/request/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.FRIEND_BAD_REQUEST,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.FRIEND_TARGET_IS_BLOCKED,
+            ErrorCode.BLOCKED_BY_FRIEND_TARGET,
+            ErrorCode.ALREADY_FRIEND,
+            ErrorCode.MY_PENDING_FRIEND_REQUEST_EXIST,
+            ErrorCode.TARGET_PENDING_FRIEND_REQUEST_EXIST
+    })
     public ApiResponse<FriendRequestResponse> sendFriendRequest(
             @PathVariable(name = "memberId") Long targetMemberId, @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.sendFriendRequest(member, targetMemberId));
@@ -45,6 +57,11 @@ public class FriendController {
     @Operation(summary = "친구 요청 수락 API", description = "대상 회원이 보낸 친구 요청을 수락 처리하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 수락할 대상 회원의 id 입니다.")
     @PatchMapping("/request/{memberId}/accept")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.FRIEND_BAD_REQUEST,
+            ErrorCode.PENDING_FRIEND_REQUEST_NOT_EXIST
+    })
     public ApiResponse<FriendRequestResponse> acceptFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
                                                                   @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.acceptFriendRequest(member, targetMemberId));
@@ -53,6 +70,11 @@ public class FriendController {
     @Operation(summary = "친구 요청 거절 API", description = "대상 회원이 보낸 친구 요청을 거절 처리하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 거절할 대상 회원의 id 입니다.")
     @PatchMapping("/request/{memberId}/reject")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.FRIEND_BAD_REQUEST,
+            ErrorCode.PENDING_FRIEND_REQUEST_NOT_EXIST
+    })
     public ApiResponse<FriendRequestResponse> rejectFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
                                                                   @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.rejectFriendRequest(member, targetMemberId));
@@ -61,6 +83,11 @@ public class FriendController {
     @Operation(summary = "친구 요청 취소 API", description = "대상 회원에게 보낸 친구 요청을 취소하는 API 입니다.")
     @Parameter(name = "memberId", description = "친구 요청을 취소할 대상 회원의 id 입니다.")
     @DeleteMapping("/request/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.FRIEND_BAD_REQUEST,
+            ErrorCode.PENDING_FRIEND_REQUEST_NOT_EXIST
+    })
     public ApiResponse<FriendRequestResponse> cancelFriendRequest(@PathVariable(name = "memberId") Long targetMemberId,
                                                                   @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.cancelFriendRequest(member, targetMemberId));
@@ -69,6 +96,12 @@ public class FriendController {
     @Operation(summary = "친구 즐겨찾기 설정/해제 API", description = "대상 친구 회원을 즐겨찾기 설정/해제 하는 API 입니다.")
     @Parameter(name = "memberId", description = "즐겨찾기 설정/해제할 친구 회원의 id 입니다.")
     @PatchMapping("/{memberId}/star")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.FRIEND_BAD_REQUEST,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.MEMBERS_NOT_FRIEND
+    })
     public ApiResponse<StarFriendResponse> reverseFriendLiked(@PathVariable(name = "memberId") Long friendMemberId,
                                                               @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.reverseFriendLiked(member, friendMemberId));
@@ -77,6 +110,11 @@ public class FriendController {
     @Operation(summary = "친구 삭제 API", description = "친구 회원과의 친구 관계를 끊는 API 입니다.")
     @Parameter(name = "memberId", description = "삭제 처리할 친구 회원의 id 입니다.")
     @DeleteMapping("/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode.FRIEND_BAD_REQUEST,
+            ErrorCode.MEMBERS_NOT_FRIEND
+    })
     public ApiResponse<DeleteFriendResponse> deleteFriend(@PathVariable(name = "memberId") Long targetMemberId,
                                                           @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.deleteFriend(member, targetMemberId));
@@ -91,6 +129,7 @@ public class FriendController {
     @Operation(summary = "소환사명으로 친구 검색 API", description = "해당 회원의 친구 중, query string으로 시작하는 소환사명을 가진 모든 친구 목록을 조회합니다.")
     @Parameter(name = "query", description = "친구 목록 검색을 위한 소환사명 string으로, 100자 이하여야 합니다.")
     @GetMapping("/search")
+    @ApiErrorCodes({ErrorCode.FRIEND_SEARCH_QUERY_BAD_REQUEST})
     public ApiResponse<List<FriendInfoResponse>> searchFriend(@RequestParam(name = "query") String query,
                                                               @AuthMember Member member) {
         return ApiResponse.ok(friendFacadeService.searchFriend(member, query));

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/friend/controller/FriendInternalController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/friend/controller/FriendInternalController.java
@@ -1,6 +1,8 @@
 package com.gamegoo.gamegoo_v2.social.friend.controller;
 
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.friend.service.FriendFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +25,8 @@ public class FriendInternalController {
     @Operation(summary = "모든 친구 id 조회 API", description = "해당 회원의 모든 친구 id 목록을 조회하는 API 입니다. " +
             "정렬 기능 없음, socket서버용 API입니다.")
     @GetMapping(value = "/{memberId}/friend/ids")
-    public ApiResponse<List<Long>> getFriendIds(@PathVariable(name = "memberId") Long memberId) {
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
+   public ApiResponse<List<Long>> getFriendIds(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(friendFacadeService.getFriendIdList(memberId));
     }
 

--- a/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
+++ b/src/main/java/com/gamegoo/gamegoo_v2/social/manner/controller/MannerController.java
@@ -3,6 +3,8 @@ package com.gamegoo.gamegoo_v2.social.manner.controller;
 import com.gamegoo.gamegoo_v2.account.auth.annotation.AuthMember;
 import com.gamegoo.gamegoo_v2.account.member.domain.Member;
 import com.gamegoo.gamegoo_v2.core.common.ApiResponse;
+import com.gamegoo.gamegoo_v2.core.config.swagger.ApiErrorCodes;
+import com.gamegoo.gamegoo_v2.core.exception.common.ErrorCode;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerInsertRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.request.MannerUpdateRequest;
 import com.gamegoo.gamegoo_v2.social.manner.dto.response.MannerInsertResponse;
@@ -35,6 +37,13 @@ public class MannerController {
     @Operation(summary = "매너 평가 등록 API", description = "매너 평가를 등록하는 API 입니다.")
     @Parameter(name = "memberId", description = "매너 평가를 등록할 대상 회원의 id 입니다.")
     @PostMapping("/positive/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.MANNER_KEYWORD_INVALID,
+            ErrorCode.MANNER_RATING_EXISTS
+    })
     public ApiResponse<MannerInsertResponse> addPositiveMannerRating(
             @PathVariable(name = "memberId") Long targetMemberId,
             @Valid @RequestBody MannerInsertRequest request,
@@ -45,6 +54,13 @@ public class MannerController {
     @Operation(summary = "비매너 평가 등록 API", description = "비매너 평가를 등록하는 API 입니다.")
     @Parameter(name = "memberId", description = "비매너 평가를 등록할 대상 회원의 id 입니다.")
     @PostMapping("/negative/{memberId}")
+    @ApiErrorCodes({
+            ErrorCode.MEMBER_NOT_FOUND,
+            ErrorCode._BAD_REQUEST,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED,
+            ErrorCode.MANNER_KEYWORD_INVALID,
+            ErrorCode.MANNER_RATING_EXISTS
+    })
     public ApiResponse<MannerInsertResponse> addNegativeMannerRating(
             @PathVariable(name = "memberId") Long targetMemberId,
             @Valid @RequestBody MannerInsertRequest request,
@@ -55,6 +71,12 @@ public class MannerController {
     @Operation(summary = "매너/비매너 평가 수정 API", description = "매너/비매너 평가를 수정하는 API 입니다.")
     @Parameter(name = "mannerId", description = "수정하고자 하는 매너/비매너 평가 id 입니다.")
     @PutMapping("/{mannerId}")
+    @ApiErrorCodes({
+            ErrorCode.MANNER_RATING_NOT_FOUND,
+            ErrorCode.MANNER_RATING_ACCESS_DENIED,
+            ErrorCode.MANNER_KEYWORD_INVALID,
+            ErrorCode.TARGET_MEMBER_DEACTIVATED
+    })
     public ApiResponse<MannerUpdateResponse> updateMannerRating(
             @PathVariable(name = "mannerId") Long mannerId,
             @Valid @RequestBody MannerUpdateRequest request,
@@ -65,6 +87,7 @@ public class MannerController {
     @Operation(summary = "특정 회원에 대한 나의 매너 평가 조회 API", description = "특정 회원에 대해 내가 실시한 매너 평가를 조회하는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
     @GetMapping("/positive/{memberId}")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<MannerRatingResponse> getPositiveMannerRatingInfo(
             @PathVariable(name = "memberId") Long targetMemberId,
             @AuthMember Member member) {
@@ -74,6 +97,7 @@ public class MannerController {
     @Operation(summary = "특정 회원에 대한 나의 비매너 평가 조회 API", description = "특정 회원에 대해 내가 실시한 비매너 평가를 조회하는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
     @GetMapping("/negative/{memberId}")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<MannerRatingResponse> getNegativeMannerRatingInfo(
             @PathVariable(name = "memberId") Long targetMemberId,
             @AuthMember Member member) {
@@ -83,6 +107,7 @@ public class MannerController {
     @Operation(summary = "특정 회원의 매너 레벨 정보 조회 API", description = "특정 회원의 매너 레벨 정보를 조회하는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
     @GetMapping("/level/{memberId}")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<MannerResponse> getMannerLevelInfo(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(mannerFacadeService.getMannerLevelInfo(memberId));
     }
@@ -90,6 +115,7 @@ public class MannerController {
     @Operation(summary = "특정 회원의 매너 키워드 정보 조회 API", description = "특정 회원의 매너 키워드 정보를 조회하는 API 입니다.")
     @Parameter(name = "memberId", description = "대상 회원의 id 입니다.")
     @GetMapping("/keyword/{memberId}")
+    @ApiErrorCodes({ErrorCode.MEMBER_NOT_FOUND})
     public ApiResponse<MannerKeywordListResponse> getMannerKeywordInfo(@PathVariable(name = "memberId") Long memberId) {
         return ApiResponse.ok(mannerFacadeService.getMannerKeywordInfo(memberId));
     }


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->
> Swagger 문서에 백엔드 커스텀 예외 응답이 자동 노출되도록 구성

## ⏳ 작업 상세 내용

- [ ]  @ApiErrorCodes 어노테이션 및 OperationCustomizer 추가로 에러 응답 자동 생성
- [ ] 주요 REST 컨트롤러에 서비스 예외 코드 매핑

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [ ] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [ ] 없을 경우 체크
